### PR TITLE
Do not recompile haskoin libraries twice when running tests

### DIFF
--- a/Network/Haskoin/Block/HeaderChain.hs
+++ b/Network/Haskoin/Block/HeaderChain.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
 module Network.Haskoin.Block.HeaderChain 
 ( BlockHeaderNode(..)
 , BlockHeaderStore(..)

--- a/Network/Haskoin/Crypto/Base58.hs
+++ b/Network/Haskoin/Crypto/Base58.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Network.Haskoin.Crypto.Base58
 ( Address(..)
 , addrToBase58

--- a/Network/Haskoin/Crypto/BigWord.hs
+++ b/Network/Haskoin/Crypto/BigWord.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE EmptyDataDecls #-}
 module Network.Haskoin.Crypto.BigWord
 (
 -- Useful type aliases

--- a/Network/Haskoin/Crypto/Keys.hs
+++ b/Network/Haskoin/Crypto/Keys.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE EmptyDataDecls #-}
 module Network.Haskoin.Crypto.Keys
 ( PubKeyI(pubKeyCompressed, pubKeyPoint)
 , PubKey, PubKeyC, PubKeyU

--- a/Network/Haskoin/Crypto/Mnemonic.hs
+++ b/Network/Haskoin/Crypto/Mnemonic.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 -- | Mnemonic keys (BIP-39). Only the English dictionary in the BIP is
 -- supported.
 module Network.Haskoin.Crypto.Mnemonic

--- a/Network/Haskoin/Internals.hs
+++ b/Network/Haskoin/Internals.hs
@@ -3,9 +3,12 @@
   stability of the interface of these internal modules.
 -}
 module Network.Haskoin.Internals
-( module Network.Haskoin.Crypto.NumberTheory
-, module Network.Haskoin.Crypto.Curve
-, module Network.Haskoin.Crypto.Hash
+( module Network.Haskoin.Util
+, module Network.Haskoin.Stratum
+, module Network.Haskoin.Constants
+, module Network.Haskoin.Crypto.NumberTheory 
+, module Network.Haskoin.Crypto.Curve 
+, module Network.Haskoin.Crypto.Hash 
 , module Network.Haskoin.Crypto.BigWord
 , module Network.Haskoin.Crypto.Point
 , module Network.Haskoin.Crypto.Base58
@@ -17,19 +20,35 @@ module Network.Haskoin.Internals
 , module Network.Haskoin.Node.Types
 , module Network.Haskoin.Node.Message
 , module Network.Haskoin.Node.Bloom
-, module Network.Haskoin.Script.Types
-, module Network.Haskoin.Script.Parser
+, module Network.Haskoin.Node.Peer
+, module Network.Haskoin.Node.PeerManager
+, module Network.Haskoin.Node.SPVNode
+, module Network.Haskoin.Script.Types 
+, module Network.Haskoin.Script.Parser 
 , module Network.Haskoin.Script.SigHash
 , module Network.Haskoin.Script.Evaluator
-, module Network.Haskoin.Transaction.Builder
 , module Network.Haskoin.Transaction.Types
+, module Network.Haskoin.Transaction.Builder
 , module Network.Haskoin.Block.Types
 , module Network.Haskoin.Block.Merkle
+, module Network.Haskoin.Block.HeaderChain
+, module Network.Haskoin.Block.Checkpoints
+, module Network.Haskoin.Test.Util
+, module Network.Haskoin.Test.Crypto
+, module Network.Haskoin.Test.Node
+, module Network.Haskoin.Test.Message
+, module Network.Haskoin.Test.Script
+, module Network.Haskoin.Test.Transaction
+, module Network.Haskoin.Test.Block
+, module Network.Haskoin.Test.Stratum
 ) where
 
-import Network.Haskoin.Crypto.NumberTheory
-import Network.Haskoin.Crypto.Curve
-import Network.Haskoin.Crypto.Hash
+import Network.Haskoin.Util
+import Network.Haskoin.Stratum
+import Network.Haskoin.Constants
+import Network.Haskoin.Crypto.NumberTheory 
+import Network.Haskoin.Crypto.Curve 
+import Network.Haskoin.Crypto.Hash 
 import Network.Haskoin.Crypto.BigWord
 import Network.Haskoin.Crypto.Point
 import Network.Haskoin.Crypto.Base58
@@ -41,12 +60,25 @@ import Network.Haskoin.Crypto.Mnemonic
 import Network.Haskoin.Node.Types
 import Network.Haskoin.Node.Message
 import Network.Haskoin.Node.Bloom
-import Network.Haskoin.Script.Types
-import Network.Haskoin.Script.Parser
+import Network.Haskoin.Node.Peer
+import Network.Haskoin.Node.PeerManager
+import Network.Haskoin.Node.SPVNode
+import Network.Haskoin.Script.Types 
+import Network.Haskoin.Script.Parser 
 import Network.Haskoin.Script.SigHash
 import Network.Haskoin.Script.Evaluator
-import Network.Haskoin.Transaction.Builder
 import Network.Haskoin.Transaction.Types
+import Network.Haskoin.Transaction.Builder
 import Network.Haskoin.Block.Types
 import Network.Haskoin.Block.Merkle
+import Network.Haskoin.Block.HeaderChain
+import Network.Haskoin.Block.Checkpoints
+import Network.Haskoin.Test.Util
+import Network.Haskoin.Test.Crypto
+import Network.Haskoin.Test.Node
+import Network.Haskoin.Test.Message
+import Network.Haskoin.Test.Script
+import Network.Haskoin.Test.Transaction
+import Network.Haskoin.Test.Block
+import Network.Haskoin.Test.Stratum
 

--- a/Network/Haskoin/Node/Peer.hs
+++ b/Network/Haskoin/Node/Peer.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 module Network.Haskoin.Node.Peer 
 ( runPeer
 , runCustomPeer

--- a/Network/Haskoin/Node/PeerManager.hs
+++ b/Network/Haskoin/Node/PeerManager.hs
@@ -1,8 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE FunctionalDependencies #-}
 module Network.Haskoin.Node.PeerManager 
 ( ManagerSession(..)
 , PeerManager(..)
@@ -27,12 +23,11 @@ import System.Random (randomIO)
 
 import Control.Monad (when, unless, forM_, liftM)
 import Control.Monad.Trans (MonadTrans, MonadIO, liftIO, lift)
-import Control.Monad.Trans.Resource (ResourceT, runResourceT, MonadResource)
-import Control.Monad.Trans.Control (MonadBaseControl)
+import Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import Control.Concurrent (forkFinally, forkIO, threadDelay)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.Async (Async, withAsync)
-import Control.Monad.Logger (LoggingT, runStdoutLoggingT, MonadLogger, logInfo)
+import Control.Monad.Logger (LoggingT, runStdoutLoggingT, logInfo)
 import qualified Control.Monad.State as S (StateT, evalStateT, gets, modify)
 
 import qualified Data.Text as T (pack)
@@ -142,7 +137,7 @@ withAsyncNode hosts a f = do
         mSource = mapOutput MergedMngrRequest (sourceTBMChan mChan)
 
     -- Launch node
-    flip withAsync (\a -> f rChan a) $ runMngrHandle a session $ do
+    flip withAsync (\ac -> f rChan ac) $ runMngrHandle a session $ do
         -- Run user init hook
         initNode
         -- Merge 3 channels into 1

--- a/Network/Haskoin/Node/SPVNode.hs
+++ b/Network/Haskoin/Node/SPVNode.hs
@@ -1,10 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Network.Haskoin.Node.SPVNode 
 ( SPVNode(..)
@@ -17,29 +11,13 @@ module Network.Haskoin.Node.SPVNode
 where
 
 import Control.Applicative ((<$>))
-import Control.Monad 
-    ( when
-    , unless
-    , forM
-    , forM_
-    , foldM
-    , forever
-    , liftM
-    )
-import Control.Monad.Trans (MonadTrans, MonadIO, liftIO, lift)
-import Control.Monad.Trans.Resource (MonadResource)
-import Control.Monad.Trans.Control (MonadBaseControl)
+import Control.Monad ( when, unless, forM, forM_, foldM, forever, liftM)
+import Control.Monad.Trans (MonadIO, liftIO)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.Async (Async, withAsync)
-import qualified Control.Monad.State as S (StateT, evalStateT, gets, modify)
-import Control.Monad.Logger 
-    ( MonadLogger
-    , logInfo
-    , logWarn
-    , logDebug
-    , logError
-    )
+import qualified Control.Monad.State as S (gets, modify)
+import Control.Monad.Logger (logInfo, logWarn, logDebug, logError)
 
 import qualified Data.Text as T (pack)
 import Data.Maybe (isJust, isNothing, fromJust, catMaybes, fromMaybe)
@@ -47,23 +25,9 @@ import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.List (nub, partition, delete, (\\))
 import Data.Conduit.TMChan (TBMChan, writeTBMChan)
 import qualified Data.Map as M 
-    ( Map
-    , member
-    , delete
-    , lookup
-    , fromList
-    , fromListWith
-    , keys
-    , elems
-    , toList
-    , toAscList
-    , empty
-    , map
-    , filter
-    , adjust
-    , update
-    , singleton
-    , unionWith
+    ( Map, member, delete, lookup, fromList, fromListWith
+    , keys, elems, toList, toAscList, empty, map, filter
+    , adjust, update, singleton, unionWith
     )
 
 import Network.Haskoin.Block

--- a/Network/Haskoin/Script/Types.hs
+++ b/Network/Haskoin/Script/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
 module Network.Haskoin.Script.Types
 ( ScriptOp(..)
 , Script(..)

--- a/Network/Haskoin/Stratum.hs
+++ b/Network/Haskoin/Stratum.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 module Network.Haskoin.Stratum
 ( -- * Stratum JSON-RPC Message Types
   StratumRequest(..)

--- a/Network/Haskoin/Test/Stratum.hs
+++ b/Network/Haskoin/Test/Stratum.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- | Arbitrary instances and data types for use in test suites.
 module Network.Haskoin.Test.Stratum

--- a/Network/Haskoin/Transaction/Builder.hs
+++ b/Network/Haskoin/Transaction/Builder.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 module Network.Haskoin.Transaction.Builder 
 ( Coin(..)
 , buildTx

--- a/README.md
+++ b/README.md
@@ -4,14 +4,26 @@ Haskoin is an implementation of the Bitcoin protocol in Haskell.
 
 ## Features
 
-- Protocol message types (de-)serialization
-- Bitcoin script interpreter
-- Cryptographic ECDSA and hashing primitives
-- Hierarchical Deterministic Wallet support (BIP32)
-- Pay-to-script-hash (P2SH, BIP16) support
-- Regular and multi-signature (BIP11) transaction support
+Haskoin is a package implementing the Bitcoin protocol specifications. It
+is written in pure Haskell and the library is implemented mostly with pure
+functions (no IO monad). It provides the following features:
+
+- ECDSA cryptographic primitives (secp256k1)
+- Hashing functions (sha-256, ripemd-160)
+- Base58 encoding
+- BIP32 extended key derivations
+- BIP39 mnemonic key
+- Script parsing and evaluation
+- Building and signing of standard transactions (regular, multisig, p2sh)
+- Deterministic signing (rfc-6979)
+- Network protocol type parsing
+- Headerchain implementation (Blockchain with headers only)
+- Bloom filters and partial merkle tree library
+- Headers-first SPV node implementation (network-only, no wallet)
 - JSON-RPC/Stratum client library
-- Mnemonic keys (BIP39)
+
+A wallet implementation using the SPV node library is available in the
+haskoin-wallet package.
 
 ## Documentation
 
@@ -36,10 +48,3 @@ Commits are done through GitHub pull requests.
 
 We do a lot of our technical discussions in the IRC channel #haskoin on
 chat.freenode.net.
-
-Code guidelines:
-
-- 80 columns.
-- 4 space indentation. No tabs.
-- Follow the general style of the code, whenever it makes sense.
-- Purity and type-safety are important.

--- a/haskoin.cabal
+++ b/haskoin.cabal
@@ -1,15 +1,31 @@
 name:                  haskoin
-version:               0.1.0.3
-synopsis:              Implementation of the Bitcoin protocol.
+version:               0.2.0
+synopsis:              
+    Implementation of the Bitcoin protocol.
 description:
-    Haskoin is a package providing an implementation of the Bitcoin protocol
-    specifications. It provides the cryptographic ECDSA and hashing primitives,
-    functions for handling BIP32 extended keys, functions for building and
-    signing various types of regular and multisig transactions and a definition
-    of the network protocol messages.
+    Haskoin is a package implementing the Bitcoin protocol specifications. It
+    is written in pure Haskell and the library is implemented mostly with pure
+    functions (no IO monad). It provides the following features:
+    .
+    * ECDSA cryptographic primitives (secp256k1)
+    * Hashing functions (sha-256, ripemd-160)
+    * Base58 encoding
+    * BIP32 extended key derivations
+    * BIP39 mnemonic key
+    * Script parsing and evaluation
+    * Building and signing of standard transactions (regular, multisig, p2sh)
+    * Deterministic signing (rfc-6979)
+    * Network protocol type parsing
+    * Headerchain implementation (Blockchain with headers only)
+    * Bloom filters and partial merkle tree library
+    * Headers-first SPV node implementation (network-only, no wallet)
+    * JSON-RPC/Stratum client library
+    .
+    A wallet implementation using the SPV node library is available in the
+    haskoin-wallet package.
 homepage:              http://github.com/haskoin/haskoin
 bug-reports:           http://github.com/haskoin/haskoin/issues
-stability:             experimental
+stability:             stable
 license:               PublicDomain
 license-file:          UNLICENSE
 author:                Philippe Laprade, Jean-Pierre Rupp
@@ -30,150 +46,147 @@ Flag Testnet
     Default:     False
 
 library
-    exposed-modules:   Network.Haskoin.Util,
-                       Network.Haskoin.Stratum,
-                       Network.Haskoin.Crypto,
-                       Network.Haskoin.Node,
-                       Network.Haskoin.Script,
-                       Network.Haskoin.Transaction,
-                       Network.Haskoin.Block,
-                       Network.Haskoin.Constants,
-                       Network.Haskoin.Test,
-                       Network.Haskoin.Internals
-    other-modules:     Network.Haskoin.Crypto.NumberTheory, 
-                       Network.Haskoin.Crypto.Curve, 
-                       Network.Haskoin.Crypto.Hash, 
-                       Network.Haskoin.Crypto.BigWord,
-                       Network.Haskoin.Crypto.Point,
-                       Network.Haskoin.Crypto.Base58,
-                       Network.Haskoin.Crypto.Keys,
-                       Network.Haskoin.Crypto.ExtendedKeys,
-                       Network.Haskoin.Crypto.NormalizedKeys,
-                       Network.Haskoin.Crypto.ECDSA,
-                       Network.Haskoin.Crypto.Mnemonic,
-                       Network.Haskoin.Node.Types,
-                       Network.Haskoin.Node.Message,
-                       Network.Haskoin.Node.Bloom,
-                       Network.Haskoin.Node.Peer,
-                       Network.Haskoin.Node.PeerManager,
-                       Network.Haskoin.Node.SPVNode,
-                       Network.Haskoin.Script.Types, 
-                       Network.Haskoin.Script.Parser, 
-                       Network.Haskoin.Script.SigHash,
-                       Network.Haskoin.Script.Evaluator,
-                       Network.Haskoin.Transaction.Types,
-                       Network.Haskoin.Transaction.Builder,
-                       Network.Haskoin.Block.Types,
-                       Network.Haskoin.Block.Merkle,
-                       Network.Haskoin.Block.HeaderChain,
-                       Network.Haskoin.Block.Checkpoints,
-                       Network.Haskoin.Test.Util,
-                       Network.Haskoin.Test.Crypto,
-                       Network.Haskoin.Test.Node,
-                       Network.Haskoin.Test.Message,
-                       Network.Haskoin.Test.Script,
-                       Network.Haskoin.Test.Transaction,
-                       Network.Haskoin.Test.Block,
-                       Network.Haskoin.Test.Stratum
-    build-depends:     aeson >= 0.7 && < 0.9,
-                       async >= 2.0 && < 2.1,
-                       base >= 4.6 && < 5, 
-                       binary >= 0.7 && < 0.8, 
-                       byteable >= 0.1 && < 0.2,
-                       bytestring >= 0.10 && < 0.11, 
-                       base16-bytestring >= 0.1 && < 0.2,
-                       conduit >= 1.2 && < 1.3,
-                       conduit-extra >= 1.1 && < 1.2,
-                       containers >= 0.5 && < 0.6,
-                       cryptohash >= 0.11 && < 0.12,
-                       deepseq >= 1.3 && < 1.4,
-                       data-default >= 0.5 && < 0.6,
-                       either >= 4.3 && < 4.4,
-                       json-rpc >= 0.2.0.1 && < 0.3,
-                       leveldb-haskell >= 0.6 && < 0.7,
-                       monad-control >= 0.3 && < 0.4,
-                       monad-logger >= 0.3 && < 0.4,
-                       mtl >= 2.1 && < 2.3, 
-                       network >= 2.4 && < 2.7,
-                       pbkdf >= 1.1 && < 1.2,
-                       QuickCheck >= 2.6 && < 2.8,
-                       random >= 1.0 && < 1.2,
-                       resourcet >= 1.1 && < 1.2,
-                       split >= 0.2 && < 0.3,
-                       stm >= 2.4 && < 2.5,
-                       stm-conduit >= 2.5 && < 2.6,
-                       text >= 0.11 && < 1.3,
-                       time >= 1.4 && < 1.5
+    exposed-modules: Network.Haskoin.Util
+                     Network.Haskoin.Stratum
+                     Network.Haskoin.Crypto
+                     Network.Haskoin.Node
+                     Network.Haskoin.Script
+                     Network.Haskoin.Transaction
+                     Network.Haskoin.Block
+                     Network.Haskoin.Constants
+                     Network.Haskoin.Test
+                     Network.Haskoin.Internals
+
+    other-modules: Network.Haskoin.Crypto.NumberTheory 
+                   Network.Haskoin.Crypto.Curve 
+                   Network.Haskoin.Crypto.Hash 
+                   Network.Haskoin.Crypto.BigWord
+                   Network.Haskoin.Crypto.Point
+                   Network.Haskoin.Crypto.Base58
+                   Network.Haskoin.Crypto.Keys
+                   Network.Haskoin.Crypto.ExtendedKeys
+                   Network.Haskoin.Crypto.NormalizedKeys
+                   Network.Haskoin.Crypto.ECDSA
+                   Network.Haskoin.Crypto.Mnemonic
+                   Network.Haskoin.Node.Types
+                   Network.Haskoin.Node.Message
+                   Network.Haskoin.Node.Bloom
+                   Network.Haskoin.Node.Peer
+                   Network.Haskoin.Node.PeerManager
+                   Network.Haskoin.Node.SPVNode
+                   Network.Haskoin.Script.Types 
+                   Network.Haskoin.Script.Parser 
+                   Network.Haskoin.Script.SigHash
+                   Network.Haskoin.Script.Evaluator
+                   Network.Haskoin.Transaction.Types
+                   Network.Haskoin.Transaction.Builder
+                   Network.Haskoin.Block.Types
+                   Network.Haskoin.Block.Merkle
+                   Network.Haskoin.Block.HeaderChain
+                   Network.Haskoin.Block.Checkpoints
+                   Network.Haskoin.Test.Util
+                   Network.Haskoin.Test.Crypto
+                   Network.Haskoin.Test.Node
+                   Network.Haskoin.Test.Message
+                   Network.Haskoin.Test.Script
+                   Network.Haskoin.Test.Transaction
+                   Network.Haskoin.Test.Block
+                   Network.Haskoin.Test.Stratum
+
+    extensions: EmptyDataDecls
+                OverloadedStrings
+                FlexibleInstances
+                FlexibleContexts
+                DeriveDataTypeable
+                MultiParamTypeClasses
+                KindSignatures
+                FunctionalDependencies
+                RecordWildCards
+
+    build-depends: aeson                    >= 0.7          && < 0.9
+                 , async                    >= 2.0          && < 2.1
+                 , base                     >= 4.6          && < 5 
+                 , binary                   >= 0.7          && < 0.8 
+                 , byteable                 >= 0.1          && < 0.2
+                 , bytestring               >= 0.10         && < 0.11 
+                 , base16-bytestring        >= 0.1          && < 0.2
+                 , conduit                  >= 1.2          && < 1.3
+                 , conduit-extra            >= 1.1          && < 1.2
+                 , containers               >= 0.5          && < 0.6
+                 , cryptohash               >= 0.11         && < 0.12
+                 , deepseq                  >= 1.3          && < 1.4
+                 , data-default             >= 0.5          && < 0.6
+                 , either                   >= 4.3          && < 4.4
+                 , json-rpc                 >= 0.2.0.1      && < 0.3
+                 , leveldb-haskell          >= 0.6          && < 0.7
+                 , monad-control            >= 0.3          && < 0.4
+                 , monad-logger             >= 0.3          && < 0.4
+                 , mtl                      >= 2.1          && < 2.3 
+                 , network                  >= 2.4          && < 2.7
+                 , pbkdf                    >= 1.1          && < 1.2
+                 , QuickCheck               >= 2.6          && < 2.8
+                 , random                   >= 1.0          && < 1.2
+                 , resourcet                >= 1.1          && < 1.2
+                 , split                    >= 0.2          && < 0.3
+                 , stm                      >= 2.4          && < 2.5
+                 , stm-conduit              >= 2.5          && < 2.6
+                 , text                     >= 0.11         && < 1.3
+                 , time                     >= 1.4          && < 1.5
+
     ghc-options:       -Wall 
+
   if flag(testnet)
-    hs-source-dirs:    . testnet
+    hs-source-dirs: . testnet
   else
-    hs-source-dirs:    . prodnet
+    hs-source-dirs: . prodnet
 
 test-suite test-haskoin
     type:              exitcode-stdio-1.0
     main-is:           Main.hs
-    other-modules:     Network.Haskoin.Util.Tests,
-                       Network.Haskoin.Crypto.BigWord.Tests,
-                       Network.Haskoin.Crypto.Point.Tests,
-                       Network.Haskoin.Crypto.ECDSA.Tests,
-                       Network.Haskoin.Crypto.Base58.Tests,
-                       Network.Haskoin.Crypto.Base58.Units,
-                       Network.Haskoin.Crypto.Keys.Tests,
-                       Network.Haskoin.Crypto.ExtendedKeys.Tests,
-                       Network.Haskoin.Crypto.ExtendedKeys.Units,
-                       Network.Haskoin.Crypto.Hash.Tests,
-                       Network.Haskoin.Crypto.Hash.Units,
-                       Network.Haskoin.Crypto.Mnemonic.Tests,
-                       Network.Haskoin.Crypto.Mnemonic.Units,
-                       Network.Haskoin.Crypto.Units,
-                       Network.Haskoin.Node.Units,
-                       Network.Haskoin.Script.Tests,
-                       Network.Haskoin.Script.Units,
-                       Network.Haskoin.Transaction.Tests,
-                       Network.Haskoin.Transaction.Units,
-                       Network.Haskoin.Block.Tests,
-                       Network.Haskoin.Block.Units,
-                       Network.Haskoin.Stratum.Tests,
-                       Network.Haskoin.Stratum.Units,
-                       Network.Haskoin.Json.Tests,
-                       Network.Haskoin.Binary.Tests
-    build-depends:     aeson >= 0.7 && < 0.9,
-                       async >= 2.0 && < 2.1,
-                       base >= 4.6 && < 5, 
-                       binary >= 0.7 && < 0.8, 
-                       byteable >= 0.1 && < 0.2,
-                       bytestring >= 0.10 && < 0.11, 
-                       base16-bytestring >= 0.1 && < 0.2,
-                       conduit >= 1.2 && < 1.3,
-                       conduit-extra >= 1.1 && < 1.2,
-                       containers >= 0.5 && < 0.6,
-                       cryptohash >= 0.11 && < 0.12,
-                       data-default >= 0.5 && < 0.6,
-                       deepseq >= 1.3 && < 1.4,
-                       either >= 4.3 && < 4.4,
-                       json-rpc >= 0.2.0.1 && < 0.3,
-                       leveldb-haskell >= 0.6 && < 0.7,
-                       monad-control >= 0.3 && < 0.4,
-                       monad-logger >= 0.3 && < 0.4,
-                       mtl >= 2.1 && < 2.3, 
-                       network >= 2.4 && < 2.7,
-                       pbkdf >= 1.1 && < 1.2,
-                       random >= 1.0 && < 1.2,
-                       resourcet >= 1.1 && < 1.2,
-                       split >= 0.2 && < 0.3,
-                       stm >= 2.4 && < 2.5,
-                       stm-conduit >= 2.5 && < 2.6,
-                       text >= 0.11 && < 1.3,
-                       time >= 1.4 && < 1.5,
-                       HUnit >= 1.2 && < 1.3,
-                       QuickCheck >= 2.6 && < 2.8,
-                       test-framework >= 0.8 && < 0.9, 
-                       test-framework-quickcheck2 >= 0.3 && < 0.4, 
-                       test-framework-hunit >= 0.3 && < 0.4 
-    ghc-options:       -Wall 
-  if flag(testnet)
-    hs-source-dirs:    . tests testnet
-  else
-    hs-source-dirs:    . tests prodnet
+
+    extensions: EmptyDataDecls
+
+    other-modules: Network.Haskoin.Util.Tests
+                   Network.Haskoin.Crypto.BigWord.Tests
+                   Network.Haskoin.Crypto.Point.Tests
+                   Network.Haskoin.Crypto.ECDSA.Tests
+                   Network.Haskoin.Crypto.Base58.Tests
+                   Network.Haskoin.Crypto.Base58.Units
+                   Network.Haskoin.Crypto.Keys.Tests
+                   Network.Haskoin.Crypto.ExtendedKeys.Tests
+                   Network.Haskoin.Crypto.ExtendedKeys.Units
+                   Network.Haskoin.Crypto.Hash.Tests
+                   Network.Haskoin.Crypto.Hash.Units
+                   Network.Haskoin.Crypto.Mnemonic.Tests
+                   Network.Haskoin.Crypto.Mnemonic.Units
+                   Network.Haskoin.Crypto.Units
+                   Network.Haskoin.Node.Units
+                   Network.Haskoin.Script.Tests
+                   Network.Haskoin.Script.Units
+                   Network.Haskoin.Transaction.Tests
+                   Network.Haskoin.Transaction.Units
+                   Network.Haskoin.Block.Tests
+                   Network.Haskoin.Block.Units
+                   Network.Haskoin.Stratum.Tests
+                   Network.Haskoin.Stratum.Units
+                   Network.Haskoin.Json.Tests
+                   Network.Haskoin.Binary.Tests
+
+    build-depends: aeson                          >= 0.7        && < 0.9
+                 , base                           >= 4.6        && < 5 
+                 , binary                         >= 0.7        && < 0.8 
+                 , bytestring                     >= 0.10       && < 0.11 
+                 , containers                     >= 0.5        && < 0.6
+                 , haskoin
+                 , json-rpc                       >= 0.2.0.1    && < 0.3
+                 , mtl                            >= 2.1        && < 2.3 
+                 , split                          >= 0.2        && < 0.3
+                 , HUnit                          >= 1.2        && < 1.3
+                 , QuickCheck                     >= 2.6        && < 2.8
+                 , test-framework                 >= 0.8        && < 0.9 
+                 , test-framework-quickcheck2     >= 0.3        && < 0.4 
+                 , test-framework-hunit           >= 0.3        && < 0.4 
+
+    ghc-options: -Wall 
+    hs-source-dirs: tests
 

--- a/tests/Network/Haskoin/Binary/Tests.hs
+++ b/tests/Network/Haskoin/Binary/Tests.hs
@@ -6,13 +6,7 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 
 import Data.Binary (Binary)
 
-import Network.Haskoin.Test.Crypto
-import Network.Haskoin.Test.Node
-import Network.Haskoin.Test.Message
-import Network.Haskoin.Test.Script
-import Network.Haskoin.Test.Transaction
-import Network.Haskoin.Test.Block
-
+import Network.Haskoin.Test
 import Network.Haskoin.Util
 import Network.Haskoin.Crypto
 

--- a/tests/Network/Haskoin/Block/Tests.hs
+++ b/tests/Network/Haskoin/Block/Tests.hs
@@ -6,7 +6,7 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 
 import Data.Maybe (fromJust)
 
-import Network.Haskoin.Block.Merkle
+import Network.Haskoin.Block
 import Network.Haskoin.Crypto
 import Network.Haskoin.Util
 

--- a/tests/Network/Haskoin/Block/Units.hs
+++ b/tests/Network/Haskoin/Block/Units.hs
@@ -6,8 +6,8 @@ import Test.Framework.Providers.HUnit (testCase)
 
 import Data.Maybe (fromJust)
 
-import Network.Haskoin.Crypto.BigWord
-import Network.Haskoin.Block.Merkle
+import Network.Haskoin.Crypto
+import Network.Haskoin.Block
 
 tests :: [Test]
 tests =

--- a/tests/Network/Haskoin/Crypto/Base58/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/Base58/Tests.hs
@@ -3,8 +3,8 @@ module Network.Haskoin.Crypto.Base58.Tests (tests) where
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 
-import Network.Haskoin.Test.Crypto
-import Network.Haskoin.Crypto.Base58
+import Network.Haskoin.Test
+import Network.Haskoin.Crypto
 
 tests :: [Test]
 tests = 

--- a/tests/Network/Haskoin/Crypto/Base58/Units.hs
+++ b/tests/Network/Haskoin/Crypto/Base58/Units.hs
@@ -4,9 +4,9 @@ import Test.HUnit (Assertion, assertBool)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 
-import qualified Data.ByteString as BS
+import qualified Data.ByteString as BS (ByteString, append, pack, empty)
 
-import Network.Haskoin.Crypto.Base58
+import Network.Haskoin.Crypto
 import Network.Haskoin.Util
 
 tests :: [Test]

--- a/tests/Network/Haskoin/Crypto/BigWord/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/BigWord/Tests.hs
@@ -1,10 +1,12 @@
-{-# LANGUAGE EmptyDataDecls #-}
 module Network.Haskoin.Crypto.BigWord.Tests (tests) where
 
 import Test.QuickCheck.Property (Property, (==>))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 
+import Data.Int (Int32)
+import Data.Word (Word8, Word32)
+import qualified Data.ByteString as BS (length, index)
 import Data.Bits 
     ( isSigned
     , bit
@@ -15,14 +17,16 @@ import Data.Bits
     , (.&.), (.|.)
     , xor, complement
     )
-import Data.Int (Int32)
-import Data.Word (Word8, Word32)
-import qualified Data.ByteString as BS (length, index)
 
-import Network.Haskoin.Crypto.BigWord
-import Network.Haskoin.Crypto.NumberTheory
-import Network.Haskoin.Crypto.Curve
+import Network.Haskoin.Crypto
 import Network.Haskoin.Util
+import Network.Haskoin.Internals 
+    ( BigWordMod(..)
+    , BigWord(..)
+    , mulInverse
+    , quadraticResidue
+    , curveP
+    )
 
 tests :: [Test]
 tests = 

--- a/tests/Network/Haskoin/Crypto/ECDSA/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/ECDSA/Tests.hs
@@ -4,15 +4,12 @@ import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 
 import Data.Bits (testBit)
-import qualified Data.ByteString as BS
+import qualified Data.ByteString as BS (index, length)
 
-import Network.Haskoin.Test.Crypto
-
-import Network.Haskoin.Crypto.ECDSA
-import Network.Haskoin.Crypto.BigWord
-import Network.Haskoin.Crypto.Keys
-import Network.Haskoin.Crypto.Curve
+import Network.Haskoin.Test
+import Network.Haskoin.Crypto
 import Network.Haskoin.Util
+import Network.Haskoin.Internals (Signature(..), BigWord(..), curveN)
 
 tests :: [Test]
 tests = 

--- a/tests/Network/Haskoin/Crypto/ExtendedKeys/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/ExtendedKeys/Tests.hs
@@ -10,8 +10,7 @@ import Data.Word (Word32)
 import Data.Bits ((.&.))
 import Data.Maybe (fromJust)
 
-import Network.Haskoin.Test.Crypto
-
+import Network.Haskoin.Test
 import Network.Haskoin.Crypto
 import Network.Haskoin.Util
 

--- a/tests/Network/Haskoin/Crypto/Hash/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/Hash/Tests.hs
@@ -3,8 +3,7 @@ module Network.Haskoin.Crypto.Hash.Tests (tests) where
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 
-import Network.Haskoin.Crypto.Hash
-import Network.Haskoin.Crypto.BigWord
+import Network.Haskoin.Crypto
 
 tests :: [Test]
 tests = 

--- a/tests/Network/Haskoin/Crypto/Hash/Units.hs
+++ b/tests/Network/Haskoin/Crypto/Hash/Units.hs
@@ -7,8 +7,9 @@ import Test.Framework.Providers.HUnit (testCase)
 import Data.Maybe (fromJust)
 import Data.Word (Word32)
 
-import Network.Haskoin.Crypto.Hash
+import Network.Haskoin.Crypto
 import Network.Haskoin.Util
+import Network.Haskoin.Internals (hmacDRBGNew, hmacDRBGGen, hmacDRBGRsd)
 
 -- Test vectors from NIST
 -- http://csrc.nist.gov/groups/STM/cavp/documents/drbg/drbgtestvectors.zip

--- a/tests/Network/Haskoin/Crypto/Keys/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/Keys/Tests.hs
@@ -9,11 +9,10 @@ import Data.Binary.Get (runGet)
 import Data.Binary.Put (runPut)
 import qualified Data.ByteString as BS (length, index)
 
-import Network.Haskoin.Test.Crypto
-
-import Network.Haskoin.Crypto.Keys
-import Network.Haskoin.Crypto.BigWord
+import Network.Haskoin.Test
+import Network.Haskoin.Crypto
 import Network.Haskoin.Util
+import Network.Haskoin.Internals (PubKeyI(..), PrvKeyI(..))
 
 tests :: [Test]
 tests = 

--- a/tests/Network/Haskoin/Crypto/Mnemonic/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/Mnemonic/Tests.hs
@@ -8,13 +8,18 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Data.Bits ((.&.), shiftR)
 import Data.Binary (Binary)
 import Data.Word (Word32)
-import qualified Data.ByteString as BS
+import qualified Data.ByteString as BS 
+    ( ByteString
+    , empty
+    , append
+    , length
+    , last
+    )
 
-import Network.Haskoin.Test.Crypto
-
-import Network.Haskoin.Crypto.Mnemonic
-import Network.Haskoin.Crypto.BigWord
-import Network.Haskoin.Util (encode', fromRight)
+import Network.Haskoin.Test
+import Network.Haskoin.Crypto
+import Network.Haskoin.Util 
+import Network.Haskoin.Internals (fromMnemonic, getBits)
 
 
 tests :: [Test]

--- a/tests/Network/Haskoin/Crypto/Mnemonic/Units.hs
+++ b/tests/Network/Haskoin/Crypto/Mnemonic/Units.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Network.Haskoin.Crypto.Mnemonic.Units (tests) where
 
 import Test.HUnit (assertEqual)
@@ -6,8 +5,10 @@ import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 
 import Data.Maybe (fromJust)
-import Network.Haskoin.Crypto.Mnemonic
-import Network.Haskoin.Util (hexToBS, bsToHex, fromRight)
+
+import Network.Haskoin.Crypto
+import Network.Haskoin.Util 
+import Network.Haskoin.Internals (fromMnemonic)
 
 tests :: [Test]
 tests =

--- a/tests/Network/Haskoin/Crypto/Point/Tests.hs
+++ b/tests/Network/Haskoin/Crypto/Point/Tests.hs
@@ -6,10 +6,20 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 
 import Data.Maybe (fromJust)
 
-import Network.Haskoin.Test.Crypto
-
-import Network.Haskoin.Crypto.Point
-import Network.Haskoin.Crypto.BigWord
+import Network.Haskoin.Test
+import Network.Haskoin.Crypto
+import Network.Haskoin.Internals
+    ( Point(..)
+    , getAffine
+    , addPoint
+    , mulPoint
+    , shamirsTrick
+    , makeInfPoint
+    , makePoint
+    , validatePoint
+    , isInfPoint
+    , doublePoint
+    )
 
 tests :: [Test]
 tests = 

--- a/tests/Network/Haskoin/Crypto/Units.hs
+++ b/tests/Network/Haskoin/Crypto/Units.hs
@@ -7,16 +7,13 @@ import Test.Framework.Providers.HUnit (testCase)
 import Control.Monad (replicateM_)
 import Control.Monad.Trans (liftIO)
 
-import Data.Maybe
-import Data.Binary
-import qualified Data.ByteString as BS
+import Data.Maybe (fromJust, isJust, isNothing)
+import Data.Binary (put)
+import qualified Data.ByteString as BS (pack)
 
-import Network.Haskoin.Crypto.Keys
-import Network.Haskoin.Crypto.BigWord
-import Network.Haskoin.Crypto.ECDSA
-import Network.Haskoin.Crypto.Hash
-import Network.Haskoin.Crypto.Base58
+import Network.Haskoin.Crypto
 import Network.Haskoin.Util
+import Network.Haskoin.Internals (PrvKeyI(..), PubKeyI(..), Signature(..))
 
 -- Unit tests copied from bitcoind implementation
 -- https://github.com/bitcoin/bitcoin/blob/master/src/test/key_tests.cpp

--- a/tests/Network/Haskoin/Json/Tests.hs
+++ b/tests/Network/Haskoin/Json/Tests.hs
@@ -5,9 +5,7 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 
 import Data.Aeson (FromJSON, ToJSON, decode, encode)
 
-import Network.Haskoin.Test.Crypto
-import Network.Haskoin.Test.Script
-import Network.Haskoin.Test.Transaction
+import Network.Haskoin.Test
 import Network.Haskoin.Crypto
 
 tests :: [Test]

--- a/tests/Network/Haskoin/Node/Units.hs
+++ b/tests/Network/Haskoin/Node/Units.hs
@@ -7,18 +7,17 @@ import Test.Framework.Providers.HUnit (testCase)
 import Data.Maybe (fromJust)
 
 import Network.Haskoin.Crypto
-import Network.Haskoin.Node.Bloom
+import Network.Haskoin.Node
 import Network.Haskoin.Util
 
 tests :: [Test]
 tests =
-    [ 
-      -- Test cases come from bitcoind /src/test/bloom_tests.cpp
+    [ -- Test cases come from bitcoind /src/test/bloom_tests.cpp
       testGroup "Bloom Filters"
-      [ testCase "Bloom Filter Vector 1" bloomFilter1
-      , testCase "Bloom Filter Vector 2" bloomFilter2
-      , testCase "Bloom Filter Vector 3" bloomFilter3
-      ]
+        [ testCase "Bloom Filter Vector 1" bloomFilter1
+        , testCase "Bloom Filter Vector 2" bloomFilter2
+        , testCase "Bloom Filter Vector 3" bloomFilter3
+        ]
     ]
 
 bloomFilter1 :: Assertion

--- a/tests/Network/Haskoin/Script/Tests.hs
+++ b/tests/Network/Haskoin/Script/Tests.hs
@@ -10,22 +10,23 @@ import Test.QuickCheck.Property (Property, (==>))
 import Test.Framework (Test, testGroup, buildTest)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-
 import Test.Framework.Runners.Console (defaultMainWithArgs)
-
-import qualified Test.HUnit as HUnit
+import qualified Test.HUnit as HUnit (assertFailure, assertBool)
 
 import Control.Applicative ((<$>))
 import Control.Monad (when)
 
-import Numeric (readHex)
-
-import qualified Data.Aeson as A (decode)
 import Data.Bits (setBit, testBit)
-import Text.Read (readMaybe)
 import Data.List (isPrefixOf)
 import Data.List.Split ( splitOn )
 import Data.Char (ord)
+import Data.Maybe (catMaybes, isNothing)
+import Data.Int (Int64)
+import Data.Word (Word8, Word32)
+import Data.Binary (encode, decode, decodeOrFail)
+import qualified Data.Aeson as A (decode)
+import qualified Data.ByteString.Lazy as LBS (pack, unpack)
+import qualified Data.ByteString.Lazy.Char8 as C (readFile)
 import qualified Data.ByteString as BS
     ( singleton
     , length
@@ -36,35 +37,24 @@ import qualified Data.ByteString as BS
     , ByteString
     )
 
-import qualified Data.ByteString.Lazy as LBS
-    ( pack
-    , unpack
-    )
+import Numeric (readHex)
+import Text.Read (readMaybe)
 
-import Data.Maybe
-    ( catMaybes
-    , isNothing
-    )
-
-import Data.Binary
-    ( Word8
-    , encode
-    , decode
-    , decodeOrFail)
-
-import qualified Data.ByteString.Lazy.Char8 as C (readFile)
-
-import Data.Int (Int64)
-import Data.Word (Word32)
-
-import Network.Haskoin.Test.Script
-import Network.Haskoin.Test.Transaction
-
-import Network.Haskoin.Transaction.Types
+import Network.Haskoin.Test
+import Network.Haskoin.Transaction
 import Network.Haskoin.Script
-import Network.Haskoin.Script.Evaluator
 import Network.Haskoin.Crypto
 import Network.Haskoin.Util
+import Network.Haskoin.Internals 
+    ( Flag
+    , runStack
+    , dumpStack
+    , decodeInt
+    , encodeInt
+    , decodeBool
+    , encodeBool
+    , execScript
+    )
 
 tests :: [Test]
 tests = 
@@ -401,3 +391,4 @@ scriptPairTestExec scriptSig pubKey flags =
 
 runTests :: [Test] -> IO ()
 runTests ts = defaultMainWithArgs ts ["--hide-success"]
+

--- a/tests/Network/Haskoin/Stratum/Tests.hs
+++ b/tests/Network/Haskoin/Stratum/Tests.hs
@@ -1,12 +1,25 @@
 module Network.Haskoin.Stratum.Tests (tests) where
 
-import Data.Aeson
-import Data.Aeson.Types
-import Test.Framework
-import Test.Framework.Providers.QuickCheck2
-import Network.JsonRpc
+import Data.Aeson (ToJSON, toJSON)
+import Data.Aeson.Types (parseMaybe)
+import Test.Framework (Test, testGroup)
+import Test.Framework.Providers.QuickCheck2 (testProperty)
+
+import Network.JsonRpc 
+    ( Request(..)
+    , ToRequest
+    , FromRequest
+    , FromResponse
+    , Notif
+    , ToNotif
+    , FromNotif
+    , parseRequest
+    , parseResponse
+    , parseNotif
+    )
+
 import Network.Haskoin.Stratum
-import Network.Haskoin.Test.Stratum
+import Network.Haskoin.Test
 
 tests :: [Test]
 tests =

--- a/tests/Network/Haskoin/Transaction/Tests.hs
+++ b/tests/Network/Haskoin/Transaction/Tests.hs
@@ -6,15 +6,12 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Data.Word (Word64)
 import qualified Data.ByteString as BS (length)
 
-import Network.Haskoin.Test.Transaction
-import Network.Haskoin.Test.Script
-import Network.Haskoin.Test.Crypto
-
-import Network.Haskoin.Transaction.Builder
-import Network.Haskoin.Transaction.Types
+import Network.Haskoin.Test
+import Network.Haskoin.Transaction
 import Network.Haskoin.Script
 import Network.Haskoin.Crypto
 import Network.Haskoin.Util
+import Network.Haskoin.Internals (getFee, getMSFee)
 
 tests :: [Test]
 tests = 

--- a/tests/Network/Haskoin/Transaction/Units.hs
+++ b/tests/Network/Haskoin/Transaction/Units.hs
@@ -9,8 +9,7 @@ import Data.Maybe (fromJust)
 import Data.Binary.Get (getWord32le)
 import qualified Data.ByteString as BS (reverse)
 
-import Network.Haskoin.Transaction.Builder
-import Network.Haskoin.Transaction.Types
+import Network.Haskoin.Transaction
 import Network.Haskoin.Script
 import Network.Haskoin.Crypto
 import Network.Haskoin.Util

--- a/tests/Network/Haskoin/Util/Tests.hs
+++ b/tests/Network/Haskoin/Util/Tests.hs
@@ -8,7 +8,7 @@ import Data.Maybe (fromJust, catMaybes)
 import Data.Foldable (toList)
 import qualified Data.Sequence as Seq (update, fromList)
 
-import Network.Haskoin.Test.Crypto
+import Network.Haskoin.Test
 import Network.Haskoin.Util 
 
 tests :: [Test]


### PR DESCRIPTION
No functional changes. Mostly streamlining the cabal build process.
