### PR TITLE
Request a full block locator on a block tickle

### DIFF
--- a/Network/Haskoin/Node/SpvBlockChain.hs
+++ b/Network/Haskoin/Node/SpvBlockChain.hs
@@ -145,7 +145,7 @@ processBlockTickle pid bid = do
             -- TODO: We could have a DoS leak here
             setPeerTickle pid bid
             --Request headers so we can connect this block
-            headerSync (ThisPeer pid) PartialLocator $ Just bid
+            headerSync (ThisPeer pid) FullLocator $ Just bid
 
 processBlockHeaders :: (HeaderTree m, MonadLogger m, MonadIO m) 
                     => PeerId -> [BlockHeader] -> StateT SpvSession m ()


### PR DESCRIPTION
On a block tickle, we have to issue a full block locator. Otherwise, on a reorg, the remote peer will send us everything again from the genesis. 
