### PR TITLE
Add toMixed function and return more information for address derivations

### DIFF
--- a/Network/Haskoin/Crypto.hs
+++ b/Network/Haskoin/Crypto.hs
@@ -168,6 +168,7 @@ module Network.Haskoin.Crypto
 , parseSoft
 , toHard
 , toSoft
+, toMixed
 , derivePath
 , derivePubPath
 , derivePathE


### PR DESCRIPTION
There are 2 changes in this pull request.
- Add a `toMixed` function that transforms an arbitrary `DerivPathI t` into a `DerivPath` (mixed path). This is always possible and will always type check as a mixed path can contain any type of derivations.
- Address derivation functions now also return the associated redeem script for multisig addresses or the public key for regular addresses. This is helpful further up in wallet libraries to prevent duplication of work.
