### PR TITLE
Bump dependency versions.

### DIFF
--- a/Network/Haskoin/Node/Bloom.hs
+++ b/Network/Haskoin/Node/Bloom.hs
@@ -61,7 +61,7 @@ data BloomFlags
     -- This is the default setting.
     deriving (Eq, Show, Read)
 
-instance NFData BloomFlags
+instance NFData BloomFlags where rnf x = seq x ()
 
 instance Binary BloomFlags where
     get = go =<< getWord8

--- a/Network/Haskoin/Node/Types.hs
+++ b/Network/Haskoin/Node/Types.hs
@@ -158,7 +158,7 @@ data InvType
     | InvMerkleBlock -- ^ InvVector has is related to a merkle block
     deriving (Eq, Show, Read)
 
-instance NFData InvType
+instance NFData InvType where rnf x = seq x ()
 
 instance Binary InvType where
 
@@ -529,7 +529,7 @@ data MessageCommand
     | MCReject
     deriving (Eq, Show, Read)
 
-instance NFData MessageCommand
+instance NFData MessageCommand where rnf x = seq x ()
 
 instance Binary MessageCommand where
     

--- a/Network/Haskoin/Script/Types.hs
+++ b/Network/Haskoin/Script/Types.hs
@@ -74,7 +74,7 @@ data PushDataType
     | OPDATA4
     deriving (Show, Read, Eq)
 
-instance NFData PushDataType
+instance NFData PushDataType where rnf x = seq x ()
 
 -- | Data type representing all of the operators allowed inside a 'Script'.
 data ScriptOp

--- a/haskoin.cabal
+++ b/haskoin.cabal
@@ -94,13 +94,13 @@ library
                  , conduit                  >= 1.2          && < 1.3
                  , containers               >= 0.5          && < 0.6
                  , cryptohash               >= 0.11         && < 0.12
-                 , deepseq                  >= 1.3          && < 1.4
-                 , either                   >= 4.3          && < 4.4
+                 , deepseq                  >= 1.3          && < 1.5
+                 , either                   >= 4.3          && < 4.5
                  , mtl                      >= 2.1          && < 2.3 
                  , murmur3                  >= 1.0          && < 1.1
                  , network                  >= 2.6          && < 2.7
                  , pbkdf                    >= 1.1          && < 1.2
-                 , QuickCheck               >= 2.6          && < 2.8
+                 , QuickCheck               >= 2.6          && < 2.9
                  , split                    >= 0.2          && < 0.3
                  , text                     >= 0.11         && < 1.3
                  , time                     >= 1.4          && < 1.6


### PR DESCRIPTION
Apply the suggested fix to make deepseq backwards compatible.
See https://hackage.haskell.org/package/deepseq-1.4.1.1/docs/Control-DeepSeq.html#v:rnf

Closes #177 
