### PR TITLE
Return to 1MB blocks in Testnet3

### DIFF
--- a/haskoin-core/Network/Haskoin/Constants.hs
+++ b/haskoin-core/Network/Haskoin/Constants.hs
@@ -232,7 +232,7 @@ testnet3 = Network
         , blockBits      = 486604799
         , bhNonce        = 414098458
         }
-    , getMaxBlockSize = 8000000
+    , getMaxBlockSize = 1000000
     , getMaxSatoshi = 2100000000000000
     , getHaskoinUserAgent = "/haskoin-testnet:0.3.0/"
     , getDefaultPort = 18333


### PR DESCRIPTION
Goes into a blockchain header download loop when connecting to 1MB-block hosts having a longer 8MB chain.
