### PR TITLE
Submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "secp256k1-haskell"]
+	path = secp256k1-haskell
+	url = https://github.com/haskoin/secp256k1-haskell.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: generic
 sudo: required
 dist: trusty
+git:
+  submodules: false
 
 matrix:
   include:
@@ -86,6 +88,7 @@ matrix:
     - env: CABALVER=head GHCVER=head
 
 before_install:
+  - git submodule update --init --recursive
   - export PATH=/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:$PATH
   - if [[ "$GHCVER" == "stack" ]]; then 
       mkdir -p ~/.local/bin;

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Get [Stack](https://github.com/commercialhaskell/stack).
 Clone this repository, and then install using Stack.
 
 ```sh
-git clone https://github.com/haskoin/haskoin.git
+git clone --recursive https://github.com/haskoin/haskoin.git
 cd haskoin
 stack install
 ```

--- a/haskoin-core/stack.yaml
+++ b/haskoin-core/stack.yaml
@@ -1,9 +1,9 @@
 flags: {}
 packages:
 - '.'
-- location:
-    git: https://github.com/haskoin/secp256k1.git
-    commit: 5ee603061b3c1eaf2943e8d2c08e6effe85f38e7
+- location: '..'
+  subdirs:
+    - secp256k1-haskell
   extra-dep: true
 extra-deps:
 - murmur3-1.0.1

--- a/haskoin-node/stack.yaml
+++ b/haskoin-node/stack.yaml
@@ -1,11 +1,10 @@
 flags: {}
 packages:
 - '.'
-- location: '../haskoin-core'
-  extra-dep: true
-- location:
-    git: https://github.com/haskoin/secp256k1.git
-    commit: 5ee603061b3c1eaf2943e8d2c08e6effe85f38e7
+- location: '..'
+  subdirs:
+    - haskoin-core
+    - secp256k1-haskell
   extra-dep: true
 extra-deps:
 - concurrent-extra-0.7.0.10

--- a/haskoin-wallet/stack.yaml
+++ b/haskoin-wallet/stack.yaml
@@ -1,13 +1,11 @@
 flags: {}
 packages:
 - '.'
-- location: '../haskoin-core'
-  extra-dep: true
-- location: '../haskoin-node'
-  extra-dep: true
-- location:
-    git: https://github.com/haskoin/secp256k1.git
-    commit: 5ee603061b3c1eaf2943e8d2c08e6effe85f38e7
+- location: '..'
+  subdirs:
+    - haskoin-core
+    - haskoin-node
+    - secp256k1-haskell
   extra-dep: true
 extra-deps:
 - concurrent-extra-0.7.0.10

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,11 @@
 flags: {}
 packages:
-- 'haskoin-core'
-- 'haskoin-node'
 - 'haskoin-wallet'
-- location:
-    git: https://github.com/haskoin/secp256k1.git
-    commit: 5ee603061b3c1eaf2943e8d2c08e6effe85f38e7
+- location: '.'
+  subdirs:
+    - haskoin-core
+    - haskoin-node
+    - secp256k1-haskell
   extra-dep: true
 extra-deps:
 - concurrent-extra-0.7.0.10


### PR DESCRIPTION
Using submodules since `secp256k1-haskell` now uses submodules, and `stack` will not fetch submodules recursively when provided a Git entry. Also, this avoids specifying the Git entry for `secp256k1-haskell` in multiple `stack.yaml` files simultaneously for every update.
