### PR TITLE
documentation fix for applyPath

### DIFF
--- a/haskoin-core/Network/Haskoin/Crypto/ExtendedKeys.hs
+++ b/haskoin-core/Network/Haskoin/Crypto/ExtendedKeys.hs
@@ -675,9 +675,11 @@ data XKey = XPrv { getXPrvKey :: !XPrvKey }
           | XPub { getXPubKey :: !XPubKey }
     deriving (Eq, Show)
 
--- | Apply a parsed path to a private key to derive the new key defined in the
+-- | Apply a parsed path to an extended key to derive the new key defined in the
 -- path. If the path starts with m/, a private key will be returned and if the
 -- path starts with M/, a public key will be returned.
+-- Private derivations on a public key, and public derivations with a hard segment,
+-- return an error value.
 applyPath :: ParsedPath -> XKey -> Either String XKey
 applyPath path key = case (path, key) of
     (ParsedPrv _, XPrv k) -> return $ XPrv $ derivPrvF k


### PR DESCRIPTION
Small but legitimate haddock fix. 

This fails travis for "CABALVER=stack GHCVER=stack" configuration but I'm thinking the problem must be on the travis side as I don't see anything in the commit that would cause this. The other configurations pass.
