### PR TITLE
language pragmas so stack ghci works again

### DIFF
--- a/haskoin-core/Network/Haskoin/Constants.hs
+++ b/haskoin-core/Network/Haskoin/Constants.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-cse -fno-full-laziness #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-|
   Network specific constants
 -}

--- a/haskoin-core/Network/Haskoin/Crypto/Base58.hs
+++ b/haskoin-core/Network/Haskoin/Crypto/Base58.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Network.Haskoin.Crypto.Base58
 ( Address(..)
 , addrToBase58

--- a/haskoin-core/Network/Haskoin/Crypto/ExtendedKeys.hs
+++ b/haskoin-core/Network/Haskoin/Crypto/ExtendedKeys.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GADTs, TypeSynonymInstances, FlexibleInstances, OverloadedStrings #-}
 module Network.Haskoin.Crypto.ExtendedKeys
 ( XPubKey(..)
 , XPrvKey(..)

--- a/haskoin-core/Network/Haskoin/Crypto/Keys.hs
+++ b/haskoin-core/Network/Haskoin/Crypto/Keys.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, FlexibleContexts #-}
+
 module Network.Haskoin.Crypto.Keys
 ( PubKeyI(pubKeyCompressed, pubKeyPoint)
 , PubKey, PubKeyC, PubKeyU

--- a/haskoin-core/Network/Haskoin/Crypto/Mnemonic.hs
+++ b/haskoin-core/Network/Haskoin/Crypto/Mnemonic.hs
@@ -1,5 +1,7 @@
 -- | Mnemonic keys (BIP-39). Only the English dictionary in the BIP is
 -- supported.
+{-# LANGUAGE OverloadedStrings #-}
+
 module Network.Haskoin.Crypto.Mnemonic
 (
   -- * Data types

--- a/haskoin-core/Network/Haskoin/Node/Types.hs
+++ b/haskoin-core/Network/Haskoin/Node/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards, OverloadedStrings #-}
+
 module Network.Haskoin.Node.Types
 ( Addr(..)
 , NetworkAddressTime

--- a/haskoin-core/Network/Haskoin/Script/Evaluator.hs
+++ b/haskoin-core/Network/Haskoin/Script/Evaluator.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase, OverloadedStrings  #-}
 {-|
 
 Module providing Bitcoin script evaluation.  See

--- a/haskoin-core/Network/Haskoin/Script/SigHash.hs
+++ b/haskoin-core/Network/Haskoin/Script/SigHash.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Network.Haskoin.Script.SigHash
 ( SigHash(..)
 , encodeSigHash32

--- a/haskoin-core/Network/Haskoin/Transaction/Builder.hs
+++ b/haskoin-core/Network/Haskoin/Transaction/Builder.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings, FlexibleContexts #-}
+
 module Network.Haskoin.Transaction.Builder
 ( Coin(..)
 , buildTx


### PR DESCRIPTION
ghci stopped working with a mysterio error that has been reported elsewhere (appears to be stack issue).

these language pragmas make stack ghci semi-usable again.

```
➜  haskoin-core git:(bip65_test_vectors) ✗ stack ghci
Configuring GHCi with the following packages: haskoin-core, haskoin-node, haskoin-wallet
GHCi, version 7.10.3: http://www.haskell.org/ghc/  :? for help

<no location info>:
    module ‘main@main:Network.Haskoin.Node.Units’ is defined in multiple files: /Users/thomashartman/dev/haskoin-arena/haskoin/haskoin-core/tests/Network/Haskoin/Node/Units.hs
                                                                                /Users/thomashartman/dev/haskoin-arena/haskoin/haskoin-node/tests/Network/Haskoin/Node/Units.hs
Failed, modules loaded: none.
```

stack ghci, then :l path/to/module.hs works ok, with pragmas here.
