### PR TITLE
Changes required to use "inproc" ZeroMQ transport + example app

### DIFF
--- a/haskoin-core/Network/Haskoin/Crypto/ECDSA.hs
+++ b/haskoin-core/Network/Haskoin/Crypto/ECDSA.hs
@@ -91,11 +91,11 @@ hashToMsg =
 
 -- <http://www.secg.org/sec1-v2.pdf Section 4.1.3>
 -- | Sign a message
-signMsg :: Hash256 -> PrvKey -> Signature
+signMsg :: Hash256 -> PrvKeyI c -> Signature
 signMsg h d = Signature $ EC.signMsg (prvKeySecKey d) (hashToMsg h)
 
 -- | Verify an ECDSA signature
-verifySig :: Hash256 -> Signature -> PubKey -> Bool
+verifySig :: Hash256 -> Signature -> PubKeyI c -> Bool
 verifySig h s q =
     EC.verifySig p g m
   where

--- a/haskoin-core/haskoin-core.cabal
+++ b/haskoin-core/haskoin-core.cabal
@@ -82,7 +82,7 @@ library
                 DeriveDataTypeable
                 GADTs
 
-    build-depends: aeson                    >= 0.7          && < 0.12
+    build-depends: aeson                    >= 0.7          && < 1.1
                  , base                     >= 4.8          && < 5
                  , byteable                 >= 0.1          && < 0.2
                  , bytestring               >= 0.10         && < 0.11
@@ -97,7 +97,7 @@ library
                  , murmur3                  >= 1.0          && < 1.1
                  , network                  >= 2.6          && < 2.7
                  , pbkdf                    >= 1.1          && < 1.2
-                 , QuickCheck               >= 2.6          && < 2.9
+                 , QuickCheck               >= 2.6          && < 2.10
                  , split                    >= 0.2          && < 0.3
                  , text                     >= 0.11         && < 1.3
                  , time                     >= 1.4          && < 1.7
@@ -138,7 +138,7 @@ test-suite test-haskoin-core
                    Network.Haskoin.Json.Tests
                    Network.Haskoin.Cereal.Tests
 
-    build-depends: aeson                          >= 0.7        && < 0.12
+    build-depends: aeson                          >= 0.7        && < 1.1
                  , base                           >= 4.8        && < 5
                  , bytestring                     >= 0.10       && < 0.11
                  , cereal                         >= 0.5        && < 0.6
@@ -147,7 +147,7 @@ test-suite test-haskoin-core
                  , mtl                            >= 2.2        && < 2.3
                  , split                          >= 0.2        && < 0.3
                  , HUnit                          >= 1.2        && < 1.4
-                 , QuickCheck                     >= 2.6        && < 2.9
+                 , QuickCheck                     >= 2.6        && < 2.10
                  , test-framework                 >= 0.8        && < 0.9
                  , test-framework-quickcheck2     >= 0.3        && < 0.4
                  , test-framework-hunit           >= 0.3        && < 0.4

--- a/haskoin-node/Network/Haskoin/Node/HeaderTree.hs
+++ b/haskoin-node/Network/Haskoin/Node/HeaderTree.hs
@@ -30,6 +30,9 @@ module Network.Haskoin.Node.HeaderTree
 , nodeHeader
 , nodePrev
 , nodeTimestamp
+, nodeWork
+, nodeHeight
+, nodeChain
 , isBestChain
 , isChainReorg
 , isSideChain
@@ -101,6 +104,15 @@ nodePrev = prevBlock . nodeHeader
 
 nodeTimestamp :: NodeBlock -> Timestamp
 nodeTimestamp = blockTimestamp . nodeHeader
+
+nodeWork :: NodeBlock -> Work
+nodeWork = nodeBlockWork
+
+nodeHeight :: NodeBlock -> BlockHeight
+nodeHeight = nodeBlockHeight
+
+nodeChain :: NodeBlock -> Word32
+nodeChain = nodeBlockChain
 
 -- | Number of blocks on average between difficulty cycles (2016 blocks).
 diffInterval :: Word32

--- a/haskoin-node/haskoin-node.cabal
+++ b/haskoin-node/haskoin-node.cabal
@@ -48,7 +48,7 @@ library
                 RecordWildCards
                 DeriveDataTypeable
 
-    build-depends: aeson                    >= 0.7          && < 0.12
+    build-depends: aeson                    >= 0.7          && < 1.1
                  , async                    >= 2.0          && < 2.2
                  , base                     >= 4.8          && < 5
                  , bytestring               >= 0.10         && < 0.11
@@ -96,7 +96,7 @@ test-suite test-haskoin-node
                  , haskoin-core
                  , haskoin-node
                  , HUnit                          >= 1.2        && < 1.4
-                 , QuickCheck                     >= 2.6        && < 2.9
+                 , QuickCheck                     >= 2.6        && < 2.10
                  , monad-logger                   >= 0.3        && < 0.4
                  , mtl                            >= 2.2        && < 2.3
                  , persistent                     >= 2.2        && < 2.3

--- a/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
@@ -195,6 +195,7 @@ dispatchCommand cfg args = flip R.runReaderT cfg $ case args of
     "label"       : name : index : label  : [] -> cmdLabel name index label
     "txs"         : name : page                -> cmdTxs name page
     "addrtxs"     : name : index : page        -> cmdAddrTxs name index page
+    "getindex"    : name : key            : [] -> cmdKeyIndex name key
     "genaddrs"    : name : i              : [] -> cmdGenAddrs name i
     "send"        : name : add : amnt     : [] -> cmdSend name add amnt
     "sendmany"    : name : xs                  -> cmdSendMany name xs

--- a/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
@@ -190,6 +190,7 @@ dispatchCommand cfg args = flip R.runReaderT cfg $ case args of
     "accounts"    : page                       -> cmdAccounts page
     "rename"      : name : new            : [] -> cmdRenameAcc name new
     "list"        : name : page                -> cmdList name page
+    "pubkeys"     : name : page                -> cmdPubKeys name page
     "unused"      : name : page                -> cmdUnused name page
     "label"       : name : index : label  : [] -> cmdLabel name index label
     "txs"         : name : page                -> cmdTxs name page

--- a/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
@@ -214,6 +214,7 @@ dispatchCommand cfg args = flip R.runReaderT cfg $ case args of
     "decodetx"                            : [] -> cmdDecodeTx
     "status"                              : [] -> cmdStatus
     "keypair"                             : [] -> cmdKeyPair
+    "blockinfo"   : hashes                     -> cmdBlockInfo hashes
     "version"                             : [] -> cmdVersion
     "help"        : [] -> liftIO $ forM_ usage (hPutStrLn stderr)
     []                 -> liftIO $ forM_ usage (hPutStrLn stderr)

--- a/haskoin-wallet/Network/Haskoin/Wallet/Server.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Server.hs
@@ -442,6 +442,7 @@ dispatchRequest req = fmap ResponseValid $ case req of
     GetAddressesR n t m o p          -> getAddressesR n t m o p
     GetAddressesUnusedR n t p        -> getAddressesUnusedR n t p
     GetAddressR n i t m o            -> getAddressR n i t m o
+    GetIndexR n k t                  -> getIndexR n k t
     PutAddressR n i t l              -> putAddressR n i t l
     PostAddressesR n i t             -> postAddressesR n i t
     GetTxsR n p                      -> getTxsR n p

--- a/haskoin-wallet/Network/Haskoin/Wallet/Server.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Server.hs
@@ -458,3 +458,4 @@ dispatchRequest req = fmap ResponseValid $ case req of
     GetSyncHeightR a n b             -> getSyncR a (Left n) b
     GetPendingR a p                  -> getPendingR a p
     GetDeadR a p                     -> getDeadR a p
+    GetBlockInfoR l                  -> getBlockInfoR l

--- a/haskoin-wallet/Network/Haskoin/Wallet/Server/Handler.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Server/Handler.hs
@@ -252,6 +252,26 @@ getAddressR name i addrType minConf offline = do
             _           -> (entityVal addrE, Nothing)
     return $ Just $ toJSON $ toJsonAddr addr balM
 
+getIndexR :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+          => AccountName
+          -> PubKeyC
+          -> AddressType
+          -> Handler m (Maybe Value)
+getIndexR name key addrType = do
+    $(logInfo) $ format $ unlines
+        [ "getIndexR"
+        , "  Account name: " ++ unpack name
+        , "  Key         : " ++ show key
+        , "  Address type: " ++ show addrType
+        ]
+    addrLst <- runDB $ do
+        accE <- getAccount name
+        lookupByPubKey accE key addrType
+    let hello = map (`toJsonAddr` Nothing) addrLst
+    liftIO $ putStrLn $ show hello
+    liftIO $ print $ toJSON $ hello
+    return $ Just $ toJSON $ hello
+
 putAddressR :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
             => AccountName
             -> KeyIndex

--- a/haskoin-wallet/Network/Haskoin/Wallet/Server/Handler.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Server/Handler.hs
@@ -8,7 +8,7 @@ import           Control.Arrow                      (first)
 import           Control.Concurrent.STM.TBMChan     (TBMChan)
 import           Control.Exception                  (SomeException (..),
                                                      tryJust)
-import           Control.Monad                      (liftM, unless, when)
+import           Control.Monad                      (liftM, forM, unless, when)
 import           Control.Monad.Base                 (MonadBase)
 import           Control.Monad.Catch                (MonadThrow, throwM)
 import           Control.Monad.Logger               (MonadLoggerIO, logError,
@@ -23,6 +23,7 @@ import qualified Data.Map.Strict                    as M (elems, fromList,
 import           Data.String.Conversions            (cs)
 import           Data.Text                          (Text, pack, unpack)
 import           Data.Word                          (Word32)
+import           Data.Maybe                         (catMaybes)
 import           Database.Esqueleto                 (Entity (..), SqlPersistT)
 import           Database.Persist.Sql               (ConnectionPool,
                                                      SqlPersistM,
@@ -41,6 +42,7 @@ import           Network.Haskoin.Wallet.Model
 import           Network.Haskoin.Wallet.Settings
 import           Network.Haskoin.Wallet.Transaction
 import           Network.Haskoin.Wallet.Types
+import           Network.Haskoin.Wallet.Types.BlockInfo (fromNodeBlock)
 
 type Handler m = ReaderT HandlerSession m
 
@@ -568,6 +570,16 @@ getSyncR acc blockE lq@ListRequest{..} = runDB $ do
     showBlock = case blockE of
         Left  e -> show e
         Right b -> cs $ blockHashToHex b
+
+getBlockInfoR :: (MonadThrow m, MonadLoggerIO m, MonadBaseControl IO m)
+              => [BlockHash]
+              -> Handler m (Maybe Value)
+getBlockInfoR headerLst = do
+    lstMaybeBlk <- forM headerLst (runNode . runSqlNodeT . getBlockByHash)
+    return $ toJSON <$> Just (handleRes lstMaybeBlk)
+  where
+    handleRes :: [Maybe NodeBlock] -> [BlockInfo]
+    handleRes = map fromNodeBlock . catMaybes
 
 {- Helpers -}
 

--- a/haskoin-wallet/Network/Haskoin/Wallet/Types.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Types.hs
@@ -334,6 +334,7 @@ data WalletRequest
     | GetAddressesR !AccountName !AddressType !Word32 !Bool !ListRequest
     | GetAddressesUnusedR !AccountName !AddressType !ListRequest
     | GetAddressR !AccountName !KeyIndex !AddressType !Word32 !Bool
+    | GetIndexR !AccountName !PubKeyC !AddressType
     | PutAddressR !AccountName !KeyIndex !AddressType !AddressLabel
     | PostAddressesR !AccountName !KeyIndex !AddressType
     | GetTxsR !AccountName !ListRequest

--- a/haskoin-wallet/Network/Haskoin/Wallet/Types.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Types.hs
@@ -35,6 +35,7 @@ module Network.Haskoin.Wallet.Types
 , JsonSyncBlock(..)
 , JsonBlock(..)
 , Notif(..)
+, BlockInfo(..)
 
 -- Helper Types
 , WalletException(..)
@@ -98,6 +99,7 @@ import           Network.Haskoin.Script
 import           Network.Haskoin.Transaction
 import           Network.Haskoin.Util
 import           Network.Haskoin.Wallet.Database
+import           Network.Haskoin.Wallet.Types.BlockInfo
 
 type AccountName = Text
 
@@ -350,6 +352,7 @@ data WalletRequest
     | GetSyncHeightR !AccountName !BlockHeight !ListRequest
     | GetPendingR !AccountName !ListRequest
     | GetDeadR !AccountName !ListRequest
+    | GetBlockInfoR ![BlockHash]
 
 -- TODO: Set omitEmptyContents on aeson-0.9
 $(deriveJSON

--- a/haskoin-wallet/Network/Haskoin/Wallet/Types/BlockInfo.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Types/BlockInfo.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Network.Haskoin.Wallet.Types.BlockInfo
+(
+  BlockInfo(..)
+, JsonHash256
+, fromNodeBlock
+)
+where
+
+import Data.String.Conversions  (cs, ConvertibleStrings(..))
+import Data.Maybe               (fromMaybe)
+import Data.Aeson.TH            (deriveJSON)
+import Data.Word                (Word32)
+import Data.Time                (UTCTime)
+import Data.ByteString          (ByteString)
+import Data.Time.Clock.POSIX    (posixSecondsToUTCTime)
+import Data.Aeson               (FromJSON, ToJSON, Value (String),
+                                 parseJSON, toJSON, withText)
+
+import Network.Haskoin.Block
+import Network.Haskoin.Node.HeaderTree
+import Network.Haskoin.Crypto
+import Network.Haskoin.Util
+import Network.Haskoin.Constants
+
+
+newtype JsonHash256 = JsonHash256 { jsonGetHash256 :: Hash256 }
+    deriving (Eq, Show)
+
+jsonHashToHex :: JsonHash256 -> ByteString
+jsonHashToHex = blockHashToHex . BlockHash . jsonGetHash256
+
+instance ToJSON JsonHash256 where
+    toJSON = String . cs . jsonHashToHex
+
+instance FromJSON JsonHash256 where
+    parseJSON = withText "JsonHash256" $
+        return . JsonHash256 . getBlockHash <$>
+            fromMaybe (error "Invalid 256 bit hash") .
+                hexToBlockHash . cs
+
+instance ConvertibleStrings JsonHash256 String where
+    convertString = cs . jsonHashToHex
+
+data BlockInfo = BlockInfo
+   { blockInfoHash          :: !BlockHash
+   , blockInfoHeight        :: !BlockHeight
+   , blockInfoVersion       :: !Word32
+   , blockInfoTimestamp     :: !UTCTime
+   , blockInfoPrevBlock     :: !BlockHash
+   , blockInfoMerkleRoot    :: !JsonHash256
+   , blockInfoBits          :: !Word32
+   , blockInfoNonce         :: !Word32
+   , blockInfoChain         :: !Word32
+   , blockInfoChainWork     :: !Double
+   } deriving (Eq, Show)
+
+$(deriveJSON (dropFieldLabel 9) ''BlockInfo)
+
+fromNodeBlock :: NodeBlock -> BlockInfo
+fromNodeBlock nb =
+    BlockInfo
+       { blockInfoHash          =   headerHash header
+       , blockInfoVersion       = blockVersion header
+       , blockInfoPrevBlock     =    prevBlock header
+       , blockInfoNonce         =      bhNonce header
+       , blockInfoBits          =    blockBits header
+       , blockInfoMerkleRoot    = JsonHash256 $ merkleRoot header
+       , blockInfoTimestamp     = utcTimestamp
+       , blockInfoChainWork     = nodeWork   nb
+       , blockInfoHeight        = nodeHeight nb
+       , blockInfoChain         = nodeChain  nb
+       }
+  where
+    header = nodeHeader nb
+    utcTimestamp = posixSecondsToUTCTime . realToFrac .
+        blockTimestamp $ header
+

--- a/haskoin-wallet/config/help
+++ b/haskoin-wallet/config/help
@@ -16,6 +16,7 @@ Account commands:
 
 Address commands:
   list      acc [page] [-c pagesize] [-r]  Display addresses by page
+  pubkeys   acc [page] [-c pagesize] [-r]  Display address public keys
   unused    acc [page] [-c pagesize] [-r]  Display unused addresses
   label     acc index label                Set the label of an address
   addrtxs   acc index [page] [-c pagesize] Display txs related to an address

--- a/haskoin-wallet/config/help
+++ b/haskoin-wallet/config/help
@@ -20,6 +20,7 @@ Address commands:
   unused    acc [page] [-c pagesize] [-r]  Display unused addresses
   label     acc index label                Set the label of an address
   addrtxs   acc index [page] [-c pagesize] Display txs related to an address
+  getindex  acc key                        Get key index by pubkey
   genaddrs  acc index [--internal]         Generate addresses up to this index
 
 Transaction commands:

--- a/haskoin-wallet/config/help
+++ b/haskoin-wallet/config/help
@@ -45,6 +45,7 @@ Utility commands:
   rescan   [timestamp]                     Rescan the wallet
   keypair                                  Get curve key pair for ØMQ auth
   monitor [account]                        Monitor events (no account: blocks)
+  blockinfo [hash1] [hash2] [...]          Get block header information by hash
 
 Other commands:
   version                                  Display version information

--- a/haskoin-wallet/haskoin-wallet.cabal
+++ b/haskoin-wallet/haskoin-wallet.cabal
@@ -58,7 +58,7 @@ library
                 RecordWildCards
                 GeneralizedNewtypeDeriving
 
-    build-depends: aeson                         >= 0.7       && < 0.12
+    build-depends: aeson                         >= 0.7       && < 1.1
                  , aeson-pretty                  >= 0.7       && < 0.8
                  , base                          >= 4.8       && < 5
                  , bytestring                    >= 0.10      && < 0.11
@@ -124,7 +124,7 @@ test-suite test-haskoin-wallet
     extensions: RecordWildCards
                 OverloadedStrings
 
-    build-depends: aeson                         >= 0.7       && < 0.12
+    build-depends: aeson                         >= 0.7       && < 1.1
                  , base                          >= 4.8       && < 5
                  , bytestring                    >= 0.10      && < 0.11
                  , containers                    >= 0.5       && < 0.6
@@ -140,7 +140,7 @@ test-suite test-haskoin-wallet
                  , text                          >= 0.11      && < 1.3
                  , unordered-containers          >= 0.2       && < 0.3
                  , HUnit                         >= 1.2       && < 1.4
-                 , QuickCheck                    >= 2.8       && < 2.9
+                 , QuickCheck                    >= 2.8       && < 2.10
                  , stm                           >= 2.4       && < 2.5
                  , stm-chans                     >= 3.0       && < 3.1
                  , string-conversions            >= 0.4       && < 0.5

--- a/haskoin-wallet/haskoin-wallet.cabal
+++ b/haskoin-wallet/haskoin-wallet.cabal
@@ -37,6 +37,7 @@ library
                      Network.Haskoin.Wallet.Internals
 
     other-modules: Network.Haskoin.Wallet.Types
+                   Network.Haskoin.Wallet.Types.BlockInfo
                    Network.Haskoin.Wallet.Accounts
                    Network.Haskoin.Wallet.Transaction
                    Network.Haskoin.Wallet.Block


### PR DESCRIPTION
First commits adds `runSPVServerWithContext` (by separating it out from `runSPVServer`), which allows passing a specific ZeroMQ `Context` to the haskoin-wallet server. A shared Context between receiver and sender is required in order to speak to the server in-process/inter-thread via the "inproc" ZeroMQ transport.

Second commit adds an example executable that embeds a haskoin-wallet server in-app, using `runSPVServerWithContext` and the "inproc" transport for inter-thread communication with the server. (If I had more ncurses skills I would create a proper GUI for it, but for now it makes most sense to run it as `example-inproc-wallet-server 2> debug.log` and, optionally, view the log using `tail -f debug.log`)
