### PR TITLE
lts-7.18 compatibility: increase upper bounds + separate out prettyJson

### DIFF
--- a/haskoin-core/haskoin-core.cabal
+++ b/haskoin-core/haskoin-core.cabal
@@ -146,7 +146,7 @@ test-suite test-haskoin-core
                  , haskoin-core
                  , mtl                            >= 2.2        && < 2.3
                  , split                          >= 0.2        && < 0.3
-                 , HUnit                          >= 1.2        && < 1.4
+                 , HUnit                          >= 1.2        && < 1.6
                  , QuickCheck                     >= 2.6        && < 2.10
                  , test-framework                 >= 0.8        && < 0.9
                  , test-framework-quickcheck2     >= 0.3        && < 0.4

--- a/haskoin-node/haskoin-node.cabal
+++ b/haskoin-node/haskoin-node.cabal
@@ -57,10 +57,10 @@ library
                  , conduit                  >= 1.2          && < 1.3
                  , conduit-extra            >= 1.1          && < 1.2
                  , containers               >= 0.5          && < 0.6
-                 , data-default             >= 0.5          && < 0.6
+                 , data-default             >= 0.5          && < 0.8
                  , deepseq                  >= 1.4          && < 1.5
                  , either                   >= 4.3          && < 4.5
-                 , esqueleto                >= 2.4          && < 2.5
+                 , esqueleto                >= 2.4          && < 2.6
                  , exceptions               >= 0.8          && < 0.9
                  , haskoin-core             >= 0.3          && < 0.5
                  , largeword                >= 1.2.4        && < 1.3
@@ -70,13 +70,13 @@ library
                  , monad-logger             >= 0.3          && < 0.4
                  , mtl                      >= 2.2          && < 2.3
                  , network                  >= 2.4          && < 2.7
-                 , persistent               >= 2.2          && < 2.3
-                 , persistent-template      >= 2.1          && < 2.2
+                 , persistent               >= 2.2          && < 2.7
+                 , persistent-template      >= 2.1          && < 2.6
                  , resource-pool            >= 0.2          && < 0.3
                  , random                   >= 1.0          && < 1.2
                  , stm                      >= 2.4          && < 2.5
                  , stm-chans                >= 3.0          && < 3.1
-                 , stm-conduit              >= 2.5          && < 2.9
+                 , stm-conduit              >= 2.5          && < 3.1
                  , string-conversions       >= 0.4          && < 0.5
                  , text                     >= 0.11         && < 1.3
                  , time                     >= 1.4          && < 1.7
@@ -95,12 +95,12 @@ test-suite test-haskoin-node
     build-depends: base                           >= 4.8        && < 5
                  , haskoin-core
                  , haskoin-node
-                 , HUnit                          >= 1.2        && < 1.4
+                 , HUnit                          >= 1.2        && < 1.6
                  , QuickCheck                     >= 2.6        && < 2.10
                  , monad-logger                   >= 0.3        && < 0.4
                  , mtl                            >= 2.2        && < 2.3
-                 , persistent                     >= 2.2        && < 2.3
-                 , persistent-sqlite              >= 2.2        && < 2.3
+                 , persistent                     >= 2.2        && < 2.7
+                 , persistent-sqlite              >= 2.2        && < 2.7
                  , resourcet                      >= 1.1        && < 1.2
                  , test-framework                 >= 0.8        && < 0.9
                  , test-framework-quickcheck2     >= 0.3        && < 0.4

--- a/haskoin-wallet/Network/Haskoin/Wallet/Client/Commands.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Client/Commands.hs
@@ -39,7 +39,7 @@ where
 
 import           Control.Applicative             ((<|>))
 import           Control.Concurrent.Async.Lifted (async, wait)
-import           Control.Monad                   (mapM_, forM_, forever, liftM2,
+import           Control.Monad                   (forM_, forever, liftM2,
                                                   unless, when)
 import qualified Control.Monad.Reader            as R (ReaderT, ask, asks)
 import           Control.Monad.Trans             (liftIO)
@@ -742,6 +742,11 @@ encodeScriptOutputJSON so = case so of
         [ "pay2scripthash" .= object
             [ "address-base64" .= (cs $ encodeHex $ encode $ getAddrHash a :: Text)
             , "address-base58" .= (cs (addrToBase58 a) :: Text)
+            ]
+        ]
+    DataCarrier bs -> object
+        [ "op_return" .= object
+            [ "data" .= (cs $ encodeHex bs :: Text)
             ]
         ]
 

--- a/haskoin-wallet/Network/Haskoin/Wallet/Client/Commands.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Client/Commands.hs
@@ -47,9 +47,6 @@ import           Data.Aeson                      (FromJSON, ToJSON, Value (..),
                                                   decode, eitherDecode, object,
                                                   toJSON, (.=))
 import qualified Data.Aeson                      as Aeson (encode)
-import qualified Data.Aeson.Encode.Pretty        as JSON (Config (..),
-                                                          defConfig,
-                                                          encodePretty')
 import qualified Data.ByteString.Char8           as B8 (hPutStrLn, putStrLn,
                                                         unwords)
 import           Data.String                     (fromString)
@@ -74,6 +71,7 @@ import           Network.Haskoin.Util
 import           Network.Haskoin.Wallet.Server
 import           Network.Haskoin.Wallet.Settings
 import           Network.Haskoin.Wallet.Types
+import qualified Network.Haskoin.Wallet.Client.PrettyJson as JSON
 import qualified System.Console.Haskeline        as Haskeline
 import           System.IO                       (stderr)
 import           System.ZMQ4                     (KeyFormat (..), Req (..),
@@ -537,7 +535,7 @@ cmdDecodeTx = do
         _          -> YAML.encode $ val tx
   where
     val = encodeTxJSON
-    jsn = JSON.encodePretty' JSON.defConfig{ JSON.confIndent = 2 } . val
+    jsn = JSON.encodePretty . val
 
 cmdVersion :: Handler ()
 cmdVersion = liftIO $ do
@@ -581,7 +579,7 @@ handleNotif :: OutputFormat -> Either String Notif -> IO ()
 handleNotif _   (Left e) = error e
 handleNotif fmt (Right notif) = case fmt of
     OutputJSON -> formatStr $ cs $
-        JSON.encodePretty' JSON.defConfig{ JSON.confIndent = 2 } notif
+        JSON.encodePretty notif
     OutputYAML -> do
         putStrLn "---"
         formatStr $ cs $ YAML.encode notif
@@ -608,7 +606,7 @@ handleResponse resE handle = case parseResponse resE of
   where
     formatOutput a format = case format of
         OutputJSON   -> liftIO . formatStr $ cs $
-            JSON.encodePretty' JSON.defConfig{ JSON.confIndent = 2 } a
+            JSON.encodePretty a
         OutputYAML   -> liftIO . formatStr $ cs $ YAML.encode a
         OutputNormal -> handle a
 

--- a/haskoin-wallet/Network/Haskoin/Wallet/Client/PrettyJson.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Client/PrettyJson.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE CPP #-}
+module Network.Haskoin.Wallet.Client.PrettyJson
+( encodePretty )
+where
+
+import qualified Data.ByteString.Lazy  as BL
+import Data.Aeson                                (ToJSON)
+import Data.Aeson.Encode.Pretty        as Export (Config (..),
+                                                  defConfig,
+                                                  encodePretty')
+
+-- aeson-pretty 0.8.0 introduces a new way to specify indentation
+#if MIN_VERSION_aeson_pretty(0,8,0)
+import Data.Aeson.Encode.Pretty        as Export (Indent(..))
+jsonIndent :: Indent
+jsonIndent = Spaces 2
+#else
+jsonIndent :: Int
+jsonIndent = 2
+#endif
+
+encodePretty :: ToJSON a => a -> BL.ByteString
+encodePretty = encodePretty' defConfig{ confIndent = jsonIndent }

--- a/haskoin-wallet/Network/Haskoin/Wallet/Types/BlockInfo.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Types/BlockInfo.hs
@@ -21,7 +21,6 @@ import Network.Haskoin.Block
 import Network.Haskoin.Node.HeaderTree
 import Network.Haskoin.Crypto
 import Network.Haskoin.Util
-import Network.Haskoin.Constants
 
 
 newtype JsonHash256 = JsonHash256 { jsonGetHash256 :: Hash256 }

--- a/haskoin-wallet/haskoin-wallet.cabal
+++ b/haskoin-wallet/haskoin-wallet.cabal
@@ -43,6 +43,7 @@ library
                    Network.Haskoin.Wallet.Block
                    Network.Haskoin.Wallet.Server.Handler
                    Network.Haskoin.Wallet.Client.Commands
+                   Network.Haskoin.Wallet.Client.PrettyJson
                    Network.Haskoin.Wallet.Database
 
     extensions: TemplateHaskell
@@ -59,18 +60,18 @@ library
                 GeneralizedNewtypeDeriving
 
     build-depends: aeson                         >= 0.7       && < 1.1
-                 , aeson-pretty                  >= 0.7       && < 0.8
+                 , aeson-pretty                  >= 0.7       && < 0.9
                  , base                          >= 4.8       && < 5
                  , bytestring                    >= 0.10      && < 0.11
                  , cereal                        >= 0.5       && < 0.6
                  , containers                    >= 0.5       && < 0.6
                  , conduit                       >= 1.2       && < 1.3
                  , deepseq                       >= 1.4       && < 1.5
-                 , data-default                  >= 0.5       && < 0.6
+                 , data-default                  >= 0.5       && < 0.8
                  , directory                     >= 1.2       && < 1.3
                  , daemons                       >= 0.2       && < 0.3
                  , exceptions                    >= 0.6       && < 0.9
-                 , esqueleto                     >= 2.4       && < 2.5
+                 , esqueleto                     >= 2.4       && < 2.6
                  , file-embed                    >= 0.0       && < 0.1
                  , filepath                      >= 1.4       && < 1.5
                  , haskeline
@@ -81,15 +82,15 @@ library
                  , monad-logger                  >= 0.3.13    && < 0.4
                  , monad-control                 >= 1.0       && < 1.1
                  , mtl                           >= 2.1       && < 2.3
-                 , persistent                    >= 2.2       && < 2.3
-                 , persistent-template           >= 2.1       && < 2.2
-                 , persistent-sqlite             >= 2.2       && < 2.3
+                 , persistent                    >= 2.2       && < 2.7
+                 , persistent-template           >= 2.1       && < 2.6
+                 , persistent-sqlite             >= 2.2       && < 2.7
                  , resourcet                     >= 1.1       && < 1.2
                  , semigroups
                  , split                         >= 0.2       && < 0.3
                  , stm                           >= 2.4       && < 2.5
                  , stm-chans                     >= 3.0       && < 3.1
-                 , stm-conduit                   >= 2.6       && < 2.9
+                 , stm-conduit                   >= 2.6       && < 3.1
                  , string-conversions            >= 0.4       && < 0.5
                  , text                          >= 0.11      && < 1.3
                  , time                          >= 1.5       && < 1.7
@@ -134,12 +135,12 @@ test-suite test-haskoin-wallet
                  , haskoin-wallet
                  , monad-logger                  >= 0.3       && < 0.4
                  , mtl                           >= 2.1       && < 2.3
-                 , persistent                    >= 2.2       && < 2.3
-                 , persistent-sqlite             >= 2.2       && < 2.3
+                 , persistent                    >= 2.2       && < 2.7
+                 , persistent-sqlite             >= 2.2       && < 2.7
                  , resourcet                     >= 1.1       && < 1.2
                  , text                          >= 0.11      && < 1.3
                  , unordered-containers          >= 0.2       && < 0.3
-                 , HUnit                         >= 1.2       && < 1.4
+                 , HUnit                         >= 1.2       && < 1.6
                  , QuickCheck                    >= 2.8       && < 2.10
                  , stm                           >= 2.4       && < 2.5
                  , stm-chans                     >= 3.0       && < 3.1
@@ -166,12 +167,12 @@ executable example-inproc-wallet-server
                  -with-rtsopts=-N4
 
     build-depends:     base                          >= 4.8       && < 5
-                     , aeson                         >= 0.7       && < 0.12
-                     , aeson-pretty                  >= 0.7       && < 0.8
+                     , aeson                         >= 0.7       && < 1.1
+                     , aeson-pretty                  >= 0.7       && < 0.9
                      , haskoin-node                  >= 0.3       && < 0.5
                      , haskoin-wallet
                      , monad-logger                  >= 0.3       && < 0.4
-                     , persistent-sqlite             >= 2.2       && < 2.3
+                     , persistent-sqlite             >= 2.2       && < 2.7
                      , resourcet                     >= 1.1       && < 1.2
                      , unordered-containers          >= 0.2       && < 0.3
                      , string-conversions            >= 0.4       && < 0.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
+resolver: lts-6.15
+
 flags: {}
 packages:
 - haskoin-core
@@ -5,7 +7,8 @@ packages:
 - haskoin-wallet
 extra-deps:
 - daemons-0.2.1
-- murmur3-1.0.2
 - pbkdf-1.1.1.1
 - secp256k1-0.4.6
-resolver: lts-6.15
+- murmur3-1.0.3
+### uncomment below for lts-7.18 compatibility
+#- esqueleto-2.5.1


### PR DESCRIPTION
lts-7.18 contains aeson-pretty-0.8.0, which introduces a new type for
specifying identation ('Indent'), rather than accepting an 'Int'. We
factor out JSON pretty-printing into its own module, in order to contain
the CPP logic required to handle this.