### PR TITLE
Generalize the display of public keys

### DIFF
--- a/haskoin-wallet/Network/Haskoin/Wallet.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet.hs
@@ -13,7 +13,6 @@ module Network.Haskoin.Wallet
 
 -- *Server
 , runSPVServer
-, stopSPVServer
 , SPVMode(..)
 
 -- *API JSON Types

--- a/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
@@ -90,6 +90,10 @@ options =
         (NoArg $ \cfg -> cfg { configAddrType = AddressInternal }) $
         "Internal addresses. Default: "
             ++ show (configAddrType def == AddressInternal)
+    , Option "k" ["pubkeys"]
+        (NoArg $ \cfg -> cfg { configDisplayPubKeys = True }) $
+        "Display public keys instead of addresses. Default: "
+            ++ show (configDisplayPubKeys def)
     , Option "o" ["offline"]
         (NoArg $ \cfg -> cfg { configOffline = True }) $
         "Offline balance. Default: " ++ show (configOffline def)
@@ -190,12 +194,11 @@ dispatchCommand cfg args = flip R.runReaderT cfg $ case args of
     "accounts"    : page                       -> cmdAccounts page
     "rename"      : name : new            : [] -> cmdRenameAcc name new
     "list"        : name : page                -> cmdList name page
-    "pubkeys"     : name : page                -> cmdPubKeys name page
     "unused"      : name : page                -> cmdUnused name page
     "label"       : name : index : label  : [] -> cmdLabel name index label
     "txs"         : name : page                -> cmdTxs name page
     "addrtxs"     : name : index : page        -> cmdAddrTxs name index page
-    "getindex"    : name : key            : [] -> cmdKeyIndex name key
+    "getindex"    : name : key            : [] -> cmdGetIndex name key
     "genaddrs"    : name : i              : [] -> cmdGenAddrs name i
     "send"        : name : add : amnt     : [] -> cmdSend name add amnt
     "sendmany"    : name : xs                  -> cmdSendMany name xs

--- a/haskoin-wallet/Network/Haskoin/Wallet/Server/Handler.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Server/Handler.hs
@@ -269,10 +269,8 @@ getIndexR name key addrType = do
     addrLst <- runDB $ do
         accE <- getAccount name
         lookupByPubKey accE key addrType
-    let hello = map (`toJsonAddr` Nothing) addrLst
-    liftIO $ putStrLn $ show hello
-    liftIO $ print $ toJSON $ hello
-    return $ Just $ toJSON $ hello
+    -- TODO: We don't return the balance for now. Maybe add it? Or not?
+    return $ Just $ toJSON $ map (`toJsonAddr` Nothing) addrLst
 
 putAddressR :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
             => AccountName
@@ -575,11 +573,17 @@ getBlockInfoR :: (MonadThrow m, MonadLoggerIO m, MonadBaseControl IO m)
               => [BlockHash]
               -> Handler m (Maybe Value)
 getBlockInfoR headerLst = do
+    $(logInfo) $ format "Received GetBlockInfoR request"
     lstMaybeBlk <- forM headerLst (runNode . runSqlNodeT . getBlockByHash)
     return $ toJSON <$> Just (handleRes lstMaybeBlk)
   where
     handleRes :: [Maybe NodeBlock] -> [BlockInfo]
     handleRes = map fromNodeBlock . catMaybes
+
+postStopServerR :: MonadLoggerIO m => Handler m (Maybe Value)
+postStopServerR = do
+    $(logInfo) $ format "Received StopServerR request"
+    return Nothing
 
 {- Helpers -}
 

--- a/haskoin-wallet/Network/Haskoin/Wallet/Settings.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Settings.hs
@@ -42,65 +42,67 @@ data OutputFormat
     | OutputYAML
 
 data Config = Config
-    { configCount         :: !Word32
+    { configCount          :: !Word32
     -- ^ Output size of commands
-    , configMinConf       :: !Word32
+    , configMinConf        :: !Word32
     -- ^ Minimum number of confirmations
-    , configSignTx        :: !Bool
+    , configSignTx         :: !Bool
     -- ^ Sign transactions
-    , configFee           :: !Word64
+    , configFee            :: !Word64
     -- ^ Fee to pay per 1000 bytes when creating new transactions
-    , configRcptFee       :: !Bool
+    , configRcptFee        :: !Bool
     -- ^ Recipient pays fee (dangerous, no config file setting)
-    , configAddrType      :: !AddressType
+    , configAddrType       :: !AddressType
     -- ^ Return internal instead of external addresses
-    , configOffline       :: !Bool
+    , configDisplayPubKeys :: !Bool
+    -- ^ Display public keys instead of addresses
+    , configOffline        :: !Bool
     -- ^ Display the balance including offline transactions
-    , configReversePaging :: !Bool
+    , configReversePaging  :: !Bool
     -- ^ Use reverse paging for displaying addresses and transactions
-    , configPath          :: !(Maybe HardPath)
+    , configPath           :: !(Maybe HardPath)
     -- ^ Derivation path when creating account
-    , configFormat        :: !OutputFormat
+    , configFormat         :: !OutputFormat
     -- ^ How to format the command-line results
-    , configConnect       :: !String
+    , configConnect        :: !String
     -- ^ ZeroMQ socket to connect to (location of the server)
-    , configConnectNotif  :: !String
+    , configConnectNotif   :: !String
     -- ^ ZeroMQ socket to connect for notifications
-    , configDetach        :: !Bool
+    , configDetach         :: !Bool
     -- ^ Detach server when launched from command-line
-    , configFile          :: !FilePath
+    , configFile           :: !FilePath
     -- ^ Configuration file
-    , configTestnet       :: !Bool
+    , configTestnet        :: !Bool
     -- ^ Use Testnet3 network
-    , configDir           :: !FilePath
+    , configDir            :: !FilePath
     -- ^ Working directory
-    , configBind          :: !String
+    , configBind           :: !String
     -- ^ Bind address for the ZeroMQ socket
-    , configBindNotif     :: !String
+    , configBindNotif      :: !String
     -- ^ Bind address for ZeroMQ notifications
-    , configBTCNodes      :: !(HashMap Text [BTCNode])
+    , configBTCNodes       :: !(HashMap Text [BTCNode])
     -- ^ Trusted Bitcoin full nodes to connect to
-    , configMode          :: !SPVMode
+    , configMode           :: !SPVMode
     -- ^ Operation mode of the SPV node.
-    , configBloomFP       :: !Double
+    , configBloomFP        :: !Double
     -- ^ False positive rate for the bloom filter.
-    , configDatabase      :: !(HashMap Text DatabaseConfType)
+    , configDatabase       :: !(HashMap Text DatabaseConfType)
     -- ^ Database configuration
-    , configLogFile       :: !FilePath
+    , configLogFile        :: !FilePath
     -- ^ Log file
-    , configPidFile       :: !FilePath
+    , configPidFile        :: !FilePath
     -- ^ PID File
-    , configLogLevel      :: !LogLevel
+    , configLogLevel       :: !LogLevel
     -- ^ Log level
-    , configVerbose       :: !Bool
+    , configVerbose        :: !Bool
     -- ^ Verbose
-    , configServerKey     :: !(Maybe (Restricted Div5 ByteString))
+    , configServerKey      :: !(Maybe (Restricted Div5 ByteString))
     -- ^ Server key for authentication and encryption (server config)
-    , configServerKeyPub  :: !(Maybe (Restricted Div5 ByteString))
+    , configServerKeyPub   :: !(Maybe (Restricted Div5 ByteString))
     -- ^ Server public key for authentication and encryption (client config)
-    , configClientKey     :: !(Maybe (Restricted Div5 ByteString))
+    , configClientKey      :: !(Maybe (Restricted Div5 ByteString))
     -- ^ Client key for authentication and encryption (client config)
-    , configClientKeyPub  :: !(Maybe (Restricted Div5 ByteString))
+    , configClientKeyPub   :: !(Maybe (Restricted Div5 ByteString))
     -- ^ Client public key for authentication and encryption
     -- (client + server config)
     }
@@ -158,6 +160,7 @@ instance FromJSON Config where
         configSignTx                <- o .: "sign-transactions"
         configFee                   <- o .: "transaction-fee"
         configAddrType              <- o .: "address-type"
+        configDisplayPubKeys        <- o .: "display-pubkeys"
         configOffline               <- o .: "offline"
         configReversePaging         <- o .: "reverse-paging"
         configFormat                <- o .: "display-format"

--- a/haskoin-wallet/config/config.yml
+++ b/haskoin-wallet/config/config.yml
@@ -66,6 +66,9 @@ output-size: 10
 # Type of addresses to display. Example: external, internal
 address-type: external
 
+# Displaz public keys instead of addresses in relevant commands
+display-pubkeys: false
+
 # Use reverse paging for diplaying addresses and txs when set to True.
 reverse-paging: false
 
@@ -103,9 +106,6 @@ verbose: false
 
 # Recipient pays transaction fee. DANGEROUS.
 recipient-fee: false
-
-# Configuration file name. Only set at compile time.
-config-file: config.yml
 
 # Server key for authentication and encryption (server config).
 server-key:

--- a/haskoin-wallet/config/help
+++ b/haskoin-wallet/config/help
@@ -16,7 +16,6 @@ Account commands:
 
 Address commands:
   list      acc [page] [-c pagesize] [-r]  Display addresses by page
-  pubkeys   acc [page] [-c pagesize] [-r]  Display address public keys
   unused    acc [page] [-c pagesize] [-r]  Display unused addresses
   label     acc index label                Set the label of an address
   addrtxs   acc index [page] [-c pagesize] Display txs related to an address

--- a/haskoin-wallet/examples/embedded-inproc-wallet-server/Main.hs
+++ b/haskoin-wallet/examples/embedded-inproc-wallet-server/Main.hs
@@ -120,64 +120,66 @@ btcNodes =
 
 walletServerConf :: Config
 walletServerConf = Config
-    { configCount         = 100
+    { configCount          = 100
     -- ^ Output size of commands
-    , configMinConf       = 6
+    , configMinConf        = 6
     -- ^ Minimum number of confirmations
-    , configSignTx        = True
+    , configSignTx         = True
     -- ^ Sign transactions
-    , configFee           = 50000
+    , configFee            = 50000
     -- ^ Fee to pay per 1000 bytes when creating new transactions
-    , configRcptFee       = False
+    , configRcptFee        = False
     -- ^ Recipient pays fee (dangerous, no config file setting)
-    , configAddrType      = AddressExternal
+    , configAddrType       = AddressExternal
     -- ^ Return internal instead of external addresses
-    , configOffline       = False
+    , configDisplayPubKeys = False
+    -- ^ Display public keys instead of addresses
+    , configOffline        = False
     -- ^ Display the balance including offline transactions
-    , configReversePaging = False
+    , configReversePaging  = False
     -- ^ Use reverse paging for displaying addresses and transactions
-    , configPath          = Nothing
+    , configPath           = Nothing
     -- ^ Derivation path when creating account
-    , configFormat        = OutputNormal
+    , configFormat         = OutputNormal
     -- ^ How to format the command-line results
-    , configConnect       = cmdSocket
+    , configConnect        = cmdSocket
     -- ^ ZeroMQ socket to connect to (location of the server)
-    , configConnectNotif  = notifSocket
+    , configConnectNotif   = notifSocket
     -- ^ ZeroMQ socket to connect for notifications
-    , configDetach        = False
+    , configDetach         = False
     -- ^ Detach server when launched from command-line
-    , configFile          = ""
+    , configFile           = ""
     -- ^ Configuration file
-    , configTestnet       = False
+    , configTestnet        = False
     -- ^ Use Testnet3 network
-    , configDir           = ""
+    , configDir            = ""
     -- ^ Working directory
-    , configBind          = cmdSocket
+    , configBind           = cmdSocket
     -- ^ Bind address for the ZeroMQ socket
-    , configBindNotif     = notifSocket
+    , configBindNotif      = notifSocket
     -- ^ Bind address for ZeroMQ notifications
-    , configBTCNodes      = HM.fromList [ ( "prodnet", btcNodes ) ]
+    , configBTCNodes       = HM.fromList [ ( "prodnet", btcNodes ) ]
     -- ^ Trusted Bitcoin full nodes to connect to
-    , configMode          = SPVOnline
+    , configMode           = SPVOnline
     -- ^ Operation mode of the SPV node.
-    , configBloomFP       = 0.00001
+    , configBloomFP        = 0.00001
     -- ^ False positive rate for the bloom filter.
-    , configDatabase      = HM.fromList [ ( "prodnet", databaseConf ) ]
+    , configDatabase       = HM.fromList [ ( "prodnet", databaseConf ) ]
     -- ^ Database configuration
-    , configLogFile       = ""
+    , configLogFile        = ""
     -- ^ Log file
-    , configPidFile       = ""
+    , configPidFile        = ""
     -- ^ PID File
-    , configLogLevel      = Log.LevelInfo
+    , configLogLevel       = Log.LevelInfo
     -- ^ Log level
-    , configVerbose       = True
+    , configVerbose        = True
     -- ^ Verbose
-    , configServerKey     = Nothing
+    , configServerKey      = Nothing
     -- ^ Server key for authentication and encryption (server config)
-    , configServerKeyPub  = Nothing
+    , configServerKeyPub   = Nothing
     -- ^ Server public key for authentication and encryption (client config)
-    , configClientKey     = Nothing
+    , configClientKey      = Nothing
     -- ^ Client key for authentication and encryption (client config)
-    , configClientKeyPub  = Nothing
+    , configClientKeyPub   = Nothing
     -- ^ Client public key for authentication and encryption
     }


### PR DESCRIPTION
At the command line, public keys can now be requested instead of
addresses (for relevant commands) by using the -k or --pubkeys option.
This generalizes the previous pubkeys command which has now been
removed.

This commit also includes a bit of cleanup and style changes in the
wallet code.