### PR TITLE
Generate a bip-39 mnemonic using dice

### DIFF
--- a/haskoin-core/Network/Haskoin/Crypto/Base58.hs
+++ b/haskoin-core/Network/Haskoin/Crypto/Base58.hs
@@ -47,10 +47,10 @@ decodeBase58I s =
         Just (r,[]) -> Just r
         _           -> Nothing
   where
-    p = isJust . b58'
-    f = fromMaybe e . b58'
+    p  = isJust . b58'
+    f  = fromMaybe e . b58'
     go = listToMaybe $ readInt 58 p f (cs s)
-    e = error "Could not decode base58"
+    e  = error "Could not decode base58"
 
 -- | Encode a 'ByteString' to a base 58 representation.
 encodeBase58 :: ByteString -> ByteString
@@ -68,7 +68,7 @@ decodeBase58 :: ByteString -> Maybe ByteString
 decodeBase58 t =
     BS.append prefix <$> r
   where
-    (z, b)  = BS.span (== BS.index b58Data 0) t
+    (z, b) = BS.span (== BS.index b58Data 0) t
     prefix = BS.replicate (BS.length z) 0 -- preserve leading 1's
     r | BS.null b = Just BS.empty
       | otherwise = integerToBS <$> decodeBase58I b

--- a/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
@@ -223,6 +223,7 @@ dispatchCommand cfg args = flip R.runReaderT cfg $ case args of
     "dead"        : name : page                -> cmdDead name page
     "monitor"     : name                       -> cmdMonitor name
     "decodetx"                            : [] -> cmdDecodeTx
+    "dice"        : rolls                 : [] -> cmdDice rolls
     "status"                              : [] -> cmdStatus
     "keypair"                             : [] -> cmdKeyPair
     "blockinfo"   : hashes                     -> cmdBlockInfo hashes

--- a/haskoin-wallet/config/help
+++ b/haskoin-wallet/config/help
@@ -41,10 +41,11 @@ Offline tx signing commands:
 
 Utility commands:
   decodetx                                 Decode HEX transaction
-  rescan   [timestamp]                     Rescan the wallet
+  rescan    [timestamp]                    Rescan the wallet
   keypair                                  Get curve key pair for ØMQ auth
-  monitor [account]                        Monitor events (no account: blocks)
+  monitor   [account]                      Monitor events (no account: blocks)
   blockinfo [hash1] [hash2] [...]          Get block header information by hash
+  dice      dicerolls                      Mnemonic from 99 dice rolls
 
 Other commands:
   version                                  Display version information


### PR DESCRIPTION
This patch adds the "dice" utility command to hw. It is a client side
command that will transform a string of 6 sided dice rolls to a bip-39
mnemonic. You have to call the command as so:

hw dice 123456.....

The command will currently only convert 99 dice rolls (255.9 bits of
entropy) to a 24 word mnemonic.