### PR TITLE
Mix dice entropy with system entropy using xor

### DIFF
--- a/haskoin-wallet/haskoin-wallet.cabal
+++ b/haskoin-wallet/haskoin-wallet.cabal
@@ -70,6 +70,7 @@ library
                  , data-default                  >= 0.5       && < 0.8
                  , directory                     >= 1.2       && < 1.4
                  , daemons                       >= 0.2       && < 0.3
+                 , entropy                       >= 0.3.7     && < 0.4
                  , exceptions                    >= 0.6       && < 0.9
                  , esqueleto                     >= 2.4       && < 2.6
                  , file-embed                    >= 0.0       && < 0.1

--- a/haskoin-wallet/tests/Network/Haskoin/Wallet/Units.hs
+++ b/haskoin-wallet/tests/Network/Haskoin/Wallet/Units.hs
@@ -8,8 +8,7 @@ import           Control.Monad                    (guard)
 import           Control.Monad.Logger             (NoLoggingT)
 import           Control.Monad.Trans              (liftIO)
 import           Control.Monad.Trans.Resource     (ResourceT)
-import qualified Data.ByteString                  as BS (ByteString, empty,
-                                                         pack, replicate)
+import qualified Data.ByteString                  as BS
 import           Data.List                        (sort)
 import           Data.Maybe                       (fromJust, isJust)
 import           Data.String.Conversions          (cs)
@@ -314,6 +313,7 @@ tests =
         , testCase "diceToEntropy" testDiceToEntropy
         , testCase "diceToMnemonic" testDiceToMnemonic
         , testCase "Invalid dice rolls" testInvalidDiceToEntropy
+        , testCase "mixEntropy" testMixEntropy
         ]
     ]
 
@@ -1631,4 +1631,28 @@ testInvalidDiceToEntropy = do
     assertEqual "Invalid dice roll digit 0"
         (Left "Could not decode base6")
         (diceToEntropy "666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666660")
+
+testMixEntropy :: Assertion
+testMixEntropy = do
+    assertEqual "Unit 1"
+        (BS.pack [0x00])
+        (mixEntropy (BS.pack [0x00]) (BS.pack [0x00]))
+    assertEqual "Unit 2"
+        (BS.pack [0xff])
+        (mixEntropy (BS.pack [0x00]) (BS.pack [0xff]))
+    assertEqual "Unit 3"
+        (BS.pack [0xff])
+        (mixEntropy (BS.pack [0xff]) (BS.pack [0x00]))
+    assertEqual "Unit 4"
+        (BS.pack [0x00])
+        (mixEntropy (BS.pack [0xff]) (BS.pack [0xff]))
+    assertEqual "Unit 5"
+        (BS.pack [0xff])
+        (mixEntropy (BS.pack [0xaa]) (BS.pack [0x55]))
+    assertEqual "Unit 6"
+        (BS.pack [0xff, 0xff])
+        (mixEntropy (BS.pack [0x55, 0xaa]) (BS.pack [0xaa, 0x55]))
+    assertEqual "Unit 7"
+        (BS.pack [0xa9, 0xda])
+        (mixEntropy (BS.pack [0x7a, 0x54]) (BS.pack [0xd3, 0x8e]))
 


### PR DESCRIPTION
The dice command line utility will now mix the 32 bytes of your 99 dice
rolls with 32 bytes of entropy generated from System.Random.getEntropy
which will use /dev/urandom on most *nix systems. Both entropy sources
are mixed using xor which is secure as long as both sources of entropy
are independant and neither is reused. Do not reuse the same dice roll
sequence to generate multiple keys.