### PR TITLE
Change wallet structure to Bip44

### DIFF
--- a/haskoin-core/Network/Haskoin/Constants.hs
+++ b/haskoin-core/Network/Haskoin/Constants.hs
@@ -31,6 +31,7 @@ module Network.Haskoin.Constants
 , targetTimespan
 , targetSpacing
 , checkpoints
+, bip44Coin
 ) where
 
 import Data.Bits (shiftR)
@@ -62,6 +63,7 @@ data Network = Network
     , getTargetTimespan             :: !Word32
     , getTargetSpacing              :: !Word32
     , getCheckpoints                :: ![(Int, BlockHash)]
+    , getBip44Coin                  :: !Word32
     } deriving (Eq, Show, Read)
 
 -- | Switch to Testnet3.  Do at start of program.
@@ -155,6 +157,10 @@ targetSpacing = getTargetSpacing getNetwork
 checkpoints :: [(Int, BlockHash)]
 checkpoints = getCheckpoints getNetwork
 
+-- | Bip44 coin derivation (m/44'/coin'/account'/internal/address/)
+bip44Coin :: Word32
+bip44Coin = getBip44Coin getNetwork
+
 prodnet :: Network
 prodnet = Network
     { getNetworkName = "prodnet"
@@ -222,6 +228,7 @@ prodnet = Network
           , "0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40"
           )
         ]
+    , getBip44Coin = 0
     }
 
 testnet3 :: Network
@@ -258,6 +265,7 @@ testnet3 = Network
           , "000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70"
           )
         ]
+    , getBip44Coin = 1
     }
 
 testnet5 :: Network
@@ -293,4 +301,5 @@ testnet5 = Network
         [ ( 10001
           , "00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8" )
         ]
+    , getBip44Coin = 1
     }

--- a/haskoin-wallet/Network/Haskoin/Wallet.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet.hs
@@ -54,6 +54,9 @@ module Network.Haskoin.Wallet
 , isMultisigAccount
 , isReadAccount
 , isCompleteAccount
+, defaultDeriv
+, rootToAccKey
+, rootToAccKeys
 
 -- *Database Addresses
 , getAddress

--- a/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
@@ -32,7 +32,6 @@ import Data.Yaml (decodeFileEither)
 import Data.String.Conversions (cs)
 
 import Network.Haskoin.Constants
-import Network.Haskoin.Crypto
 import Network.Haskoin.Wallet.Settings
 import Network.Haskoin.Wallet.Client.Commands
 import Network.Haskoin.Wallet.Types
@@ -98,24 +97,23 @@ options =
         (NoArg $ \cfg -> cfg { configOffline = True }) $
         "Offline balance. Default: " ++ show (configOffline def)
     , Option "e" ["entropy"]
-        ( ReqArg
-            (\s cfg -> cfg { configEntropy =
-                                read' "Could not parse entropy" s
-                           })
-            "INT"
+        ( ReqArg ( \s cfg -> cfg { configEntropy =
+                                       read' "Could not parse entropy" s
+                                 }
+                 ) "INT"
         ) $ "Entropy in Bytes between 16 and 32. Default: "
             ++ show (configEntropy def)
     , Option "r" ["revpage"]
         (NoArg $ \cfg -> cfg { configReversePaging = True }) $
         "Reverse paging. Default: "
             ++ show (configReversePaging def)
-    , Option "p" ["path"]
-        ( ReqArg ( \s cfg -> case parseHard s of
-                       Just p -> cfg { configPath = Just p }
-                       Nothing -> error "Could not parse derivation path"
-                 ) "PATH"
-        )
-        "Derivation path (e.g. m/44'/3')"
+    , Option "I" ["index"]
+        ( ReqArg ( \s cfg -> cfg { configDerivIndex =
+                                       read' "Could not parse index" s
+                                 }
+                 ) "INT"
+        ) $ "Derivation index for new accounts. Default: "
+            ++ show (configDerivIndex def)
     , Option "j" ["json"]
         (NoArg $ \cfg -> cfg { configFormat = OutputJSON })
         "Output JSON"

--- a/haskoin-wallet/Network/Haskoin/Wallet/Model.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Model.hs
@@ -60,7 +60,6 @@ toJsonAccount msM acc = JsonAccount
     , jsonAccountType         = accountType acc
     , jsonAccountMnemonic     = fmap cs msM
     , jsonAccountMaster       = accountMaster acc
-    , jsonAccountDerivation   = accountDerivation acc
     , jsonAccountKeys         = accountKeys acc
     , jsonAccountGap          = accountGap acc
     , jsonAccountCreated      = accountCreated acc

--- a/haskoin-wallet/Network/Haskoin/Wallet/Server.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Server.hs
@@ -223,7 +223,6 @@ initDatabase cfg = do
         _ <- runMigration migrateWallet
         _ <- runMigration migrateHeaderTree
         initWallet $ configBloomFP cfg
-    -- Return the semaphrone and the connection pool
     return pool
 
 merkleSync

--- a/haskoin-wallet/Network/Haskoin/Wallet/Settings.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Settings.hs
@@ -62,7 +62,7 @@ data Config = Config
     -- ^ Entropy in bytes to use when generating a mnemonic (between 16 and 32)
     , configReversePaging  :: !Bool
     -- ^ Use reverse paging for displaying addresses and transactions
-    , configPath           :: !(Maybe HardPath)
+    , configDerivIndex     :: !KeyIndex
     -- ^ Derivation path when creating account
     , configFormat         :: !OutputFormat
     -- ^ How to format the command-line results
@@ -154,7 +154,7 @@ instance FromJSON Config where
     parseJSON = withObject "config" $ \o' -> do
         let defValue         = either throw id $ decodeEither' configBS
             (Object o)       = mergeValues defValue (Object o')
-            configPath       = Nothing
+            configDerivIndex = 0
         configFile                  <- o .: "config-file"
         configRcptFee               <- o .: "recipient-fee"
         configCount                 <- o .: "output-size"

--- a/haskoin-wallet/Network/Haskoin/Wallet/Types.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Types.hs
@@ -201,7 +201,7 @@ data NewAccount = NewAccount
     , newAccountMnemonic :: !(Maybe Text)
     , newAccountEntropy  :: !(Maybe Word8)
     , newAccountMaster   :: !(Maybe XPrvKey)
-    , newAccountDeriv    :: !(Maybe HardPath)
+    , newAccountDeriv    :: !(Maybe KeyIndex)
     , newAccountKeys     :: ![XPubKey]
     , newAccountReadOnly :: !Bool
     }
@@ -376,7 +376,6 @@ data JsonAccount = JsonAccount
     , jsonAccountType       :: !AccountType
     , jsonAccountMaster     :: !(Maybe XPrvKey)
     , jsonAccountMnemonic   :: !(Maybe Text)
-    , jsonAccountDerivation :: !(Maybe HardPath)
     , jsonAccountKeys       :: ![XPubKey]
     , jsonAccountGap        :: !Word32
     , jsonAccountCreated    :: !UTCTime

--- a/haskoin-wallet/config/config.yml
+++ b/haskoin-wallet/config/config.yml
@@ -87,7 +87,7 @@ minimum-confirmations: 0
 offline: false
 
 # Entropy in bytes to use when generating a mnemonic (between 16 and 32)
-seed-entropy: 20
+seed-entropy: 16
 
 # How command-line output should be displayed. Supported values are:
 # normal, json or yaml.

--- a/haskoin-wallet/config/help
+++ b/haskoin-wallet/config/help
@@ -45,7 +45,7 @@ Utility commands:
   keypair                                  Get curve key pair for ØMQ auth
   monitor   [account]                      Monitor events (no account: blocks)
   blockinfo [hash1] [hash2] [...]          Get block header information by hash
-  dice      dicerolls                      Mnemonic from 99 dice rolls
+  dice      dicerolls                      Mnemonic from 99 dice rolls (1 to 6)
 
 Other commands:
   version                                  Display version information

--- a/haskoin-wallet/config/models
+++ b/haskoin-wallet/config/models
@@ -1,7 +1,6 @@
 Account
     name Text maxlen=200
     type AccountType maxlen=64
-    derivation HardPath Maybe maxlen=200
     master XPrvKey Maybe
     keys [XPubKey]
     gap Word32

--- a/haskoin-wallet/examples/embedded-inproc-wallet-server/Main.hs
+++ b/haskoin-wallet/examples/embedded-inproc-wallet-server/Main.hs
@@ -140,7 +140,7 @@ walletServerConf = Config
     -- ^ Entropy in bytes to use when generating a mnemonic (between 16 and 32)
     , configReversePaging  = False
     -- ^ Use reverse paging for displaying addresses and transactions
-    , configPath           = Nothing
+    , configDerivIndex     = 0
     -- ^ Derivation path when creating account
     , configFormat         = OutputNormal
     -- ^ How to format the command-line results

--- a/haskoin-wallet/tests/Network/Haskoin/Wallet/Units.hs
+++ b/haskoin-wallet/tests/Network/Haskoin/Wallet/Units.hs
@@ -33,6 +33,13 @@ import           Network.Haskoin.Util
 
 type App = SqlPersistT (NoLoggingT (ResourceT IO))
 
+xPrv1 :: XPrvKey
+xPrv1 = "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+
+-- Bip44 account derivation 0 of xPrv1
+xPub1 :: XPubKey
+xPub1 = "xpub6CsAAZAfnTnNFdmJu6St12N1vHHCPpG8uunWsTwc5PPnB4tk4k99mrgGoRBbt48SarGnLJZf5uwqGBtaBnQzVBtoA6aqtZAsx1xYvFCXM6H"
+
 -- TODO: Add tests for accounts with no private key
 tests :: [Test]
 tests =
@@ -44,11 +51,9 @@ tests =
                     { newAccountName = "fail-this"
                     , newAccountType = AccountRegular
                     -- This key does not correspond to the one below
-                    , newAccountMaster = Just
-                        "xprv9s21ZrQH143K33Ezpb81k5upGyhrVcwgqNzHRHnQ2kGBPHkJ3sLPjGwj4LML1kr1bLfguJiY21XrYfVrL1CGurfVoMKSPwRdmzt1LwBtVyR"
-                    , newAccountDeriv = Nothing
-                    , newAccountKeys =
-                        ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                    , newAccountMaster = Just "xprv9s21ZrQH143K33Ezpb81k5upGyhrVcwgqNzHRHnQ2kGBPHkJ3sLPjGwj4LML1kr1bLfguJiY21XrYfVrL1CGurfVoMKSPwRdmzt1LwBtVyR"
+                    , newAccountDeriv = Just 0
+                    , newAccountKeys = [xPub1]
                     , newAccountMnemonic = Nothing
                     , newAccountReadOnly = False
                     , newAccountEntropy  = Nothing
@@ -61,11 +66,9 @@ tests =
                     _ <- newAccount NewAccount
                         { newAccountName = "main"
                         , newAccountType = AccountRegular
-                        , newAccountMaster = Just
-                            "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
-                        , newAccountDeriv = Nothing
-                        , newAccountKeys =
-                            ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                        , newAccountMaster = Just xPrv1
+                        , newAccountDeriv = Just 0
+                        , newAccountKeys = [xPub1]
                         , newAccountMnemonic = Nothing
                         , newAccountReadOnly = False
                         , newAccountEntropy  = Nothing
@@ -74,9 +77,8 @@ tests =
                         { newAccountName = "main"
                         , newAccountType = AccountRegular
                         , newAccountMaster = Nothing
-                        , newAccountDeriv = Nothing
-                        , newAccountKeys =
-                            ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                        , newAccountDeriv = Just 0
+                        , newAccountKeys = [xPub1]
                         , newAccountMnemonic = Nothing
                         , newAccountReadOnly = False
                         , newAccountEntropy  = Nothing
@@ -86,11 +88,9 @@ tests =
                 newAccount NewAccount
                     { newAccountName = "multisig-0-of-1"
                     , newAccountType = AccountMultisig 0 1
-                    , newAccountMaster = Just
-                        "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+                    , newAccountMaster = Just xPrv1
                     , newAccountDeriv = Nothing
-                    , newAccountKeys =
-                        ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                    , newAccountKeys = [xPub1]
                     , newAccountMnemonic = Nothing
                     , newAccountReadOnly = False
                     , newAccountEntropy  = Nothing
@@ -101,11 +101,9 @@ tests =
                 newAccount NewAccount
                     { newAccountName = "multisig-2-of-1"
                     , newAccountType = AccountMultisig 2 1
-                    , newAccountMaster = Just
-                        "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+                    , newAccountMaster = Just xPrv1
                     , newAccountDeriv = Nothing
-                    , newAccountKeys =
-                        ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                    , newAccountKeys = [xPub1]
                     , newAccountMnemonic = Nothing
                     , newAccountReadOnly = False
                     , newAccountEntropy  = Nothing
@@ -116,11 +114,9 @@ tests =
                 newAccount NewAccount
                     { newAccountName = "multisig-15-of-16"
                     , newAccountType = AccountMultisig 15 16
-                    , newAccountMaster = Just
-                        "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+                    , newAccountMaster = Just xPrv1
                     , newAccountDeriv = Nothing
-                    , newAccountKeys =
-                        ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                    , newAccountKeys = [xPub1]
                     , newAccountMnemonic = Nothing
                     , newAccountReadOnly = False
                     , newAccountEntropy  = Nothing
@@ -131,11 +127,10 @@ tests =
                 newAccount NewAccount
                     { newAccountName = "multisig-1-of-2-with-3"
                     , newAccountType = AccountMultisig 1 2
-                    , newAccountMaster = Just
-                        "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+                    , newAccountMaster = Just xPrv1
                     , newAccountDeriv = Nothing
                     , newAccountKeys =
-                        [ "xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"
+                        [ xPub1
                         , "xpub661MyMwAqRbcFEPH5Aon6F7edspeu1v6a1Nw5qJgk1aX5XYg1ktBL9Azra2CKaAJ2bHXEXkeKHE3eFaCJktFiA5tSMDQDs6bi83maQtdYby"
                         , "xpub661MyMwAqRbcFtDszBWpawpg4KbNWL9qD4VdRwjd1L5cmcS8nXHWXpg9WL1Xc9Yh7HbQBwWDw37YJfc4AF3YEpvAHEBPBFQPFkUcFHnopw8"
                         ]
@@ -150,11 +145,9 @@ tests =
                     res <- newAccount NewAccount
                         { newAccountName = "multisig-1-of-2-plus-empty"
                         , newAccountType = AccountMultisig 1 2
-                        , newAccountMaster = Just
-                            "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+                        , newAccountMaster = Just xPrv1
                         , newAccountDeriv = Nothing
-                        , newAccountKeys =
-                            ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                        , newAccountKeys = [xPub1]
                         , newAccountMnemonic = Nothing
                         , newAccountReadOnly = False
                         , newAccountEntropy  = Nothing
@@ -167,11 +160,9 @@ tests =
                     res <- newAccount NewAccount
                         { newAccountName = "regular-plus-more"
                         , newAccountType = AccountRegular
-                        , newAccountMaster = Just
-                            "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+                        , newAccountMaster = Just xPrv1
                         , newAccountDeriv = Nothing
-                        , newAccountKeys =
-                            ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                        , newAccountKeys = [xPub1]
                         , newAccountMnemonic = Nothing
                         , newAccountReadOnly = False
                         , newAccountEntropy  = Nothing
@@ -185,11 +176,10 @@ tests =
                     res <- newAccount NewAccount
                         { newAccountName = "regular-plus-more"
                         , newAccountType = AccountMultisig 1 2
-                        , newAccountMaster = Just
-                            "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+                        , newAccountMaster = Just xPrv1
                         , newAccountDeriv = Nothing
                         , newAccountKeys =
-                            [ "xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"
+                            [ xPub1
                             , "xpub661MyMwAqRbcFEPH5Aon6F7edspeu1v6a1Nw5qJgk1aX5XYg1ktBL9Azra2CKaAJ2bHXEXkeKHE3eFaCJktFiA5tSMDQDs6bi83maQtdYby"
                             ]
                         , newAccountMnemonic = Nothing
@@ -211,11 +201,9 @@ tests =
                 res <- newAccount NewAccount
                     { newAccountName = "reduce-gap"
                     , newAccountType = AccountRegular
-                    , newAccountMaster = Just
-                        "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+                    , newAccountMaster = Just xPrv1
                     , newAccountDeriv = Nothing
-                    , newAccountKeys =
-                        ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                    , newAccountKeys = [xPub1]
                     , newAccountMnemonic = Nothing
                     , newAccountReadOnly = False
                     , newAccountEntropy  = Nothing
@@ -228,11 +216,9 @@ tests =
                 res <- newAccount NewAccount
                     { newAccountName = "label-hidden"
                     , newAccountType = AccountRegular
-                    , newAccountMaster = Just
-                        "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+                    , newAccountMaster = Just xPrv1
                     , newAccountDeriv = Nothing
-                    , newAccountKeys =
-                        ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                    , newAccountKeys = [xPub1]
                     , newAccountMnemonic = Nothing
                     , newAccountReadOnly = False
                     , newAccountEntropy  = Nothing
@@ -244,11 +230,9 @@ tests =
                 res <- newAccount NewAccount
                     { newAccountName = "label-invalid"
                     , newAccountType = AccountRegular
-                    , newAccountMaster = Just
-                        "xprv9s21ZrQH143K4a5123LatJaWPdyMvCG4Phpb79kLUXNF3Y9U537QUeKzUjkrdoZVVse747ZnNNUGryPZXEoMFjkuUKyWpEMcg7jbxYECE2b"
+                    , newAccountMaster = Just xPrv1
                     , newAccountDeriv = Nothing
-                    , newAccountKeys =
-                        ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                    , newAccountKeys = [xPub1]
                     , newAccountMnemonic = Nothing
                     , newAccountReadOnly = False
                     , newAccountEntropy  = Nothing
@@ -263,8 +247,7 @@ tests =
                         , newAccountType = AccountRegular
                         , newAccountMaster = Nothing
                         , newAccountDeriv = Nothing
-                        , newAccountKeys =
-                            ["xpub661MyMwAqRbcH49U84sbFSXEwforKeyukvkBuY9x2ruDvLUccaRf2SeUL1f6StQke7sCuvott5CjzFqw6aA49g2NSjaARBkQdHE18zjC5hB"]
+                        , newAccountKeys = [xPub1]
                         , newAccountMnemonic = Nothing
                         , newAccountReadOnly = False
                         , newAccountEntropy  = Nothing
@@ -307,6 +290,7 @@ tests =
         , testCase "Delete Tx" $ runUnit testDeleteTx
         , testCase "Delete Unsigned Tx" $ runUnit testDeleteUnsignedTx
         , testCase "Notifications" $ runUnit testNotification
+        , testCase "RootToAccKey" $ testRootToAccKey
         ]
     , testGroup "Dice conversion tests"
         [ testCase "Base 6 to Base 16" testDecodeBase6
@@ -385,7 +369,7 @@ testDerivations = do
     accE <- fst <$> newAccount NewAccount
         { newAccountName = "acc1"
         , newAccountType = AccountRegular
-        , newAccountDeriv = Just (Deriv :| 0)
+        , newAccountDeriv = Just 0
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
         , newAccountKeys = []
@@ -393,34 +377,19 @@ testDerivations = do
         , newAccountEntropy  = Nothing
         }
 
-    unusedAddresses accE AddressExternal (ListRequest 0 0 False)
+    unusedAddresses accE AddressExternal (ListRequest 0 3 False)
         >>= liftIO . assertEqual "Generated external addresses do not match"
-            [ "1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe"
-            , "1NrcKe9UNtxjjgMSLdhBYaEgrQWQFnvJXX"
-            , "123XgHRNxkprjec72EpxBFPytPim21u9Kc"
-            , "16AuD3mAQMzsUHkMGfkQQapG6jhHmV3Rys"
-            , "1AjF1GhsxyXCN5doPGLjSztDcuLbfYMkqw"
-            , "1LPUYEjUd1u9dgjM3RqnoYj7Zt4j4dmZYA"
-            , "1Kzyb5Fpj2VmMoCNWxLNMYeMSu5ocS7u7e"
-            , "131L3UXV6WakXpyXvmqzqNkHwWJzWExR9i"
-            , "19FWGTZERHzMePTqKoR8nB9y6w7S5u9yGr"
-            , "135dwGc8JG2dmhy79onerHKdqoqibHShRJ"
+            [ "1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in"
+            , "1Cf66C6MVTYgMSuXrpn5W1x12RRtAa6v2x"
+            , "1Guyp96E7ph4PQJoPpz1DLsash8pqjEdVN"
             ] . map (addrToBase58 . walletAddrAddress) . fst
 
-    unusedAddresses accE AddressInternal (ListRequest 0 0 False)
+    unusedAddresses accE AddressInternal (ListRequest 0 3 False)
         >>= liftIO . assertEqual "Generated internal addresses do not match"
-            [ "1PY7pWZ5FddWi747C6k5Y7okNHFUM2BKAm"
-            , "1JVocGcqZvQFbfpeQUY92iL9ARLsAP4DjW"
-            , "15yaPowqF2g9B3xbdyXaPygV9bfXFjYj2X"
-            , "187xp9nQTsCa7QJLHYSMyaM1Mf5u2knJYY"
-            , "1QDQwk4d4zVWH3TnUHMCvDvvrTqFSaA3hr"
-            , "17ATGqWhkXYLxPdynWrFjnJBvD3EYxqC5A"
-            , "1EHgPV5DEs3GwUSaRQD7hd2m5MkR4hdByb"
-            , "1EvUYGoC7p7GC8BtYTz4RX2ERxjUsT3zLz"
-            , "15857PJZQxUH8Jgomv83mYqJqDsVEUZwz1"
-            , "18L5fQjr5yXdqqnK98v2UQi1WHAXfYHr7L"
+            [ "1JGvK2MYQ3wwxMdYeyf7Eg1HeVJuEq3AT1"
+            , "1JMTxp3kbXtwHwFMNPCUc2QyjQNQ8ZZxc4"
+            , "19mTjNo7m7eRVULZ47PzYvnbdXGHGnKXKi"
             ] . map (addrToBase58 . walletAddrAddress) . fst
-
 
 assertBalance :: AccountId -> Word32 -> Word64 -> App ()
 assertBalance ai conf b = do
@@ -476,7 +445,7 @@ testBalances = do
     accE@(Entity ai _) <- fst <$> newAccount NewAccount
         { newAccountName = "acc1"
         , newAccountType = AccountRegular
-        , newAccountDeriv = Just (Deriv :| 0)
+        , newAccountDeriv = Just 0
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
         , newAccountKeys = []
@@ -485,8 +454,8 @@ testBalances = do
         }
     let fundingTx = fakeTx
             [ (tid1, 0) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 10000000)
-            , ("1NrcKe9UNtxjjgMSLdhBYaEgrQWQFnvJXX", 20000000)
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 10000000)
+            , ("1Cf66C6MVTYgMSuXrpn5W1x12RRtAa6v2x", 20000000)
             ]
     let tx1 = fakeTx
             [ (txHash fundingTx, 0)
@@ -496,7 +465,7 @@ testBalances = do
         tx2 = fakeTx
             [ (txHash fundingTx, 0) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 5000000) -- external
-            , ("1PY7pWZ5FddWi747C6k5Y7okNHFUM2BKAm", 5000000) -- change
+            , ("1JGvK2MYQ3wwxMdYeyf7Eg1HeVJuEq3AT1", 5000000) -- change
             ]
 
     assertBalance ai 0 0
@@ -695,7 +664,7 @@ testConflictBalances = do
     accE@(Entity ai _) <- fst <$> newAccount NewAccount
         { newAccountName = "acc1"
         , newAccountType = AccountRegular
-        , newAccountDeriv = Just (Deriv :| 0)
+        , newAccountDeriv = Just 0
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
         , newAccountKeys = []
@@ -704,18 +673,18 @@ testConflictBalances = do
         }
     let tx1 = fakeTx
             [ (tid1, 4) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 10000000) ]
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 10000000) ]
         tx2 = fakeTx
             [ (txHash tx1, 0) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 6000000) -- external
-            , ("1PY7pWZ5FddWi747C6k5Y7okNHFUM2BKAm", 4000000) -- change
+            , ("1JGvK2MYQ3wwxMdYeyf7Eg1HeVJuEq3AT1", 4000000) -- change
             ]
         tx3 = fakeTx
             [ (txHash tx2, 1) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 4000000) ] -- external
         tx4 = fakeTx
             [ (tid1, 4) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 20000000) ]
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 20000000) ]
 
     -- Import first transaction
     assertImportTx ai 1 TxPending tx1
@@ -870,7 +839,7 @@ testOffline = do
     accE@(Entity ai _) <- fst <$> newAccount NewAccount
         { newAccountName = "acc1"
         , newAccountType = AccountRegular
-        , newAccountDeriv = Just (Deriv :| 0)
+        , newAccountDeriv = Just 0
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
         , newAccountKeys = []
@@ -879,18 +848,18 @@ testOffline = do
         }
     let tx1 = fakeTx
             [ (tid1, 4) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 10000000) ]
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 10000000) ]
         tx2 = fakeTx
             [ (txHash tx1, 0) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 6000000) -- external
-            , ("1PY7pWZ5FddWi747C6k5Y7okNHFUM2BKAm", 4000000) -- change
+            , ("1JGvK2MYQ3wwxMdYeyf7Eg1HeVJuEq3AT1", 4000000) -- change
             ]
         tx3 = fakeTx
             [ (txHash tx2, 1) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 4000000) ] -- external
         tx4 = fakeTx
             [ (tid1, 4) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 20000000) ]
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 20000000) ]
 
     -- Import first transaction
     assertImportTxOffline ai 1 TxOffline tx1
@@ -965,7 +934,7 @@ testKillOffline = do
     accE@(Entity ai _) <- fst <$> newAccount NewAccount
         { newAccountName = "acc1"
         , newAccountType = AccountRegular
-        , newAccountDeriv = Just (Deriv :| 0)
+        , newAccountDeriv = Just 0
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
         , newAccountKeys = []
@@ -974,11 +943,11 @@ testKillOffline = do
         }
     let tx1 = fakeTx
             [ (tid1, 4) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 10000000) ]
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 10000000) ]
         tx2 = fakeTx
             [ (txHash tx1, 0) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 6000000) -- external
-            , ("1PY7pWZ5FddWi747C6k5Y7okNHFUM2BKAm", 4000000) -- change
+            , ("1JGvK2MYQ3wwxMdYeyf7Eg1HeVJuEq3AT1", 4000000) -- change
             ]
         tx3 = fakeTx
             [ (txHash tx2, 1) ]
@@ -986,8 +955,8 @@ testKillOffline = do
         tx4 = fakeTx
             [ (txHash tx1, 0) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 2000000) -- external
-            , ("1PY7pWZ5FddWi747C6k5Y7okNHFUM2BKAm", 3000000) -- change
-            , ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 5000000) -- more change
+            , ("1JGvK2MYQ3wwxMdYeyf7Eg1HeVJuEq3AT1", 3000000) -- change
+            , ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 5000000) -- more change
             ]
 
     -- Import tx1 as a network transaction
@@ -1058,24 +1027,24 @@ testOfflineExceptions :: Assertion
 testOfflineExceptions = do
     let tx1 = fakeTx
             [ (tid1, 4) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 10000000) ]
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 10000000) ]
         tx2 = fakeTx
             [ (txHash tx1, 0) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 6000000) -- external
-            , ("1PY7pWZ5FddWi747C6k5Y7okNHFUM2BKAm", 4000000) -- change
+            , ("1JGvK2MYQ3wwxMdYeyf7Eg1HeVJuEq3AT1", 4000000) -- change
             ]
         tx3 = fakeTx
             [ (txHash tx2, 1) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 4000000) ] -- external
         tx4 = fakeTx
             [ (tid1, 4) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 20000000) ]
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 20000000) ]
 
     assertException (WalletException "Could not import offline transaction") $ do
         _ <- newAccount NewAccount
             { newAccountName = "acc1"
             , newAccountType = AccountRegular
-            , newAccountDeriv = Just (Deriv :| 0)
+            , newAccountDeriv = Just 0
             , newAccountMaster = Nothing
             , newAccountMnemonic = Just (cs ms)
             , newAccountKeys = []
@@ -1090,7 +1059,7 @@ testOfflineExceptions = do
         _ <- newAccount NewAccount
             { newAccountName = "acc1"
             , newAccountType = AccountRegular
-            , newAccountDeriv = Just (Deriv :| 0)
+            , newAccountDeriv = Just 0
             , newAccountMaster = Nothing
             , newAccountMnemonic = Just (cs ms)
             , newAccountKeys = []
@@ -1107,7 +1076,7 @@ testOfflineExceptions = do
         _ <- newAccount NewAccount
             { newAccountName = "acc1"
             , newAccountType = AccountRegular
-            , newAccountDeriv = Just (Deriv :| 0)
+            , newAccountDeriv = Just 0
             , newAccountMaster = Nothing
             , newAccountMnemonic = Just (cs ms)
             , newAccountKeys = []
@@ -1124,20 +1093,20 @@ testImportMultisig = do
     accE1@(Entity ai1 _) <- fst <$> newAccount NewAccount
         { newAccountName = "ms1"
         , newAccountType = AccountMultisig 2 2
-        , newAccountDeriv = Just (Deriv :| 0)
+        , newAccountDeriv = Just 0
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
-        , newAccountKeys = ["xpub68kRFKHWxUt3oS8X5kVogwH5rvuAd4jrLkxVfHeudFC4MfwQ8oYV59F91uFnsLXANRB1MkN4Wa1PwymE4cRsU8PE755HNCb1EoBbSoAKXpW"]
+        , newAccountKeys = ["xpub6C5bmQQw4h4DVMVydW4bhtuz4jZpUpsrvfMYdZXVVuXyePRcDhBzXufZ5sfSZqtcnXPtDCYyAAPPkuAKEtasfRo9RatgFNP4X58zM1QjjYK"]
         , newAccountReadOnly = False
         , newAccountEntropy  = Nothing
         }
     accE2@(Entity ai2 _) <- fst <$> newAccount NewAccount
         { newAccountName = "ms2"
         , newAccountType = AccountMultisig 2 2
-        , newAccountDeriv = Just (Deriv :| 1)
+        , newAccountDeriv = Just 1
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
-        , newAccountKeys = ["xpub68kRFKHWxUt3mfJjcXdLeuDjCHnByqKSBVfMktJRXM6LSNNDR4ae6Nw1Kh621fzyKiBf6ssyZWPPTDUTQp1BhuZQuoVdtb8j2TRzqDLHmY7"]
+        , newAccountKeys = ["xpub6C5bmQQw4h4DSHbWsT7GDaU1CxcamCwTGRo81T2g9VewnEyb16eHwzojDPsZguGizLD3ttFynKPby7ABY4MQ3xAf5DNafj32uf84Gw48Phb"]
         , newAccountReadOnly = False
         , newAccountEntropy  = Nothing
         }
@@ -1146,7 +1115,7 @@ testImportMultisig = do
             [ TxIn (OutPoint tid1 0) (BS.pack [1]) maxBound ] -- dummy input
             [ TxOut 10000000 $
               encodeOutputBS $ PayScriptHash $ fromJust $
-              base58ToAddr "32RexHZdsMoV8yzL1pQyFhYY6XeUNcWP78"
+              base58ToAddr "32SupmLrYyZMSPfL4tgkuUCyvbzEyBfqxd"
             ]
             0
 
@@ -1158,7 +1127,7 @@ testImportMultisig = do
 
     -- Create a transaction which has 0 signatures in ms1
     tx1 <- fst <$> createWalletTx accE1 Nothing Nothing
-        [ ( fromJust $ base58ToAddr "3BYWaQHz6AVXx7wXmCka4846tRfa1ccWvh"
+        [ ( fromJust $ base58ToAddr "3AV9s2W9atAaChWdwTpRv8qvTHcV7L1zyj"
           , 5000000
           )
         ] 10000 0 False True
@@ -1280,7 +1249,7 @@ testDeleteTx = do
     accE@(Entity ai _) <- fst <$> newAccount NewAccount
         { newAccountName = "acc1"
         , newAccountType = AccountRegular
-        , newAccountDeriv = Just (Deriv :| 0)
+        , newAccountDeriv = Just 0
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
         , newAccountKeys = []
@@ -1289,11 +1258,11 @@ testDeleteTx = do
         }
     let tx1 = fakeTx
             [ (tid1, 4) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 10000000) ]
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 10000000) ]
         tx2 = fakeTx
             [ (txHash tx1, 0) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 6000000) -- external
-            , ("1PY7pWZ5FddWi747C6k5Y7okNHFUM2BKAm", 4000000) -- change
+            , ("1JGvK2MYQ3wwxMdYeyf7Eg1HeVJuEq3AT1", 4000000) -- change
             ]
         tx3 = fakeTx
             [ (txHash tx2, 1) ]
@@ -1333,20 +1302,20 @@ testDeleteUnsignedTx = do
     accE1@(Entity ai1 _) <- fst <$> newAccount NewAccount
         { newAccountName = "ms1"
         , newAccountType = AccountMultisig 2 2
-        , newAccountDeriv = Just (Deriv :| 0)
+        , newAccountDeriv = Just 0
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
-        , newAccountKeys = ["xpub68kRFKHWxUt3oS8X5kVogwH5rvuAd4jrLkxVfHeudFC4MfwQ8oYV59F91uFnsLXANRB1MkN4Wa1PwymE4cRsU8PE755HNCb1EoBbSoAKXpW"]
+        , newAccountKeys = ["xpub6C5bmQQw4h4DVMVydW4bhtuz4jZpUpsrvfMYdZXVVuXyePRcDhBzXufZ5sfSZqtcnXPtDCYyAAPPkuAKEtasfRo9RatgFNP4X58zM1QjjYK"]
         , newAccountReadOnly = False
         , newAccountEntropy  = Nothing
         }
     Entity ai2 _ <- fst <$> newAccount NewAccount
         { newAccountName = "ms2"
         , newAccountType = AccountMultisig 2 2
-        , newAccountDeriv = Just (Deriv :| 1)
+        , newAccountDeriv = Just 1
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
-        , newAccountKeys = ["xpub68kRFKHWxUt3mfJjcXdLeuDjCHnByqKSBVfMktJRXM6LSNNDR4ae6Nw1Kh621fzyKiBf6ssyZWPPTDUTQp1BhuZQuoVdtb8j2TRzqDLHmY7"]
+        , newAccountKeys = ["xpub6C5bmQQw4h4DSHbWsT7GDaU1CxcamCwTGRo81T2g9VewnEyb16eHwzojDPsZguGizLD3ttFynKPby7ABY4MQ3xAf5DNafj32uf84Gw48Phb"]
         , newAccountReadOnly = False
         , newAccountEntropy  = Nothing
         }
@@ -1355,7 +1324,7 @@ testDeleteUnsignedTx = do
             [ TxIn (OutPoint tid1 0) (BS.pack [1]) maxBound ] -- dummy input
             [ TxOut 10000000 $
               encodeOutputBS $ PayScriptHash $ fromJust $
-              base58ToAddr "32RexHZdsMoV8yzL1pQyFhYY6XeUNcWP78"
+              base58ToAddr "32SupmLrYyZMSPfL4tgkuUCyvbzEyBfqxd"
             ]
             0
 
@@ -1367,7 +1336,7 @@ testDeleteUnsignedTx = do
 
     -- Create a transaction which has 0 signatures in ms1
     tx1 <- fst <$> createWalletTx accE1 Nothing Nothing
-        [ ( fromJust $ base58ToAddr "3BYWaQHz6AVXx7wXmCka4846tRfa1ccWvh"
+        [ ( fromJust $ base58ToAddr "3AV9s2W9atAaChWdwTpRv8qvTHcV7L1zyj"
           , 5000000
           )
         ] 10000 0 False True
@@ -1402,7 +1371,7 @@ testNotification = do
     _ <- newAccount NewAccount
         { newAccountName = "acc1"
         , newAccountType = AccountRegular
-        , newAccountDeriv = Just (Deriv :| 0)
+        , newAccountDeriv = Just 0
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
         , newAccountKeys = []
@@ -1411,11 +1380,11 @@ testNotification = do
         }
     let tx1 = fakeTx
             [ (tid1, 4) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 10000000) ]
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 10000000) ]
         tx2 = fakeTx
             [ (txHash tx1, 0) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 6000000) -- external
-            , ("1PY7pWZ5FddWi747C6k5Y7okNHFUM2BKAm", 4000000) -- change
+            , ("1JGvK2MYQ3wwxMdYeyf7Eg1HeVJuEq3AT1", 4000000) -- change
             ]
         tx3 = fakeTx
             [ (txHash tx2, 1) ]
@@ -1501,7 +1470,7 @@ testKillTx = do
     accE@(Entity ai _) <- fst <$> newAccount NewAccount
         { newAccountName = "acc1"
         , newAccountType = AccountRegular
-        , newAccountDeriv = Just (Deriv :| 0)
+        , newAccountDeriv = Just 0
         , newAccountMaster = Nothing
         , newAccountMnemonic = Just (cs ms)
         , newAccountKeys = []
@@ -1510,11 +1479,11 @@ testKillTx = do
         }
     let tx1 = fakeTx
             [ (tid1, 4) ]
-            [ ("1DLW4wieCwUPMh6ThVwT2bKqSzkjeb8wUe", 10000000) ]
+            [ ("1BThGRupK6Ah44sfCtsg2QkoEDJA58d8in", 10000000) ]
         tx2 = fakeTx
             [ (txHash tx1, 0) ]
             [ ("1MchgrtQEUgV1f7Nqe1vEzvdmBzJHz8zrY", 6000000) -- external
-            , ("1PY7pWZ5FddWi747C6k5Y7okNHFUM2BKAm", 4000000) -- change
+            , ("1JGvK2MYQ3wwxMdYeyf7Eg1HeVJuEq3AT1", 4000000) -- change
             ]
         tx3 = fakeTx
             [ (txHash tx2, 1) ]
@@ -1655,4 +1624,25 @@ testMixEntropy = do
     assertEqual "Unit 7"
         (BS.pack [0xa9, 0xda])
         (mixEntropy (BS.pack [0x7a, 0x54]) (BS.pack [0xd3, 0x8e]))
+
+testRootToAccKey :: Assertion
+testRootToAccKey = do
+    let root = "xprv9s21ZrQH143K3rhWwd1RSvWM64Z2a5ZzT5RHZ7pPC4DikEGW9AWTLzuGfX8C117bfhargkgKSm3PTSyM74AnkLfJo8iHb4hoRmJWZ5AH1C6"
+        prv0 = "xprv9y6FMtt3EKVvDoX3mRaFrSXGevn6MkDbuCsXD4d4bA7xuSeSTZL3QCVFN7u1dGf7af1utDqwGjXSKVsPbcy4s5dVRJ4iFpQseVf4ZgHZuMP"
+        prv1 = "xprv9y6FMtt3EKVvGsRWXUXbLkyFWhjL5NA1ZSRwqB7swZzzmb6Tg9sjz7M5EavfWWBzLxSzA5AHxZswUCwV1KUxhyKefw8UBsWT34HuDisuDg7"
+        prv2 = "xprv9y6FMtt3EKVvLtvKwuA8H4AFB2Vz4o7T15y4GDJ3FjY2vxafMdDLBuCkG65HDW8nMQs3FVRr3SqMQ1X5LHsdDd6VzxuwLmPcz7SP1TafMyN"
+        acc0 = "xpub6C5bmQQw4h4DSHbWsT7GDaU1CxcamCwTGRo81T2g9VewnEyb16eHwzojDPsZguGizLD3ttFynKPby7ABY4MQ3xAf5DNafj32uf84Gw48Phb"
+        acc1 = "xpub6C5bmQQw4h4DVMVydW4bhtuz4jZpUpsrvfMYdZXVVuXyePRcDhBzXufZ5sfSZqtcnXPtDCYyAAPPkuAKEtasfRo9RatgFNP4X58zM1QjjYK"
+        acc2 = "xpub6C5bmQQw4h4DZNzo3vh8eC6yj4LUUFqJNJtf4bhep551okuouAXajhXE7QZqGNLJigrRWairbTKeKZ5LsLcSNbmzZGarY1JJcjFDi8JxFPC"
+        custom = "xprvA1kxrV2ViHBViVSwasXMsWutXtNR8N3L6w88KT7Z6FodeCVtg2qsrgnqcvLkMpoNq4tSnEuNwFaKtSTaAH2U15qipAPWpT7g1PG6ecZfED8"
+
+    assertEqual "Unit 1" prv0 $ rootToAccKey root 0
+    assertEqual "Unit 2" prv0 $ rootToAccKey prv0 0
+    assertEqual "Unit 3" custom $ rootToAccKey custom 0
+    assertEqual "Unit 4" [prv0, prv1, prv2] $
+        rootToAccKeys root [acc0, acc1, acc2]
+    assertEqual "Unit 5" [prv0] $
+        rootToAccKeys prv0 [acc0, acc1, acc2]
+    assertEqual "Unit 6" [custom] $
+        rootToAccKeys custom [acc0, acc1, acc2]
 


### PR DESCRIPTION
This patch introduces a non-backwards compatible change to the wallet
structure. Account derivations will now follow the Bip44 standard
(m/purpose'/coin'/account'/address_type/address). Specifically, Haskoin
accounts will be created under m/44'/0'/account'/ in prodnet.

It is no longer possible to specify the derivation path (--path) at the
command line to derive accounts at arbitrary depths. However, you can
specify the Bip44 account' derivation with --index.

When using a custom XPrvKey to create a new account, Haskoin will check
if the provided key is a root key (depth = 0). Haskoin will generate the
account key using the Bip44 structure for root keys. If you create
an account with an XPrvKey which is not a root key, Haskoin will use
the key as is.