### PR TITLE
Payment requests and offline signing improvements

### DIFF
--- a/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet/Client.hs
@@ -202,6 +202,7 @@ dispatchCommand cfg args = flip R.runReaderT cfg $ case args of
     "list"        : name : page                -> cmdList name page
     "unused"      : name : page                -> cmdUnused name page
     "label"       : name : index : label  : [] -> cmdLabel name index label
+    "uri"         : name : index : ls          -> cmdURI name index ls
     "txs"         : name : page                -> cmdTxs name page
     "addrtxs"     : name : index : page        -> cmdAddrTxs name index page
     "getindex"    : name : key            : [] -> cmdGetIndex name key
@@ -213,7 +214,7 @@ dispatchCommand cfg args = flip R.runReaderT cfg $ case args of
     "gettx"       : name : txid           : [] -> cmdGetTx name txid
     "balance"     : name                  : [] -> cmdBalance name
     "getoffline"  : name : txid           : [] -> cmdGetOffline name txid
-    "signoffline" : name : tx : dat       : [] -> cmdSignOffline name tx dat
+    "signoffline" : name                  : [] -> cmdSignOffline name
     "rescan"      : rescantime                 -> cmdRescan rescantime
     "deletetx"    : txid                  : [] -> cmdDeleteTx txid
     "sync"        : name : block : page        -> cmdSync name block page

--- a/haskoin-wallet/config/help
+++ b/haskoin-wallet/config/help
@@ -21,6 +21,7 @@ Address commands:
   addrtxs   acc index [page] [-c pagesize] Display txs related to an address
   getindex  acc key                        Get key index by pubkey
   genaddrs  acc index [--internal]         Generate addresses up to this index
+  uri       acc index [amount] [msg]       Create a Bitcoin payment request URI
 
 Transaction commands:
   txs       acc [page] [-c pagesize] [-r]  Display all transactions by page
@@ -37,7 +38,7 @@ Transaction commands:
 
 Offline tx signing commands:
   getoffline  acc txhash                   Get data to sign a tx offline
-  signoffline acc tx coindata              Sign a tx with offline signing data
+  signoffline acc                          Sign a tx with offline signing data
 
 Utility commands:
   decodetx                                 Decode HEX transaction

--- a/haskoin-wallet/haskoin-wallet.cabal
+++ b/haskoin-wallet/haskoin-wallet.cabal
@@ -62,6 +62,7 @@ library
     build-depends: aeson                         >= 0.7       && < 1.1
                  , aeson-pretty                  >= 0.7       && < 0.9
                  , base                          >= 4.8       && < 5
+                 , base64-bytestring             >= 1.0.0.1
                  , bytestring                    >= 0.10      && < 0.11
                  , cereal                        >= 0.5       && < 0.6
                  , containers                    >= 0.5       && < 0.6
@@ -98,6 +99,7 @@ library
                  , transformers-base             >= 0.4       && < 0.5
                  , unix                          >= 2.6       && < 2.8
                  , unordered-containers          >= 0.2       && < 0.3
+                 , uri-encode                    >= 1.5.0.5
                  , yaml                          >= 0.8       && < 0.9
                  , zeromq4-haskell               >= 0.6       && < 0.7
 


### PR DESCRIPTION
Add the uri command to the command line tool allowing users to generate
Bitcoin payment requests. The output of this command can be piped to qr
code generators like qrencode.

The getoffline command has been changed to print a base64 blob
containing the transaction and coin signing data. The signoffline
command will now read this base64 blob from stdin. The output of
getoffline can be piped into signoffline. These changes allow you to use
qr codes to pass data between these commands.