### PR TITLE
Fix dead coinbase txs in the wallet

### DIFF
--- a/haskoin-wallet/Network/Haskoin/Wallet.hs
+++ b/haskoin-wallet/Network/Haskoin/Wallet.hs
@@ -86,6 +86,7 @@ module Network.Haskoin.Wallet
 , createWalletTx
 , signOfflineTx
 , getOfflineTxData
+, isCoinbaseTx
 
 -- *Database blocks
 , importMerkles


### PR DESCRIPTION
Coinbase transactions all spend the same input (0x00..). The wallet
would mark those coinbase transactions as double spends. This patch adds
tests making sure that coinbase transactions can be imported in the
wallet without being marked as dead.