### PR TITLE
Better arbitrary instances in haskoin-core

### DIFF
--- a/haskoin-core/Network/Haskoin/Script/Parser.hs
+++ b/haskoin-core/Network/Haskoin/Script/Parser.hs
@@ -35,10 +35,10 @@ import           Data.Aeson                     (FromJSON, ToJSON,
                                                  Value (String), parseJSON,
                                                  toJSON, withText)
 import           Data.ByteString                (ByteString)
-import qualified Data.ByteString                as BS (head, singleton)
+import qualified Data.ByteString                as BS
 import           Data.Foldable                  (foldrM)
 import           Data.List                      (sortBy)
-import           Data.Serialize                 (encode, decode)
+import           Data.Serialize                 (decode, encode)
 import           Data.String.Conversions        (cs)
 import           Network.Haskoin.Crypto.Base58
 import           Network.Haskoin.Crypto.Hash
@@ -74,36 +74,36 @@ instance ToJSON ScriptOutput where
     toJSON = String . cs . encodeHex . encodeOutputBS
 
 instance NFData ScriptOutput where
-    rnf (PayPK k) = rnf k
-    rnf (PayPKHash a) = rnf a
-    rnf (PayMulSig k r) = rnf k `seq` rnf r
+    rnf (PayPK k)         = rnf k
+    rnf (PayPKHash a)     = rnf a
+    rnf (PayMulSig k r)   = rnf k `seq` rnf r
     rnf (PayScriptHash a) = rnf a
-    rnf (DataCarrier a) = rnf a
+    rnf (DataCarrier a)   = rnf a
 
 -- | Returns True if the script is a pay to public key output.
 isPayPK :: ScriptOutput -> Bool
 isPayPK (PayPK _) = True
-isPayPK _ = False
+isPayPK _         = False
 
 -- | Returns True if the script is a pay to public key hash output.
 isPayPKHash :: ScriptOutput -> Bool
 isPayPKHash (PayPKHash _) = True
-isPayPKHash _ = False
+isPayPKHash _             = False
 
 -- | Returns True if the script is a pay to multiple public keys output.
 isPayMulSig :: ScriptOutput -> Bool
 isPayMulSig (PayMulSig _ _) = True
-isPayMulSig _ = False
+isPayMulSig _               = False
 
 -- | Returns true if the script is a pay to script hash output.
 isPayScriptHash :: ScriptOutput -> Bool
 isPayScriptHash (PayScriptHash _) = True
-isPayScriptHash _ = False
+isPayScriptHash _                 = False
 
 -- | Returns True if the script is an OP_RETURN "datacarrier" output
 isDataCarrier :: ScriptOutput -> Bool
 isDataCarrier (DataCarrier _) = True
-isDataCarrier _ = False
+isDataCarrier _               = False
 
 -- | Computes a script address from a script output. This address can be used
 -- in a pay to script hash output.
@@ -189,8 +189,8 @@ matchPayMulSig (Script ops) = case splitAt (length ops - 2) ops of
     _ -> Left "matchPayMulSig: script did not match output template"
   where
     go (OP_PUSHDATA bs _:xs) = liftM2 (:) (decode bs) (go xs)
-    go [] = return []
-    go  _ = Left "matchPayMulSig: invalid multisig opcode"
+    go []                    = return []
+    go  _                    = Left "matchPayMulSig: invalid multisig opcode"
 
 -- | Transforms integers [1 .. 16] to 'ScriptOp' [OP_1 .. OP_16]
 intToScriptOp :: Int -> ScriptOp
@@ -199,24 +199,24 @@ intToScriptOp i
     | otherwise = err
   where
     op  = decode $ BS.singleton $ fromIntegral $ i + 0x50
-    err = error $ "intToScriptOp: Invalid integer " ++ (show i)
+    err = error $ "intToScriptOp: Invalid integer " ++ show i
 
 -- | Decode 'ScriptOp' [OP_1 .. OP_16] to integers [1 .. 16]. This functions
 -- fails for other values of 'ScriptOp'
 scriptOpToInt :: ScriptOp -> Either String Int
 scriptOpToInt s
     | res `elem` [1..16] = return res
-    | otherwise          = Left $ "scriptOpToInt: invalid opcode " ++ (show s)
+    | otherwise          = Left $ "scriptOpToInt: invalid opcode " ++ show s
   where
-    res = (fromIntegral $ BS.head $ encode s) - 0x50
+    res = fromIntegral (BS.head $ encode s) - 0x50
 
 -- | Get the address of a `ScriptOutput`
 outputAddress :: ScriptOutput -> Either String Address
 outputAddress s = case s of
-    PayPKHash a -> return a
+    PayPKHash a     -> return a
     PayScriptHash a -> return a
-    PayPK k -> return $ pubKeyAddr k
-    _ -> Left "outputAddress: bad output script type"
+    PayPK k         -> return $ pubKeyAddr k
+    _               -> Left "outputAddress: bad output script type"
 
 -- | Get the address of a `ScriptInput`
 inputAddress :: ScriptInput -> Either String Address
@@ -240,28 +240,28 @@ data SimpleInput
     deriving (Eq, Show, Read)
 
 instance NFData SimpleInput where
-    rnf (SpendPK i) = rnf i
+    rnf (SpendPK i)       = rnf i
     rnf (SpendPKHash i k) = rnf i `seq` rnf k
-    rnf (SpendMulSig k) = rnf k
+    rnf (SpendMulSig k)   = rnf k
 
 -- | Returns True if the input script is spending a public key.
 isSpendPK :: ScriptInput -> Bool
 isSpendPK (RegularInput (SpendPK _)) = True
-isSpendPK _ = False
+isSpendPK _                          = False
 
 -- | Returns True if the input script is spending a public key hash.
 isSpendPKHash :: ScriptInput -> Bool
 isSpendPKHash (RegularInput (SpendPKHash _ _)) = True
-isSpendPKHash _ = False
+isSpendPKHash _                                = False
 
 -- | Returns True if the input script is spending a multisignature output.
 isSpendMulSig :: ScriptInput -> Bool
 isSpendMulSig (RegularInput (SpendMulSig _)) = True
-isSpendMulSig _ = False
+isSpendMulSig _                              = False
 
 isScriptHashInput :: ScriptInput -> Bool
 isScriptHashInput (ScriptHashInput _ _) = True
-isScriptHashInput _ = False
+isScriptHashInput _                     = False
 
 type RedeemScript = ScriptOutput
 
@@ -273,7 +273,7 @@ data ScriptInput
     deriving (Eq, Show, Read)
 
 instance NFData ScriptInput where
-    rnf (RegularInput i) = rnf i
+    rnf (RegularInput i)      = rnf i
     rnf (ScriptHashInput i o) = rnf i `seq` rnf o
 
 -- | Computes a 'Script' from a 'SimpleInput'. The 'Script' is a list of
@@ -291,7 +291,7 @@ decodeSimpleInput (Script ops) = maybeToEither errMsg $
     matchPK ops <|> matchPKHash ops <|> matchMulSig ops
   where
     matchPK [OP_PUSHDATA bs _] = SpendPK <$> eitherToMaybe (decodeSig bs)
-    matchPK _ = Nothing
+    matchPK _                  = Nothing
     matchPKHash [OP_PUSHDATA sig _, OP_PUSHDATA pub _] =
         liftM2 SpendPKHash (eitherToMaybe $ decodeSig sig) (decodeToMaybe pub)
     matchPKHash _ = Nothing
@@ -308,7 +308,7 @@ encodeInput :: ScriptInput -> Script
 encodeInput s = case s of
     RegularInput ri -> encodeSimpleInput ri
     ScriptHashInput i o -> Script $
-        (scriptOps $ encodeSimpleInput i) ++ [opPushData $ encodeOutputBS o]
+        scriptOps (encodeSimpleInput i) ++ [opPushData $ encodeOutputBS o]
 
 -- | Similar to 'encodeInput' but encodes to a ByteString
 encodeInputBS :: ScriptInput -> ByteString
@@ -320,7 +320,7 @@ decodeInput :: Script -> Either String ScriptInput
 decodeInput s@(Script ops) = maybeToEither errMsg $
     matchSimpleInput <|> matchPayScriptHash
   where
-    matchSimpleInput = RegularInput <$> (eitherToMaybe $ decodeSimpleInput s)
+    matchSimpleInput = RegularInput <$> eitherToMaybe (decodeSimpleInput s)
     matchPayScriptHash = case splitAt (length (scriptOps s) - 1) ops of
         (is, [OP_PUSHDATA bs _]) -> do
             rdm <- eitherToMaybe $ decodeOutputBS bs

--- a/haskoin-core/Network/Haskoin/Script/Types.hs
+++ b/haskoin-core/Network/Haskoin/Script/Types.hs
@@ -35,10 +35,10 @@ import qualified Data.ByteString as BS
 -- * Define the spending conditions in the output of a transaction
 --
 -- * Provide the spending signatures in the input of a transaction
-data Script =
+newtype Script =
     Script {
              -- | List of script operators defining this script
-             scriptOps :: ![ScriptOp]
+             scriptOps :: [ScriptOp]
            }
     deriving (Eq, Show, Read)
 
@@ -202,7 +202,7 @@ instance Serialize ScriptOp where
     get = go =<< (fromIntegral <$> getWord8)
       where
         go op
-            | op == 0x00 = return $ OP_0
+            | op == 0x00 = return OP_0
             | op <= 0x4b = do
                 payload <- getByteString (fromIntegral op)
                 return $ OP_PUSHDATA payload OPCODE
@@ -219,130 +219,130 @@ instance Serialize ScriptOp where
                 payload <- getByteString (fromIntegral len)
                 return $ OP_PUSHDATA payload OPDATA4
 
-            | op == 0x4f = return $ OP_1NEGATE
-            | op == 0x50 = return $ OP_RESERVED
-            | op == 0x51 = return $ OP_1
-            | op == 0x52 = return $ OP_2
-            | op == 0x53 = return $ OP_3
-            | op == 0x54 = return $ OP_4
-            | op == 0x55 = return $ OP_5
-            | op == 0x56 = return $ OP_6
-            | op == 0x57 = return $ OP_7
-            | op == 0x58 = return $ OP_8
-            | op == 0x59 = return $ OP_9
-            | op == 0x5a = return $ OP_10
-            | op == 0x5b = return $ OP_11
-            | op == 0x5c = return $ OP_12
-            | op == 0x5d = return $ OP_13
-            | op == 0x5e = return $ OP_14
-            | op == 0x5f = return $ OP_15
-            | op == 0x60 = return $ OP_16
+            | op == 0x4f = return OP_1NEGATE
+            | op == 0x50 = return OP_RESERVED
+            | op == 0x51 = return OP_1
+            | op == 0x52 = return OP_2
+            | op == 0x53 = return OP_3
+            | op == 0x54 = return OP_4
+            | op == 0x55 = return OP_5
+            | op == 0x56 = return OP_6
+            | op == 0x57 = return OP_7
+            | op == 0x58 = return OP_8
+            | op == 0x59 = return OP_9
+            | op == 0x5a = return OP_10
+            | op == 0x5b = return OP_11
+            | op == 0x5c = return OP_12
+            | op == 0x5d = return OP_13
+            | op == 0x5e = return OP_14
+            | op == 0x5f = return OP_15
+            | op == 0x60 = return OP_16
             -- Flow control
-            | op == 0x61 = return $ OP_NOP
-            | op == 0x62 = return $ OP_VER        -- reserved
-            | op == 0x63 = return $ OP_IF
-            | op == 0x64 = return $ OP_NOTIF
-            | op == 0x65 = return $ OP_VERIF      -- reserved
-            | op == 0x66 = return $ OP_VERNOTIF   -- reserved
-            | op == 0x67 = return $ OP_ELSE
-            | op == 0x68 = return $ OP_ENDIF
-            | op == 0x69 = return $ OP_VERIFY
-            | op == 0x6a = return $ OP_RETURN
+            | op == 0x61 = return OP_NOP
+            | op == 0x62 = return OP_VER        -- reserved
+            | op == 0x63 = return OP_IF
+            | op == 0x64 = return OP_NOTIF
+            | op == 0x65 = return OP_VERIF      -- reserved
+            | op == 0x66 = return OP_VERNOTIF   -- reserved
+            | op == 0x67 = return OP_ELSE
+            | op == 0x68 = return OP_ENDIF
+            | op == 0x69 = return OP_VERIFY
+            | op == 0x6a = return OP_RETURN
 
             -- Stack
-            | op == 0x6b = return $ OP_TOALTSTACK
-            | op == 0x6c = return $ OP_FROMALTSTACK
-            | op == 0x6d = return $ OP_2DROP
-            | op == 0x6e = return $ OP_2DUP
-            | op == 0x6f = return $ OP_3DUP
-            | op == 0x70 = return $ OP_2OVER
-            | op == 0x71 = return $ OP_2ROT
-            | op == 0x72 = return $ OP_2SWAP
-            | op == 0x73 = return $ OP_IFDUP
-            | op == 0x74 = return $ OP_DEPTH
-            | op == 0x75 = return $ OP_DROP
-            | op == 0x76 = return $ OP_DUP
-            | op == 0x77 = return $ OP_NIP
-            | op == 0x78 = return $ OP_OVER
-            | op == 0x79 = return $ OP_PICK
-            | op == 0x7a = return $ OP_ROLL
-            | op == 0x7b = return $ OP_ROT
-            | op == 0x7c = return $ OP_SWAP
-            | op == 0x7d = return $ OP_TUCK
+            | op == 0x6b = return OP_TOALTSTACK
+            | op == 0x6c = return OP_FROMALTSTACK
+            | op == 0x6d = return OP_2DROP
+            | op == 0x6e = return OP_2DUP
+            | op == 0x6f = return OP_3DUP
+            | op == 0x70 = return OP_2OVER
+            | op == 0x71 = return OP_2ROT
+            | op == 0x72 = return OP_2SWAP
+            | op == 0x73 = return OP_IFDUP
+            | op == 0x74 = return OP_DEPTH
+            | op == 0x75 = return OP_DROP
+            | op == 0x76 = return OP_DUP
+            | op == 0x77 = return OP_NIP
+            | op == 0x78 = return OP_OVER
+            | op == 0x79 = return OP_PICK
+            | op == 0x7a = return OP_ROLL
+            | op == 0x7b = return OP_ROT
+            | op == 0x7c = return OP_SWAP
+            | op == 0x7d = return OP_TUCK
 
             -- Splice
-            | op == 0x7e = return $ OP_CAT
-            | op == 0x7f = return $ OP_SUBSTR
-            | op == 0x80 = return $ OP_LEFT
-            | op == 0x81 = return $ OP_RIGHT
-            | op == 0x82 = return $ OP_SIZE
+            | op == 0x7e = return OP_CAT
+            | op == 0x7f = return OP_SUBSTR
+            | op == 0x80 = return OP_LEFT
+            | op == 0x81 = return OP_RIGHT
+            | op == 0x82 = return OP_SIZE
 
             -- Bitwise logic
-            | op == 0x83 = return $ OP_INVERT
-            | op == 0x84 = return $ OP_AND
-            | op == 0x85 = return $ OP_OR
-            | op == 0x86 = return $ OP_XOR
-            | op == 0x87 = return $ OP_EQUAL
-            | op == 0x88 = return $ OP_EQUALVERIFY
-            | op == 0x89 = return $ OP_RESERVED1
-            | op == 0x8a = return $ OP_RESERVED2
+            | op == 0x83 = return OP_INVERT
+            | op == 0x84 = return OP_AND
+            | op == 0x85 = return OP_OR
+            | op == 0x86 = return OP_XOR
+            | op == 0x87 = return OP_EQUAL
+            | op == 0x88 = return OP_EQUALVERIFY
+            | op == 0x89 = return OP_RESERVED1
+            | op == 0x8a = return OP_RESERVED2
 
             -- Arithmetic
-            | op == 0x8b = return $ OP_1ADD
-            | op == 0x8c = return $ OP_1SUB
-            | op == 0x8d = return $ OP_2MUL
-            | op == 0x8e = return $ OP_2DIV
-            | op == 0x8f = return $ OP_NEGATE
-            | op == 0x90 = return $ OP_ABS
-            | op == 0x91 = return $ OP_NOT
-            | op == 0x92 = return $ OP_0NOTEQUAL
-            | op == 0x93 = return $ OP_ADD
-            | op == 0x94 = return $ OP_SUB
-            | op == 0x95 = return $ OP_MUL
-            | op == 0x96 = return $ OP_DIV
-            | op == 0x97 = return $ OP_MOD
-            | op == 0x98 = return $ OP_LSHIFT
-            | op == 0x99 = return $ OP_RSHIFT
-            | op == 0x9a = return $ OP_BOOLAND
-            | op == 0x9b = return $ OP_BOOLOR
-            | op == 0x9c = return $ OP_NUMEQUAL
-            | op == 0x9d = return $ OP_NUMEQUALVERIFY
-            | op == 0x9e = return $ OP_NUMNOTEQUAL
-            | op == 0x9f = return $ OP_LESSTHAN
-            | op == 0xa0 = return $ OP_GREATERTHAN
-            | op == 0xa1 = return $ OP_LESSTHANOREQUAL
-            | op == 0xa2 = return $ OP_GREATERTHANOREQUAL
-            | op == 0xa3 = return $ OP_MIN
-            | op == 0xa4 = return $ OP_MAX
-            | op == 0xa5 = return $ OP_WITHIN
+            | op == 0x8b = return OP_1ADD
+            | op == 0x8c = return OP_1SUB
+            | op == 0x8d = return OP_2MUL
+            | op == 0x8e = return OP_2DIV
+            | op == 0x8f = return OP_NEGATE
+            | op == 0x90 = return OP_ABS
+            | op == 0x91 = return OP_NOT
+            | op == 0x92 = return OP_0NOTEQUAL
+            | op == 0x93 = return OP_ADD
+            | op == 0x94 = return OP_SUB
+            | op == 0x95 = return OP_MUL
+            | op == 0x96 = return OP_DIV
+            | op == 0x97 = return OP_MOD
+            | op == 0x98 = return OP_LSHIFT
+            | op == 0x99 = return OP_RSHIFT
+            | op == 0x9a = return OP_BOOLAND
+            | op == 0x9b = return OP_BOOLOR
+            | op == 0x9c = return OP_NUMEQUAL
+            | op == 0x9d = return OP_NUMEQUALVERIFY
+            | op == 0x9e = return OP_NUMNOTEQUAL
+            | op == 0x9f = return OP_LESSTHAN
+            | op == 0xa0 = return OP_GREATERTHAN
+            | op == 0xa1 = return OP_LESSTHANOREQUAL
+            | op == 0xa2 = return OP_GREATERTHANOREQUAL
+            | op == 0xa3 = return OP_MIN
+            | op == 0xa4 = return OP_MAX
+            | op == 0xa5 = return OP_WITHIN
 
             -- Crypto
-            | op == 0xa6 = return $ OP_RIPEMD160
-            | op == 0xa7 = return $ OP_SHA1
-            | op == 0xa8 = return $ OP_SHA256
-            | op == 0xa9 = return $ OP_HASH160
-            | op == 0xaa = return $ OP_HASH256
-            | op == 0xab = return $ OP_CODESEPARATOR
-            | op == 0xac = return $ OP_CHECKSIG
-            | op == 0xad = return $ OP_CHECKSIGVERIFY
-            | op == 0xae = return $ OP_CHECKMULTISIG
-            | op == 0xaf = return $ OP_CHECKMULTISIGVERIFY
+            | op == 0xa6 = return OP_RIPEMD160
+            | op == 0xa7 = return OP_SHA1
+            | op == 0xa8 = return OP_SHA256
+            | op == 0xa9 = return OP_HASH160
+            | op == 0xaa = return OP_HASH256
+            | op == 0xab = return OP_CODESEPARATOR
+            | op == 0xac = return OP_CHECKSIG
+            | op == 0xad = return OP_CHECKSIGVERIFY
+            | op == 0xae = return OP_CHECKMULTISIG
+            | op == 0xaf = return OP_CHECKMULTISIGVERIFY
 
             -- More NOPs
-            | op == 0xb0 = return $ OP_NOP1
-            | op == 0xb1 = return $ OP_NOP2
-            | op == 0xb2 = return $ OP_NOP3
-            | op == 0xb3 = return $ OP_NOP4
-            | op == 0xb4 = return $ OP_NOP5
-            | op == 0xb5 = return $ OP_NOP6
-            | op == 0xb6 = return $ OP_NOP7
-            | op == 0xb7 = return $ OP_NOP8
-            | op == 0xb8 = return $ OP_NOP9
-            | op == 0xb9 = return $ OP_NOP10
+            | op == 0xb0 = return OP_NOP1
+            | op == 0xb1 = return OP_NOP2
+            | op == 0xb2 = return OP_NOP3
+            | op == 0xb3 = return OP_NOP4
+            | op == 0xb4 = return OP_NOP5
+            | op == 0xb5 = return OP_NOP6
+            | op == 0xb6 = return OP_NOP7
+            | op == 0xb7 = return OP_NOP8
+            | op == 0xb8 = return OP_NOP9
+            | op == 0xb9 = return OP_NOP10
 
             -- Constants
-            | op == 0xfd = return $ OP_PUBKEYHASH
-            | op == 0xfe = return $ OP_PUBKEY
+            | op == 0xfd = return OP_PUBKEYHASH
+            | op == 0xfe = return OP_PUBKEY
 
             | otherwise = return $ OP_INVALIDOPCODE op
 

--- a/haskoin-core/Network/Haskoin/Test.hs
+++ b/haskoin-core/Network/Haskoin/Test.hs
@@ -3,111 +3,115 @@
 -}
 module Network.Haskoin.Test
 (
-  -- * Util Arbitrary instances
-  ArbitraryByteString(..)
-, ArbitraryNotNullByteString(..)
-, ArbitraryUTCTime(..)
-, ArbitraryHash512(..)
-, ArbitraryHash256(..)
-, ArbitraryHash160(..)
-, ArbitraryCheckSum32(..)
+  -- * Util Arbitrary functions
+  arbitraryBS
+, arbitraryBS1
+, arbitraryBSn
+, arbitraryUTCTime
+, arbitraryMaybe
 
-  -- * Crypto Arbitrary instances
-, ArbitraryPrvKey(..)
-, ArbitraryPrvKeyC(..)
-, ArbitraryPrvKeyU(..)
-, ArbitraryPubKey(..)
-, ArbitraryPubKeyC(..)
-, ArbitraryPubKeyU(..)
-, ArbitraryAddress(..)
-, ArbitraryPubKeyAddress(..)
-, ArbitraryScriptAddress(..)
-, ArbitrarySignature(..)
-, ArbitraryXPrvKey(..)
-, ArbitraryXPubKey(..)
-, ArbitraryHardPath(..)
-, ArbitrarySoftPath(..)
-, ArbitraryDerivPath(..)
-, ArbitraryParsedPath(..)
+  -- * Crypto Arbitrary functions
+, arbitraryHash160
+, arbitraryHash256
+, arbitraryHash512
+, arbitraryCheckSum32
+, arbitraryPrvKey
+, arbitraryPrvKeyC
+, arbitraryPrvKeyU
+, arbitraryPubKey
+, arbitraryPubKeyC
+, arbitraryPubKeyU
+, arbitraryAddress
+, arbitraryPubKeyAddress
+, arbitraryScriptAddress
+, arbitrarySignature
+, arbitraryXPrvKey
+, arbitraryXPubKey
+, arbitraryBip32PathIndex
+, arbitraryHardPath
+, arbitrarySoftPath
+, arbitraryDerivPath
+, arbitraryParsedPath
 
-  -- * Node Arbitrary instances
-, ArbitraryVarInt(..)
-, ArbitraryVarString(..)
-, ArbitraryNetworkAddress(..)
-, ArbitraryNetworkAddressTime(..)
-, ArbitraryInvType(..)
-, ArbitraryInvVector(..)
-, ArbitraryInv(..)
-, ArbitraryVersion(..)
-, ArbitraryAddr(..)
-, ArbitraryAlert(..)
-, ArbitraryReject(..)
-, ArbitraryRejectCode(..)
-, ArbitraryGetData(..)
-, ArbitraryNotFound(..)
-, ArbitraryPing(..)
-, ArbitraryPong(..)
-, ArbitraryBloomFlags(..)
-, ArbitraryBloomFilter(..)
-, ArbitraryFilterLoad(..)
-, ArbitraryFilterAdd(..)
-, ArbitraryMessageCommand(..)
+  -- * Node Arbitrary functions
+, arbitraryVarInt
+, arbitraryVarString
+, arbitraryNetworkAddress
+, arbitraryNetworkAddressTime
+, arbitraryInvType
+, arbitraryInvVector
+, arbitraryInv1
+, arbitraryVersion
+, arbitraryAddr1
+, arbitraryAlert
+, arbitraryReject
+, arbitraryRejectCode
+, arbitraryGetData
+, arbitraryNotFound
+, arbitraryPing
+, arbitraryPong
+, arbitraryBloomFlags
+, arbitraryBloomFilter
+, arbitraryFilterLoad
+, arbitraryFilterAdd
+, arbitraryMessageCommand
 
-  -- * Message Arbitrary instances
-, ArbitraryMessageHeader(..)
-, ArbitraryMessage(..)
+  -- * Message Arbitrary functions
+, arbitraryMessageHeader
+, arbitraryMessage
 
-  -- * Script Arbitrary instances
-, ArbitraryScriptOp(..)
-, ArbitraryScript(..)
-, ArbitraryIntScriptOp(..)
-, ArbitraryPushDataType(..)
-, ArbitraryTxSignature(..)
-, ArbitrarySigHash(..)
-, ArbitraryValidSigHash(..)
-, ArbitraryMSParam(..)
-, ArbitraryScriptOutput(..)
-, ArbitrarySimpleOutput(..)
-, ArbitraryPKOutput(..)
-, ArbitraryPKHashOutput(..)
-, ArbitraryMSOutput(..)
-, ArbitraryMSCOutput(..)
-, ArbitrarySHOutput(..)
-, ArbitraryScriptInput(..)
-, ArbitrarySimpleInput(..)
-, ArbitraryPKInput(..)
-, ArbitraryPKHashInput(..)
-, ArbitraryPKHashCInput(..)
-, ArbitraryMSInput(..)
-, ArbitrarySHInput(..)
-, ArbitraryMulSigSHCInput(..)
+  -- * Script arbitrary functions
+, arbitraryScriptOp
+, arbitraryScript
+, arbitraryIntScriptOp
+, arbitraryPushDataType
+, arbitraryTxSignature
+, arbitrarySigHash
+, arbitraryValidSigHash
+, arbitraryMSParam
+, arbitraryScriptOutput
+, arbitrarySimpleOutput
+, arbitraryPKOutput
+, arbitraryPKHashOutput
+, arbitraryMSOutput
+, arbitraryMSCOutput
+, arbitrarySHOutput
+, arbitraryScriptInput
+, arbitrarySimpleInput
+, arbitraryPKInput
+, arbitraryPKHashInput
+, arbitraryPKHashCInput
+, arbitraryMSInput
+, arbitrarySHInput
+, arbitraryMulSigSHCInput
 
-  -- * Transaction Arbitrary instances
-, ArbitrarySatoshi(..)
-, ArbitraryTx(..)
-, ArbitraryTxHash(..)
-, ArbitraryTxIn(..)
-, ArbitraryTxOut(..)
-, ArbitraryOutPoint(..)
-, ArbitraryAddrOnlyTx(..)
-, ArbitraryAddrOnlyTxIn(..)
-, ArbitraryAddrOnlyTxOut(..)
-, ArbitrarySigInput(..)
-, ArbitraryPKSigInput(..)
-, ArbitraryPKHashSigInput(..)
-, ArbitraryMSSigInput(..)
-, ArbitrarySHSigInput(..)
-, ArbitrarySigningData(..)
-, ArbitraryPartialTxs(..)
+  -- * Transaction arbitrary functions
+, TestCoin(..)
+, arbitrarySatoshi
+, arbitraryTx
+, arbitraryTxHash
+, arbitraryTxIn
+, arbitraryTxOut
+, arbitraryOutPoint
+, arbitraryAddrOnlyTx
+, arbitraryAddrOnlyTxIn
+, arbitraryAddrOnlyTxOut
+, arbitrarySigInput
+, arbitraryPKSigInput
+, arbitraryPKHashSigInput
+, arbitraryMSSigInput
+, arbitrarySHSigInput
+, arbitrarySigningData
+, arbitraryPartialTxs
 
-  -- * Block Arbitrary instances
-, ArbitraryBlock(..)
-, ArbitraryBlockHeader(..)
-, ArbitraryBlockHash(..)
-, ArbitraryGetBlocks(..)
-, ArbitraryGetHeaders(..)
-, ArbitraryHeaders(..)
-, ArbitraryMerkleBlock(..)
+  -- * Block arbitrary functions
+, arbitraryBlock
+, arbitraryBlockHeader
+, arbitraryBlockHash
+, arbitraryGetBlocks
+, arbitraryGetHeaders
+, arbitraryHeaders
+, arbitraryMerkleBlock
 ) where
 
 import Network.Haskoin.Test.Util

--- a/haskoin-core/Network/Haskoin/Test/Crypto.hs
+++ b/haskoin-core/Network/Haskoin/Test/Crypto.hs
@@ -1,258 +1,125 @@
 {-|
   Arbitrary types for Network.Haskoin.Crypto
 -}
-module Network.Haskoin.Test.Crypto
-( ArbitraryHash512(..)
-, ArbitraryHash256(..)
-, ArbitraryHash160(..)
-, ArbitraryCheckSum32(..)
-, ArbitraryByteString(..)
-, ArbitraryNotNullByteString(..)
-, ArbitraryPrvKey(..)
-, ArbitraryPrvKeyC(..)
-, ArbitraryPrvKeyU(..)
-, ArbitraryPubKey(..)
-, ArbitraryPubKeyC(..)
-, ArbitraryPubKeyU(..)
-, ArbitraryAddress(..)
-, ArbitraryPubKeyAddress(..)
-, ArbitraryScriptAddress(..)
-, ArbitrarySignature(..)
-, ArbitraryXPrvKey(..)
-, ArbitraryXPubKey(..)
-, ArbitraryHardPath(..)
-, ArbitrarySoftPath(..)
-, ArbitraryDerivPath(..)
-, ArbitraryParsedPath(..)
+module Network.Haskoin.Test.Crypto where
 
-) where
+import           Crypto.Secp256k1                    ()
+import           Data.Bits                           (clearBit)
+import           Data.List                           (foldl')
+import           Data.Maybe                          (fromJust)
+import           Data.Word                           (Word32)
+import           Network.Haskoin.Crypto.Base58
+import           Network.Haskoin.Crypto.ECDSA
+import           Network.Haskoin.Crypto.ExtendedKeys
+import           Network.Haskoin.Crypto.Hash
+import           Network.Haskoin.Crypto.Keys
+import           Network.Haskoin.Test.Util
+import           Test.QuickCheck
 
-import Test.QuickCheck
-    ( Arbitrary
-    , Gen
-    , arbitrary
-    , oneof
-    , vectorOf
-    , listOf
-    )
+arbitraryHash160 :: Gen Hash160
+arbitraryHash160 = (fromJust . bsToHash160) <$> arbitraryBSn 20
 
-import Crypto.Secp256k1 ()
+arbitraryHash256 :: Gen Hash256
+arbitraryHash256 = (fromJust . bsToHash256) <$> arbitraryBSn 32
 
-import Data.Bits (clearBit)
-import qualified Data.ByteString as BS (pack)
-import Data.Maybe (fromMaybe)
-import Data.Word (Word32)
+arbitraryHash512 :: Gen Hash512
+arbitraryHash512 = (fromJust . bsToHash512) <$> arbitraryBSn 64
 
-import Network.Haskoin.Test.Util
-import Network.Haskoin.Crypto.ECDSA
-import Network.Haskoin.Crypto.Hash
-import Network.Haskoin.Crypto.Keys
-import Network.Haskoin.Crypto.Base58
-import Network.Haskoin.Crypto.ExtendedKeys
-import Data.List (foldl')
+arbitraryCheckSum32 :: Gen CheckSum32
+arbitraryCheckSum32 = (fromJust . bsToCheckSum32) <$> arbitraryBSn 4
 
-newtype ArbitraryHash160 = ArbitraryHash160 Hash160
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryHash160 where
-    arbitrary = (ArbitraryHash160 . fromMaybe e . bsToHash160 . BS.pack) <$>
-        vectorOf 20 arbitrary
-      where
-        e = error "Could not read arbitrary 20-byte hash"
-
-newtype ArbitraryHash256 = ArbitraryHash256 Hash256
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryHash256 where
-    arbitrary = (ArbitraryHash256 . fromMaybe e . bsToHash256 . BS.pack) <$>
-        vectorOf 32 arbitrary
-      where
-        e = error "Could not read arbitrary 32-byte hash"
-
-newtype ArbitraryHash512 = ArbitraryHash512 Hash512
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryHash512 where
-    arbitrary = (ArbitraryHash512 . fromMaybe e . bsToHash512 . BS.pack) <$>
-        vectorOf 64 arbitrary
-      where
-        e = error "Could not read arbitrary 64-byte hash"
-
-newtype ArbitraryCheckSum32 = ArbitraryCheckSum32 CheckSum32
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryCheckSum32 where
-    arbitrary = (ArbitraryCheckSum32 . fromMaybe e . bsToCheckSum32 . BS.pack) <$>
-        vectorOf 4 arbitrary
-      where
-        e = error "Could not read arbitrary checksum"
-
--- | Arbitrary private key (can be both compressed or uncompressed)
-newtype ArbitraryPrvKey = ArbitraryPrvKey PrvKey
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPrvKey where
-    arbitrary = ArbitraryPrvKey <$> oneof
-        [ arbitrary >>= \(ArbitraryPrvKeyC k) -> return (toPrvKeyG k)
-        , arbitrary >>= \(ArbitraryPrvKeyU k) -> return (toPrvKeyG k)
-        ]
+arbitraryPrvKey :: Gen PrvKey
+arbitraryPrvKey = oneof [ toPrvKeyG <$> arbitraryPrvKeyC
+                        , toPrvKeyG <$> arbitraryPrvKeyU
+                        ]
 
 -- | Arbitrary compressed private key
-newtype ArbitraryPrvKeyC = ArbitraryPrvKeyC PrvKeyC
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPrvKeyC where
-    arbitrary = do
-        i <- arbitrary
-        return $ ArbitraryPrvKeyC $ makePrvKeyC i
+arbitraryPrvKeyC :: Gen PrvKeyC
+arbitraryPrvKeyC = makePrvKeyC <$> arbitrary
 
 -- | Arbitrary uncompressed private key
-newtype ArbitraryPrvKeyU = ArbitraryPrvKeyU PrvKeyU
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPrvKeyU where
-    arbitrary = do
-        i <- arbitrary
-        return $ ArbitraryPrvKeyU $ makePrvKeyU i
+arbitraryPrvKeyU :: Gen PrvKeyU
+arbitraryPrvKeyU = makePrvKeyU <$> arbitrary
 
 -- | Arbitrary public key (can be both compressed or uncompressed) with its
 -- corresponding private key.
-data ArbitraryPubKey = ArbitraryPubKey PrvKey PubKey
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPubKey where
-    arbitrary = oneof
-        [ arbitrary >>= \(ArbitraryPubKeyC k p) ->
-            return $ ArbitraryPubKey (toPrvKeyG k) (toPubKeyG p)
-        , arbitrary >>= \(ArbitraryPubKeyU k p) ->
-            return $ ArbitraryPubKey (toPrvKeyG k) (toPubKeyG p)
-        ]
+arbitraryPubKey :: Gen (PrvKey, PubKey)
+arbitraryPubKey =
+    oneof [ f <$> arbitraryPubKeyC
+          , f <$> arbitraryPubKeyU
+          ]
+  where
+    f (k, p) = (toPrvKeyG k, toPubKeyG p)
 
 -- | Arbitrary compressed public key with its corresponding private key.
-data ArbitraryPubKeyC = ArbitraryPubKeyC PrvKeyC PubKeyC
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPubKeyC where
-    arbitrary = do
-        ArbitraryPrvKeyC k <- arbitrary
-        return $ ArbitraryPubKeyC k $ derivePubKey k
+arbitraryPubKeyC :: Gen (PrvKeyC, PubKeyC)
+arbitraryPubKeyC = (\k -> (k, derivePubKey k)) <$> arbitraryPrvKeyC
 
 -- | Arbitrary uncompressed public key with its corresponding private key.
-data ArbitraryPubKeyU = ArbitraryPubKeyU PrvKeyU PubKeyU
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPubKeyU where
-    arbitrary = do
-        ArbitraryPrvKeyU k <- arbitrary
-        return $ ArbitraryPubKeyU k $ derivePubKey k
+arbitraryPubKeyU :: Gen (PrvKeyU, PubKeyU)
+arbitraryPubKeyU = (\k -> (k, derivePubKey k)) <$> arbitraryPrvKeyU
 
 -- | Arbitrary address (can be a pubkey or script hash address)
-newtype ArbitraryAddress = ArbitraryAddress Address
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryAddress where
-    arbitrary = ArbitraryAddress <$> oneof
-        [ arbitrary >>= \(ArbitraryPubKeyAddress a) -> return a
-        , arbitrary >>= \(ArbitraryScriptAddress a) -> return a
-        ]
+arbitraryAddress :: Gen Address
+arbitraryAddress = oneof [ arbitraryPubKeyAddress
+                         , arbitraryScriptAddress
+                         ]
 
 -- | Arbitrary public key hash address
-newtype ArbitraryPubKeyAddress = ArbitraryPubKeyAddress Address
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPubKeyAddress where
-    arbitrary = do
-        ArbitraryHash160 i <- arbitrary
-        return $ ArbitraryPubKeyAddress $ PubKeyAddress i
+arbitraryPubKeyAddress :: Gen Address
+arbitraryPubKeyAddress = PubKeyAddress <$> arbitraryHash160
 
 -- | Arbitrary script hash address
-newtype ArbitraryScriptAddress = ArbitraryScriptAddress Address
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryScriptAddress where
-    arbitrary = do
-        ArbitraryHash160 i <- arbitrary
-        return $ ArbitraryScriptAddress $ ScriptAddress i
+arbitraryScriptAddress :: Gen Address
+arbitraryScriptAddress = ScriptAddress <$> arbitraryHash160
 
 -- | Arbitrary message hash, private key, nonce and corresponding signature.
 -- The signature is generated with a random message, random private key and a
 -- random nonce.
-data ArbitrarySignature = ArbitrarySignature Hash256 PrvKey Signature
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitrarySignature where
-    arbitrary = do
-        ArbitraryHash256 msg <- arbitrary
-        ArbitraryPrvKey key <- arbitrary
-        let sig = signMsg msg key
-        return $ ArbitrarySignature msg key sig
+arbitrarySignature :: Gen (Hash256, PrvKey, Signature)
+arbitrarySignature = do
+    msg <- arbitraryHash256
+    key <- arbitraryPrvKey
+    let sig = signMsg msg key
+    return (msg, key, sig)
 
 -- | Arbitrary extended private key.
-data ArbitraryXPrvKey = ArbitraryXPrvKey XPrvKey
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryXPrvKey where
-    arbitrary = do
-        d <- arbitrary
-        p <- arbitrary
-        i <- arbitrary
-        ArbitraryHash256 c <- arbitrary
-        ArbitraryPrvKeyC k <- arbitrary
-        return $ ArbitraryXPrvKey $ XPrvKey d p i c k
+arbitraryXPrvKey :: Gen XPrvKey
+arbitraryXPrvKey = XPrvKey <$> arbitrary
+                           <*> arbitrary
+                           <*> arbitrary
+                           <*> arbitraryHash256
+                           <*> arbitraryPrvKeyC
 
 -- | Arbitrary extended public key with its corresponding private key.
-data ArbitraryXPubKey = ArbitraryXPubKey XPrvKey XPubKey
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryXPubKey where
-    arbitrary = do
-        ArbitraryXPrvKey k <- arbitrary
-        return $ ArbitraryXPubKey k $ deriveXPubKey k
+arbitraryXPubKey :: Gen (XPrvKey, XPubKey)
+arbitraryXPubKey = (\k -> (k, deriveXPubKey k)) <$> arbitraryXPrvKey
 
 {- Custom derivations -}
 
 genIndex :: Gen Word32
 genIndex = (`clearBit` 31) <$> arbitrary
 
-data ArbitraryBip32PathIndex = ArbitraryBip32PathIndex Bip32PathIndex
-    deriving (Show,Eq)
+arbitraryBip32PathIndex :: Gen Bip32PathIndex
+arbitraryBip32PathIndex =
+    oneof [ Bip32SoftIndex <$> genIndex
+          , Bip32HardIndex <$> genIndex
+          ]
 
-instance Arbitrary ArbitraryBip32PathIndex where
-    arbitrary = 
-        ArbitraryBip32PathIndex <$> oneof [soft, hard]
-        where soft = Bip32SoftIndex <$> genIndex
-              hard = Bip32HardIndex <$> genIndex
-
-data ArbitraryHardPath = ArbitraryHardPath HardPath
-    deriving (Show, Eq)
-
-instance Arbitrary ArbitraryHardPath where
-    arbitrary =
-        ArbitraryHardPath . foldl' (:|) Deriv <$> listOf genIndex
+arbitraryHardPath :: Gen HardPath
+arbitraryHardPath = foldl' (:|) Deriv <$> listOf genIndex
 
 
-data ArbitrarySoftPath = ArbitrarySoftPath SoftPath
-    deriving (Show, Eq)
+arbitrarySoftPath :: Gen SoftPath
+arbitrarySoftPath = foldl' (:/) Deriv <$> listOf genIndex
 
-instance Arbitrary ArbitrarySoftPath where
-    arbitrary =
-        ArbitrarySoftPath . foldl' (:/) Deriv <$> listOf genIndex
+arbitraryDerivPath :: Gen DerivPath
+arbitraryDerivPath = concatBip32Segments <$> listOf arbitraryBip32PathIndex
 
-data ArbitraryDerivPath = ArbitraryDerivPath DerivPath
-    deriving (Show, Eq)
-
-instance Arbitrary ArbitraryDerivPath where    
-    arbitrary = ArbitraryDerivPath . concatBip32Segments . map (\(ArbitraryBip32PathIndex i) -> i ) <$> arbitrary  
-        
-
-data ArbitraryParsedPath = ArbitraryParsedPath ParsedPath 
-  deriving (Show, Eq)
-
-instance Arbitrary ArbitraryParsedPath where
-    arbitrary = do
-        ArbitraryDerivPath d <- arbitrary 
-        ArbitraryParsedPath <$> oneof [ pure $ ParsedPrv d
-                                      , pure $ ParsedPub d
-                                      , pure $ ParsedEmpty d ]
-
+arbitraryParsedPath :: Gen ParsedPath
+arbitraryParsedPath =
+    oneof [ ParsedPrv <$> arbitraryDerivPath
+          , ParsedPub <$> arbitraryDerivPath
+          , ParsedEmpty <$> arbitraryDerivPath
+          ]
 

--- a/haskoin-core/Network/Haskoin/Test/Message.hs
+++ b/haskoin-core/Network/Haskoin/Test/Message.hs
@@ -1,61 +1,45 @@
 {-|
   Arbitrary types for Network.Haskoin.Node.Message
 -}
-module Network.Haskoin.Test.Message
-( ArbitraryMessageHeader(..)
-, ArbitraryMessage(..)
-) where
+module Network.Haskoin.Test.Message where
 
-import Test.QuickCheck
-    ( Arbitrary
-    , arbitrary
-    , oneof
-    )
-
-import Network.Haskoin.Test.Crypto
-import Network.Haskoin.Test.Node
-import Network.Haskoin.Test.Transaction
-import Network.Haskoin.Test.Block
-
-import Network.Haskoin.Node.Message
+import           Network.Haskoin.Node.Message
+import           Network.Haskoin.Test.Block
+import           Network.Haskoin.Test.Crypto
+import           Network.Haskoin.Test.Node
+import           Network.Haskoin.Test.Transaction
+import           Test.QuickCheck
 
 -- | Arbitrary MessageHeader
-newtype ArbitraryMessageHeader = ArbitraryMessageHeader MessageHeader
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryMessageHeader where
-    arbitrary = ArbitraryMessageHeader <$> do
-        m <- arbitrary
-        ArbitraryMessageCommand mc <- arbitrary
-        p <- arbitrary
-        ArbitraryCheckSum32 c <- arbitrary
-        return $ MessageHeader m mc p c
+arbitraryMessageHeader :: Gen MessageHeader
+arbitraryMessageHeader =
+    MessageHeader <$> arbitrary
+                  <*> arbitraryMessageCommand
+                  <*> arbitrary
+                  <*> arbitraryCheckSum32
 
 -- | Arbitrary Message
-newtype ArbitraryMessage = ArbitraryMessage Message
-    deriving (Eq, Show)
-
-instance Arbitrary ArbitraryMessage where
-    arbitrary = ArbitraryMessage <$> oneof
-        [ arbitrary >>= \(ArbitraryVersion x) -> return $ MVersion x
+arbitraryMessage :: Gen Message
+arbitraryMessage =
+    oneof
+        [ MVersion <$> arbitraryVersion
         , return MVerAck
-        , arbitrary >>= \(ArbitraryAddr x) -> return $ MAddr x
-        , arbitrary >>= \(ArbitraryInv x) -> return $ MInv x
-        , arbitrary >>= \(ArbitraryGetData x) -> return $ MGetData x
-        , arbitrary >>= \(ArbitraryNotFound x) -> return $ MNotFound x
-        , arbitrary >>= \(ArbitraryGetBlocks x) -> return $ MGetBlocks x
-        , arbitrary >>= \(ArbitraryGetHeaders x) -> return $ MGetHeaders x
-        , arbitrary >>= \(ArbitraryTx x) -> return $ MTx x
-        , arbitrary >>= \(ArbitraryBlock x) -> return $ MBlock x
-        , arbitrary >>= \(ArbitraryMerkleBlock x) -> return $ MMerkleBlock x
-        , arbitrary >>= \(ArbitraryHeaders x) -> return $ MHeaders x
+        , MAddr <$> arbitraryAddr1
+        , MInv <$> arbitraryInv1
+        , MGetData <$> arbitraryGetData
+        , MNotFound <$> arbitraryNotFound
+        , MGetBlocks <$> arbitraryGetBlocks
+        , MGetHeaders <$> arbitraryGetHeaders
+        , MTx <$> arbitraryTx
+        , MBlock <$> arbitraryBlock
+        , MMerkleBlock <$> arbitraryMerkleBlock
+        , MHeaders <$> arbitraryHeaders
         , return MGetAddr
-        , arbitrary >>= \(ArbitraryFilterLoad x) -> return $ MFilterLoad x
-        , arbitrary >>= \(ArbitraryFilterAdd x) -> return $ MFilterAdd x
+        , MFilterLoad <$> arbitraryFilterLoad
+        , MFilterAdd <$> arbitraryFilterAdd
         , return MFilterClear
-        , arbitrary >>= \(ArbitraryPing x) -> return $ MPing x
-        , arbitrary >>= \(ArbitraryPong x) -> return $ MPong x
-        , arbitrary >>= \(ArbitraryAlert x) -> return $ MAlert x
-        , arbitrary >>= \(ArbitraryReject x) -> return $ MReject x
+        , MPing <$> arbitraryPing
+        , MPong <$> arbitraryPong
+        , MAlert <$> arbitraryAlert
+        , MReject <$> arbitraryReject
         ]
-

--- a/haskoin-core/Network/Haskoin/Test/Node.hs
+++ b/haskoin-core/Network/Haskoin/Test/Node.hs
@@ -1,177 +1,91 @@
 {-|
   Arbitrary types for Network.Haskoin.Node
 -}
-module Network.Haskoin.Test.Node
-( ArbitraryVarInt(..)
-, ArbitraryVarString(..)
-, ArbitraryNetworkAddress(..)
-, ArbitraryNetworkAddressTime(..)
-, ArbitraryInvType(..)
-, ArbitraryInvVector(..)
-, ArbitraryInv(..)
-, ArbitraryVersion(..)
-, ArbitraryAddr(..)
-, ArbitraryAlert(..)
-, ArbitraryReject(..)
-, ArbitraryRejectCode(..)
-, ArbitraryGetData(..)
-, ArbitraryNotFound(..)
-, ArbitraryPing(..)
-, ArbitraryPong(..)
-, ArbitraryBloomFlags(..)
-, ArbitraryBloomFilter(..)
-, ArbitraryFilterLoad(..)
-, ArbitraryFilterAdd(..)
-, ArbitraryMessageCommand(..)
-) where
+module Network.Haskoin.Test.Node where
 
-import Test.QuickCheck
-    ( Arbitrary
-    , arbitrary
-    , elements
-    , listOf1
-    , oneof
-    , choose
-    , vectorOf
-    )
-
-import Data.Word (Word16, Word32)
-import qualified Data.ByteString as BS (pack, empty)
-
-import Network.Socket (SockAddr(..))
-
-import Network.Haskoin.Test.Crypto
-import Network.Haskoin.Node
+import qualified Data.ByteString             as BS (empty, pack)
+import           Data.Word                   (Word16, Word32)
+import           Network.Haskoin.Node
+import           Network.Haskoin.Test.Crypto
+import           Network.Haskoin.Test.Util
+import           Network.Socket              (SockAddr (..))
+import           Test.QuickCheck
 
 -- | Arbitrary VarInt
-newtype ArbitraryVarInt = ArbitraryVarInt VarInt
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryVarInt where
-    arbitrary = ArbitraryVarInt . VarInt <$> arbitrary
+arbitraryVarInt :: Gen VarInt
+arbitraryVarInt = VarInt <$> arbitrary
 
 -- | Arbitrary VarString
-newtype ArbitraryVarString = ArbitraryVarString VarString
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryVarString where
-    arbitrary = do
-        ArbitraryByteString bs <- arbitrary
-        return $ ArbitraryVarString $ VarString bs
+arbitraryVarString :: Gen VarString
+arbitraryVarString = VarString <$> arbitraryBS
 
 -- | Arbitrary NetworkAddress
-newtype ArbitraryNetworkAddress = ArbitraryNetworkAddress NetworkAddress
-    deriving (Eq, Show)
-
-instance Arbitrary ArbitraryNetworkAddress where
-    arbitrary = do
-        s <- arbitrary
-        a <- arbitrary
-        p <- arbitrary
-        ArbitraryNetworkAddress . (NetworkAddress s) <$> oneof
-            [ do
-                b <- arbitrary
-                c <- arbitrary
-                d <- arbitrary
-                return $ SockAddrInet6 (fromIntegral p) 0 (a,b,c,d) 0
-            , return $ SockAddrInet (fromIntegral (p :: Word16)) a
-            ]
+arbitraryNetworkAddress :: Gen NetworkAddress
+arbitraryNetworkAddress = do
+    s <- arbitrary
+    a <- arbitrary
+    p <- arbitrary
+    NetworkAddress s <$> oneof
+        [ do
+            b <- arbitrary
+            c <- arbitrary
+            d <- arbitrary
+            return $ SockAddrInet6 (fromIntegral p) 0 (a,b,c,d) 0
+        , return $ SockAddrInet (fromIntegral (p :: Word16)) a
+        ]
 
 -- | Arbitrary NetworkAddressTime
-newtype ArbitraryNetworkAddressTime
-    = ArbitraryNetworkAddressTime (Word32, NetworkAddress)
-
-instance Arbitrary ArbitraryNetworkAddressTime where
-    arbitrary = do
-        w <- arbitrary
-        ArbitraryNetworkAddress a <- arbitrary
-        return $ ArbitraryNetworkAddressTime (w,a)
+arbitraryNetworkAddressTime :: Gen (Word32, NetworkAddress)
+arbitraryNetworkAddressTime = (,) <$> arbitrary <*> arbitraryNetworkAddress
 
 -- | Arbitrary InvType
-newtype ArbitraryInvType = ArbitraryInvType InvType
-    deriving (Eq, Show, Read)
+arbitraryInvType :: Gen InvType
+arbitraryInvType = elements [InvError, InvTx, InvBlock, InvMerkleBlock]
 
-instance Arbitrary ArbitraryInvType where
-    arbitrary = ArbitraryInvType <$> elements
-        [InvError, InvTx, InvBlock, InvMerkleBlock]
-
--- | Arbitrary InvVector
-newtype ArbitraryInvVector = ArbitraryInvVector InvVector
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryInvVector where
-    arbitrary = do
-        ArbitraryInvType t <- arbitrary
-        ArbitraryHash256 h <- arbitrary
-        return $ ArbitraryInvVector $ InvVector t h
+arbitraryInvVector :: Gen InvVector
+arbitraryInvVector = InvVector <$> arbitraryInvType <*> arbitraryHash256
 
 -- | Arbitrary non-empty Inv
-newtype ArbitraryInv = ArbitraryInv Inv
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryInv where
-    arbitrary = do
-        vs <- listOf1 arbitrary
-        return $ ArbitraryInv $ Inv $ map (\(ArbitraryInvVector v) -> v) vs
+arbitraryInv1 :: Gen Inv
+arbitraryInv1 = Inv <$> listOf1 arbitraryInvVector
 
 -- | Arbitrary Version
-newtype ArbitraryVersion = ArbitraryVersion Version
-    deriving (Eq, Show)
-
-instance Arbitrary ArbitraryVersion where
-    arbitrary = do
-        v <- arbitrary
-        s <- arbitrary
-        t <- arbitrary
-        ArbitraryNetworkAddress nr <- arbitrary
-        ArbitraryNetworkAddress ns <- arbitrary
-        n <- arbitrary
-        ArbitraryVarString a <- arbitrary
-        h <- arbitrary
-        r <- arbitrary
-        return $ ArbitraryVersion $ Version v s t nr ns n a h r
+arbitraryVersion :: Gen Version
+arbitraryVersion =
+    Version <$> arbitrary
+            <*> arbitrary
+            <*> arbitrary
+            <*> arbitraryNetworkAddress
+            <*> arbitraryNetworkAddress
+            <*> arbitrary
+            <*> arbitraryVarString
+            <*> arbitrary
+            <*> arbitrary
 
 -- | Arbitrary non-empty Addr
-newtype ArbitraryAddr = ArbitraryAddr Addr
-    deriving (Eq, Show)
-
-instance Arbitrary ArbitraryAddr where
-    arbitrary = do
-       vs <- listOf1 arbitrary
-       return $ ArbitraryAddr $ Addr $
-           map (\(ArbitraryNetworkAddressTime x) -> x) vs
+arbitraryAddr1 :: Gen Addr
+arbitraryAddr1 = Addr <$> listOf1 arbitraryNetworkAddressTime
 
 -- | Arbitrary alert with random payload and signature. Signature is not
 -- valid.
-newtype ArbitraryAlert = ArbitraryAlert Alert
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryAlert where
-    arbitrary = do
-        ArbitraryVarString p <- arbitrary
-        ArbitraryVarString s <- arbitrary
-        return $ ArbitraryAlert $ Alert p s
+arbitraryAlert :: Gen Alert
+arbitraryAlert = Alert <$> arbitraryVarString <*> arbitraryVarString
 
 -- | Arbitrary Reject
-newtype ArbitraryReject = ArbitraryReject Reject
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryReject where
-    arbitrary = do
-        ArbitraryMessageCommand m <- arbitrary
-        ArbitraryRejectCode c <- arbitrary
-        ArbitraryVarString s <- arbitrary
-        d <- oneof [ return BS.empty
-                   , BS.pack <$> vectorOf 32 arbitrary
-                   ]
-        return $ ArbitraryReject $ Reject m c s d
+arbitraryReject :: Gen Reject
+arbitraryReject = do
+    m <- arbitraryMessageCommand
+    c <- arbitraryRejectCode
+    s <- arbitraryVarString
+    d <- oneof [ return BS.empty
+               , BS.pack <$> vectorOf 32 arbitrary
+               ]
+    return $ Reject m c s d
 
 -- | Arbitrary RejectCode
-newtype ArbitraryRejectCode = ArbitraryRejectCode RejectCode
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryRejectCode where
-    arbitrary = ArbitraryRejectCode <$> elements
+arbitraryRejectCode :: Gen RejectCode
+arbitraryRejectCode =
+    elements
         [ RejectMalformed
         , RejectInvalid
         , RejectInvalid
@@ -183,45 +97,25 @@ instance Arbitrary ArbitraryRejectCode where
         ]
 
 -- | Arbitrary non-empty GetData
-newtype ArbitraryGetData = ArbitraryGetData GetData
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryGetData where
-    arbitrary = do
-        vs <- listOf1 arbitrary
-        return $ ArbitraryGetData $ GetData $
-            map (\(ArbitraryInvVector x) -> x) vs
+arbitraryGetData :: Gen GetData
+arbitraryGetData = GetData <$> listOf1 arbitraryInvVector
 
 -- | Arbitrary NotFound
-newtype ArbitraryNotFound = ArbitraryNotFound NotFound
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryNotFound where
-    arbitrary = do
-        vs <- listOf1 arbitrary
-        return $ ArbitraryNotFound $ NotFound $
-            map (\(ArbitraryInvVector x) -> x) vs
+arbitraryNotFound :: Gen NotFound
+arbitraryNotFound = NotFound <$> listOf1 arbitraryInvVector
 
 -- | Arbitrary Ping
-newtype ArbitraryPing = ArbitraryPing Ping
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPing where
-    arbitrary = ArbitraryPing . Ping <$> arbitrary
+arbitraryPing :: Gen Ping
+arbitraryPing = Ping <$> arbitrary
 
 -- | Arbitrary Pong
-newtype ArbitraryPong = ArbitraryPong Pong
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPong where
-    arbitrary = ArbitraryPong . Pong <$> arbitrary
+arbitraryPong :: Gen Pong
+arbitraryPong = Pong <$> arbitrary
 
 -- | Arbitrary bloom filter flags
-data ArbitraryBloomFlags = ArbitraryBloomFlags BloomFlags
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryBloomFlags where
-    arbitrary = ArbitraryBloomFlags <$> elements
+arbitraryBloomFlags :: Gen BloomFlags
+arbitraryBloomFlags =
+    elements
         [ BloomUpdateNone
         , BloomUpdateAll
         , BloomUpdateP2PubKeyOnly
@@ -229,42 +123,28 @@ instance Arbitrary ArbitraryBloomFlags where
 
 -- | Arbitrary bloom filter with its corresponding number of elements
 -- and false positive rate.
-data ArbitraryBloomFilter = ArbitraryBloomFilter Int Double BloomFilter
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryBloomFilter where
-    arbitrary = do
-        n     <- choose (0,100000)
-        fp    <- choose (1e-8,1)
-        tweak <- arbitrary
-        ArbitraryBloomFlags fl <- arbitrary
-        return $ ArbitraryBloomFilter n fp $ bloomCreate n fp tweak fl
+arbitraryBloomFilter :: Gen (Int, Double, BloomFilter)
+arbitraryBloomFilter = do
+    n     <- choose (0,100000)
+    fp    <- choose (1e-8,1)
+    tweak <- arbitrary
+    fl    <- arbitraryBloomFlags
+    return (n, fp, bloomCreate n fp tweak fl)
 
 -- | Arbitrary FilterLoad
-data ArbitraryFilterLoad = ArbitraryFilterLoad FilterLoad
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryFilterLoad where
-    arbitrary = do
-        ArbitraryBloomFilter _ _ bf <- arbitrary
-        return $ ArbitraryFilterLoad $ FilterLoad bf
+arbitraryFilterLoad :: Gen FilterLoad
+arbitraryFilterLoad = do
+    (_, _, bf) <- arbitraryBloomFilter
+    return $ FilterLoad bf
 
 -- | Arbitrary FilterAdd
-data ArbitraryFilterAdd = ArbitraryFilterAdd FilterAdd
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryFilterAdd where
-    arbitrary = do
-        ArbitraryByteString bs <- arbitrary
-        return $ ArbitraryFilterAdd $ FilterAdd bs
-
+arbitraryFilterAdd :: Gen FilterAdd
+arbitraryFilterAdd = FilterAdd <$> arbitraryBS
 
 -- | Arbitrary MessageCommand
-newtype ArbitraryMessageCommand = ArbitraryMessageCommand MessageCommand
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryMessageCommand where
-    arbitrary = ArbitraryMessageCommand <$> elements
+arbitraryMessageCommand :: Gen MessageCommand
+arbitraryMessageCommand =
+    elements
         [ MCVersion
         , MCVerAck
         , MCAddr
@@ -285,4 +165,3 @@ instance Arbitrary ArbitraryMessageCommand where
         , MCPong
         , MCAlert
         ]
-

--- a/haskoin-core/Network/Haskoin/Test/Script.hs
+++ b/haskoin-core/Network/Haskoin/Test/Script.hs
@@ -1,186 +1,152 @@
 {-|
   Arbitrary types for Network.Haskoin.Script
 -}
-module Network.Haskoin.Test.Script
-( ArbitraryScriptOp(..)
-, ArbitraryScript(..)
-, ArbitraryIntScriptOp(..)
-, ArbitraryPushDataType(..)
-, ArbitraryTxSignature(..)
-, ArbitrarySigHash(..)
-, ArbitraryValidSigHash(..)
-, ArbitraryMSParam(..)
-, ArbitraryScriptOutput(..)
-, ArbitrarySimpleOutput(..)
-, ArbitraryPKOutput(..)
-, ArbitraryPKHashOutput(..)
-, ArbitraryMSOutput(..)
-, ArbitraryMSCOutput(..)
-, ArbitrarySHOutput(..)
-, ArbitraryScriptInput(..)
-, ArbitrarySimpleInput(..)
-, ArbitraryPKInput(..)
-, ArbitraryPKHashInput(..)
-, ArbitraryPKHashCInput(..)
-, ArbitraryMSInput(..)
-, ArbitrarySHInput(..)
-, ArbitraryMulSigSHCInput(..)
-) where
+module Network.Haskoin.Test.Script where
 
-import Test.QuickCheck
-    ( Arbitrary
-    , arbitrary
-    , oneof
-    , choose
-    , vectorOf
-    , elements
-    )
-
-import Data.Bits (testBit)
-
-import Network.Haskoin.Transaction.Types
-import Network.Haskoin.Test.Crypto
-import Network.Haskoin.Script
-import Network.Haskoin.Crypto
+import           Data.Bits                         (testBit)
+import           Network.Haskoin.Crypto
+import           Network.Haskoin.Script
+import           Network.Haskoin.Test.Crypto
+import           Network.Haskoin.Test.Util
+import           Network.Haskoin.Transaction.Types
+import           Network.Haskoin.Util
+import           Test.QuickCheck
 
 -- | Arbitrary Script with random script ops
-newtype ArbitraryScript = ArbitraryScript Script
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryScript where
-    arbitrary = do
-        vs <- arbitrary
-        return $ ArbitraryScript $ Script $ map f vs
-      where
-        f (ArbitraryScriptOp op) = op
+arbitraryScript :: Gen Script
+arbitraryScript = Script <$> listOf arbitraryScriptOp
 
 -- | Arbitrary ScriptOp (push operations have random data)
-newtype ArbitraryScriptOp = ArbitraryScriptOp ScriptOp
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryScriptOp where
-    arbitrary = ArbitraryScriptOp <$> oneof
-        [ -- Pushing Data
-         arbitrary >>= \(ArbitraryNotNullByteString bs) ->
-            return $ opPushData bs
-        ,return OP_0
-        ,return OP_1NEGATE
-        ,return OP_RESERVED
-        ,return OP_1 , return OP_2 , return OP_3 , return OP_4
-        ,return OP_5 , return OP_6 , return OP_7 , return OP_8
-        ,return OP_9 , return OP_10, return OP_11, return OP_12
-        ,return OP_13, return OP_14, return OP_15, return OP_16
-
+arbitraryScriptOp :: Gen ScriptOp
+arbitraryScriptOp =
+    oneof
+          -- Pushing Data
+        [ opPushData <$> arbitraryBS1
+        , return OP_0
+        , return OP_1NEGATE
+        , return OP_RESERVED
+        , return OP_1
+        , return OP_2
+        , return OP_3
+        , return OP_4
+        , return OP_5
+        , return OP_6
+        , return OP_7
+        , return OP_8
+        , return OP_9
+        , return OP_10
+        , return OP_11
+        , return OP_12
+        , return OP_13
+        , return OP_14
+        , return OP_15
+        , return OP_16
         -- Flow control
-        ,return OP_NOP
-        ,return OP_VER
-        ,return OP_IF
-        ,return OP_NOTIF
-        ,return OP_VERIF
-        ,return OP_VERNOTIF
-        ,return OP_ELSE
-        ,return OP_ENDIF
-        ,return OP_VERIFY
-        ,return OP_RETURN
-
+        , return OP_NOP
+        , return OP_VER
+        , return OP_IF
+        , return OP_NOTIF
+        , return OP_VERIF
+        , return OP_VERNOTIF
+        , return OP_ELSE
+        , return OP_ENDIF
+        , return OP_VERIFY
+        , return OP_RETURN
         -- Stack operations
-        ,return OP_TOALTSTACK
-        ,return OP_FROMALTSTACK
-        ,return OP_IFDUP
-        ,return OP_DEPTH
-        ,return OP_DROP
-        ,return OP_DUP
-        ,return OP_NIP
-        ,return OP_OVER
-        ,return OP_PICK
-        ,return OP_ROLL
-        ,return OP_ROT
-        ,return OP_SWAP
-        ,return OP_TUCK
-        ,return OP_2DROP
-        ,return OP_2DUP
-        ,return OP_3DUP
-        ,return OP_2OVER
-        ,return OP_2ROT
-        ,return OP_2SWAP
-
+        , return OP_TOALTSTACK
+        , return OP_FROMALTSTACK
+        , return OP_IFDUP
+        , return OP_DEPTH
+        , return OP_DROP
+        , return OP_DUP
+        , return OP_NIP
+        , return OP_OVER
+        , return OP_PICK
+        , return OP_ROLL
+        , return OP_ROT
+        , return OP_SWAP
+        , return OP_TUCK
+        , return OP_2DROP
+        , return OP_2DUP
+        , return OP_3DUP
+        , return OP_2OVER
+        , return OP_2ROT
+        , return OP_2SWAP
         -- Splice
-        ,return OP_CAT
-        ,return OP_SUBSTR
-        ,return OP_LEFT
-        ,return OP_RIGHT
-        ,return OP_SIZE
-
+        , return OP_CAT
+        , return OP_SUBSTR
+        , return OP_LEFT
+        , return OP_RIGHT
+        , return OP_SIZE
         -- Bitwise logic
-        ,return OP_INVERT
-        ,return OP_AND
-        ,return OP_OR
-        ,return OP_XOR
-        ,return OP_EQUAL
-        ,return OP_EQUALVERIFY
-        ,return OP_RESERVED1
-        ,return OP_RESERVED2
-
+        , return OP_INVERT
+        , return OP_AND
+        , return OP_OR
+        , return OP_XOR
+        , return OP_EQUAL
+        , return OP_EQUALVERIFY
+        , return OP_RESERVED1
+        , return OP_RESERVED2
         -- Arithmetic
-        ,return OP_1ADD
-        ,return OP_1SUB
-        ,return OP_2MUL
-        ,return OP_2DIV
-        ,return OP_NEGATE
-        ,return OP_ABS
-        ,return OP_NOT
-        ,return OP_0NOTEQUAL
-        ,return OP_ADD
-        ,return OP_SUB
-        ,return OP_MUL
-        ,return OP_DIV
-        ,return OP_MOD
-        ,return OP_LSHIFT
-        ,return OP_RSHIFT
-        ,return OP_BOOLAND
-        ,return OP_BOOLOR
-        ,return OP_NUMEQUAL
-        ,return OP_NUMEQUALVERIFY
-        ,return OP_NUMNOTEQUAL
-        ,return OP_LESSTHAN
-        ,return OP_GREATERTHAN
-        ,return OP_LESSTHANOREQUAL
-        ,return OP_GREATERTHANOREQUAL
-        ,return OP_MIN
-        ,return OP_MAX
-        ,return OP_WITHIN
-
+        , return OP_1ADD
+        , return OP_1SUB
+        , return OP_2MUL
+        , return OP_2DIV
+        , return OP_NEGATE
+        , return OP_ABS
+        , return OP_NOT
+        , return OP_0NOTEQUAL
+        , return OP_ADD
+        , return OP_SUB
+        , return OP_MUL
+        , return OP_DIV
+        , return OP_MOD
+        , return OP_LSHIFT
+        , return OP_RSHIFT
+        , return OP_BOOLAND
+        , return OP_BOOLOR
+        , return OP_NUMEQUAL
+        , return OP_NUMEQUALVERIFY
+        , return OP_NUMNOTEQUAL
+        , return OP_LESSTHAN
+        , return OP_GREATERTHAN
+        , return OP_LESSTHANOREQUAL
+        , return OP_GREATERTHANOREQUAL
+        , return OP_MIN
+        , return OP_MAX
+        , return OP_WITHIN
         -- Crypto
-        ,return OP_RIPEMD160
-        ,return OP_SHA1
-        ,return OP_SHA256
-        ,return OP_HASH160
-        ,return OP_HASH256
-        ,return OP_CODESEPARATOR
-        ,return OP_CHECKSIG
-        ,return OP_CHECKSIGVERIFY
-        ,return OP_CHECKMULTISIG
-        ,return OP_CHECKMULTISIGVERIFY
-
+        , return OP_RIPEMD160
+        , return OP_SHA1
+        , return OP_SHA256
+        , return OP_HASH160
+        , return OP_HASH256
+        , return OP_CODESEPARATOR
+        , return OP_CHECKSIG
+        , return OP_CHECKSIGVERIFY
+        , return OP_CHECKMULTISIG
+        , return OP_CHECKMULTISIGVERIFY
         -- Expansion
-        ,return OP_NOP1, return OP_NOP2
-        ,return OP_NOP3, return OP_NOP4
-        ,return OP_NOP5, return OP_NOP6
-        ,return OP_NOP7, return OP_NOP8
-        ,return OP_NOP9, return OP_NOP10
-
+        , return OP_NOP1
+        , return OP_NOP2
+        , return OP_NOP3
+        , return OP_NOP4
+        , return OP_NOP5
+        , return OP_NOP6
+        , return OP_NOP7
+        , return OP_NOP8
+        , return OP_NOP9
+        , return OP_NOP10
         -- Other
-        ,return OP_PUBKEYHASH
-        ,return OP_PUBKEY
-        ,return $ OP_INVALIDOPCODE 0xff
+        , return OP_PUBKEYHASH
+        , return OP_PUBKEY
+        , return $ OP_INVALIDOPCODE 0xff
         ]
 
 -- | Arbtirary ScriptOp with a value in [OP_1 .. OP_16]
-newtype ArbitraryIntScriptOp = ArbitraryIntScriptOp ScriptOp
-    deriving (Eq, Show)
-
-instance Arbitrary ArbitraryIntScriptOp where
-    arbitrary = ArbitraryIntScriptOp <$> elements
+arbitraryIntScriptOp :: Gen ScriptOp
+arbitraryIntScriptOp =
+    elements
         [ OP_1,  OP_2,  OP_3,  OP_4
         , OP_5,  OP_6,  OP_7,  OP_8
         , OP_9,  OP_10, OP_11, OP_12
@@ -188,36 +154,25 @@ instance Arbitrary ArbitraryIntScriptOp where
         ]
 
 -- | Arbitrary PushDataType
-newtype ArbitraryPushDataType = ArbitraryPushDataType PushDataType
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPushDataType where
-    arbitrary = ArbitraryPushDataType <$> elements
-        [ OPCODE, OPDATA1, OPDATA2, OPDATA4 ]
+arbitraryPushDataType :: Gen PushDataType
+arbitraryPushDataType = elements [OPCODE, OPDATA1, OPDATA2, OPDATA4]
 
 -- | Arbitrary SigHash (including invalid/unknown sighash codes)
-newtype ArbitrarySigHash = ArbitrarySigHash SigHash
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitrarySigHash where
-    arbitrary = ArbitrarySigHash <$> oneof
-        [ SigAll    <$> arbitrary
-        , SigNone   <$> arbitrary
+arbitrarySigHash :: Gen SigHash
+arbitrarySigHash =
+    oneof
+        [ SigAll <$> arbitrary
+        , SigNone <$> arbitrary
         , SigSingle <$> arbitrary
-        , f
+          -- avoid valid SigHash bytes
+        , do w <- elements $ 0x00 : 0x80 : [0x04 .. 0x7f] ++ [0x84 .. 0xff]
+             return $ SigUnknown (testBit w 7) w
         ]
-      where
-        f = do
-            -- avoid valid SigHash bytes
-            w <- elements $ 0x00 : 0x80 : [0x04..0x7f] ++ [0x84..0xff]
-            return $ SigUnknown (testBit w 7) w
 
 -- | Arbitrary valid SigHash
-newtype ArbitraryValidSigHash = ArbitraryValidSigHash SigHash
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryValidSigHash where
-    arbitrary = ArbitraryValidSigHash <$> oneof
+arbitraryValidSigHash :: Gen SigHash
+arbitraryValidSigHash =
+    oneof
         [ SigAll    <$> arbitrary
         , SigNone   <$> arbitrary
         , SigSingle <$> arbitrary
@@ -226,198 +181,129 @@ instance Arbitrary ArbitraryValidSigHash where
 -- | Arbitrary message hash, private key and corresponding TxSignature. The
 -- signature is generated deterministically using a random message and a
 -- random private key.
-data ArbitraryTxSignature =
-    ArbitraryTxSignature TxHash PrvKey TxSignature
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryTxSignature where
-    arbitrary = do
-        ArbitrarySignature msg key sig <- arbitrary
-        ArbitrarySigHash sh <- arbitrary
-        let txsig = TxSignature sig sh
-        return $ ArbitraryTxSignature (TxHash msg) key txsig
+arbitraryTxSignature :: Gen (TxHash, PrvKey, TxSignature)
+arbitraryTxSignature = do
+    (msg, key, sig) <- arbitrarySignature
+    sh <- arbitrarySigHash
+    let txsig = TxSignature sig sh
+    return (TxHash msg, key, txsig)
 
 -- | Arbitrary m of n parameters
-data ArbitraryMSParam = ArbitraryMSParam Int Int
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryMSParam where
-    arbitrary = do
-        m <- choose (1,16)
-        n <- choose (m,16)
-        return $ ArbitraryMSParam m n
+arbitraryMSParam :: Gen (Int, Int)
+arbitraryMSParam = do
+    m <- choose (1,16)
+    n <- choose (m,16)
+    return (m, n)
 
 -- | Arbitrary ScriptOutput (Can by any valid type)
-newtype ArbitraryScriptOutput = ArbitraryScriptOutput ScriptOutput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryScriptOutput where
-    arbitrary = ArbitraryScriptOutput <$> oneof
-        [ arbitrary >>= \(ArbitraryPKOutput o) -> return o
-        , arbitrary >>= \(ArbitraryPKHashOutput o) -> return o
-        , arbitrary >>= \(ArbitraryMSOutput o) -> return o
-        , arbitrary >>= \(ArbitrarySHOutput o) -> return o
-        , arbitrary >>= \(ArbitraryDCOutput o) -> return o
+arbitraryScriptOutput :: Gen ScriptOutput
+arbitraryScriptOutput = 
+    oneof
+        [ arbitraryPKOutput
+        , arbitraryPKHashOutput
+        , arbitraryMSOutput
+        , arbitrarySHOutput
+        , arbitraryDCOutput
         ]
 
 -- | Arbitrary ScriptOutput of type PayPK, PayPKHash or PayMS
 -- (Not PayScriptHash or DataCarrier)
-newtype ArbitrarySimpleOutput = ArbitrarySimpleOutput ScriptOutput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitrarySimpleOutput where
-    arbitrary = ArbitrarySimpleOutput <$> oneof
-        [ arbitrary >>= \(ArbitraryPKOutput o) -> return o
-        , arbitrary >>= \(ArbitraryPKHashOutput o) -> return o
-        , arbitrary >>= \(ArbitraryMSOutput o) -> return o
+arbitrarySimpleOutput ::Gen ScriptOutput
+arbitrarySimpleOutput =
+    oneof
+        [ arbitraryPKOutput
+        , arbitraryPKHashOutput
+        , arbitraryMSOutput
         ]
 
 -- | Arbitrary ScriptOutput of type PayPK
-newtype ArbitraryPKOutput = ArbitraryPKOutput ScriptOutput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPKOutput where
-    arbitrary = do
-        ArbitraryPubKey _ key <- arbitrary
-        return $ ArbitraryPKOutput $ PayPK key
+arbitraryPKOutput :: Gen ScriptOutput
+arbitraryPKOutput =  PayPK . snd <$> arbitraryPubKey
 
 -- | Arbitrary ScriptOutput of type PayPKHash
-newtype ArbitraryPKHashOutput = ArbitraryPKHashOutput ScriptOutput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPKHashOutput where
-    arbitrary = do
-        ArbitraryPubKeyAddress a <- arbitrary
-        return $ ArbitraryPKHashOutput $ PayPKHash a
+arbitraryPKHashOutput :: Gen ScriptOutput
+arbitraryPKHashOutput = PayPKHash <$> arbitraryPubKeyAddress
 
 -- | Arbitrary ScriptOutput of type PayMS
-newtype ArbitraryMSOutput = ArbitraryMSOutput ScriptOutput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryMSOutput where
-    arbitrary = do
-        ArbitraryMSParam m n <- arbitrary
-        keys <- map f <$> vectorOf n arbitrary
-        return $ ArbitraryMSOutput $ PayMulSig keys m
-      where
-        f (ArbitraryPubKey _ key) = key
+arbitraryMSOutput :: Gen ScriptOutput
+arbitraryMSOutput = do
+    (m, n) <- arbitraryMSParam
+    keys <- map snd <$> vectorOf n arbitraryPubKey
+    return $ PayMulSig keys m
 
 -- | Arbitrary ScriptOutput of type PayMS containing only compressed keys
-newtype ArbitraryMSCOutput = ArbitraryMSCOutput ScriptOutput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryMSCOutput where
-    arbitrary = do
-        ArbitraryMSParam m n <- arbitrary
-        keys <- map f <$> vectorOf n arbitrary
-        return $ ArbitraryMSCOutput $ PayMulSig keys m
-      where
-        f (ArbitraryPubKeyC _ key) = toPubKeyG key
+arbitraryMSCOutput :: Gen ScriptOutput
+arbitraryMSCOutput = do
+    (m, n) <- arbitraryMSParam
+    keys <- map (toPubKeyG . snd) <$> vectorOf n arbitraryPubKeyC
+    return $ PayMulSig keys m
 
 -- | Arbitrary ScriptOutput of type PayScriptHash
-newtype ArbitrarySHOutput = ArbitrarySHOutput ScriptOutput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitrarySHOutput where
-    arbitrary = do
-        ArbitraryScriptAddress a <- arbitrary
-        return $ ArbitrarySHOutput $ PayScriptHash a
+arbitrarySHOutput :: Gen ScriptOutput
+arbitrarySHOutput = PayScriptHash <$> arbitraryScriptAddress
 
 -- | Arbitrary ScriptOutput of type DataCarrier
-newtype ArbitraryDCOutput = ArbitraryDCOutput ScriptOutput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryDCOutput where
-    arbitrary = do
-        ArbitraryNotNullByteString bs <- arbitrary
-        return $ ArbitraryDCOutput $ DataCarrier bs
+arbitraryDCOutput :: Gen ScriptOutput
+arbitraryDCOutput = DataCarrier <$> arbitraryBS1
 
 -- | Arbitrary ScriptInput
-newtype ArbitraryScriptInput = ArbitraryScriptInput ScriptInput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryScriptInput where
-    arbitrary = ArbitraryScriptInput <$> oneof
-        [ arbitrary >>= \(ArbitraryPKInput i) -> return i
-        , arbitrary >>= \(ArbitraryPKHashInput i) -> return i
-        , arbitrary >>= \(ArbitraryMSInput i) -> return i
-        , arbitrary >>= \(ArbitrarySHInput i) -> return i
+arbitraryScriptInput :: Gen ScriptInput
+arbitraryScriptInput =
+    oneof
+        [ arbitraryPKInput
+        , arbitraryPKHashInput
+        , arbitraryMSInput
+        , arbitrarySHInput
         ]
 
 -- | Arbitrary ScriptInput of type SpendPK, SpendPKHash or SpendMulSig
 -- (not ScriptHashInput)
-newtype ArbitrarySimpleInput = ArbitrarySimpleInput ScriptInput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitrarySimpleInput where
-    arbitrary = ArbitrarySimpleInput <$> oneof
-        [ arbitrary >>= \(ArbitraryPKInput i) -> return i
-        , arbitrary >>= \(ArbitraryPKHashInput i) -> return i
-        , arbitrary >>= \(ArbitraryMSInput i) -> return i
+arbitrarySimpleInput :: Gen ScriptInput
+arbitrarySimpleInput =
+    oneof
+        [ arbitraryPKInput
+        , arbitraryPKHashInput
+        , arbitraryMSInput
         ]
 
 -- | Arbitrary ScriptInput of type SpendPK
-newtype ArbitraryPKInput = ArbitraryPKInput ScriptInput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPKInput where
-    arbitrary = ArbitraryPKInput . RegularInput . SpendPK <$>
-        (arbitrary >>= \(ArbitraryTxSignature _ _ sig) -> return sig)
+arbitraryPKInput :: Gen ScriptInput
+arbitraryPKInput = RegularInput . SpendPK . lst3 <$> arbitraryTxSignature
 
 -- | Arbitrary ScriptInput of type SpendPK
-newtype ArbitraryPKHashInput = ArbitraryPKHashInput ScriptInput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPKHashInput where
-    arbitrary = do
-        sig <- arbitrary >>= \(ArbitraryTxSignature _ _ sig) -> return sig
-        ArbitraryPubKey _ key <- arbitrary
-        return $ ArbitraryPKHashInput $ RegularInput $ SpendPKHash sig key
+arbitraryPKHashInput :: Gen ScriptInput
+arbitraryPKHashInput = do
+    sig <- lst3 <$> arbitraryTxSignature
+    key <- snd <$> arbitraryPubKey
+    return $ RegularInput $ SpendPKHash sig key
 
 -- | Arbitrary ScriptInput of type SpendPK with a compressed public key
-newtype ArbitraryPKHashCInput = ArbitraryPKHashCInput ScriptInput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPKHashCInput where
-    arbitrary = do
-        sig <- arbitrary >>= \(ArbitraryTxSignature _ _ sig) -> return sig
-        ArbitraryPubKeyC _ key <- arbitrary
-        return $ ArbitraryPKHashCInput $ RegularInput $
-            SpendPKHash sig $ toPubKeyG key
+arbitraryPKHashCInput :: Gen ScriptInput
+arbitraryPKHashCInput = do
+    sig <- lst3 <$> arbitraryTxSignature
+    key <- snd <$> arbitraryPubKeyC
+    return $ RegularInput $ SpendPKHash sig $ toPubKeyG key
 
 -- | Arbitrary ScriptInput of type SpendMulSig
-newtype ArbitraryMSInput = ArbitraryMSInput ScriptInput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryMSInput where
-    arbitrary = do
-        ArbitraryMSParam m _ <- arbitrary
-        sigs <- vectorOf m f
-        return $ ArbitraryMSInput $ RegularInput $ SpendMulSig sigs
-      where
-        f = arbitrary >>= \(ArbitraryTxSignature _ _ sig) -> return sig
+arbitraryMSInput :: Gen ScriptInput
+arbitraryMSInput = do
+    m    <- fst <$> arbitraryMSParam
+    sigs <- map lst3 <$> vectorOf m arbitraryTxSignature
+    return $ RegularInput $ SpendMulSig sigs
 
 -- | Arbitrary ScriptInput of type ScriptHashInput
-newtype ArbitrarySHInput = ArbitrarySHInput ScriptInput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitrarySHInput where
-    arbitrary = do
-        ArbitrarySimpleInput i <- arbitrary
-        ArbitrarySimpleOutput o <- arbitrary
-        return $ ArbitrarySHInput $ ScriptHashInput (getRegularInput i) o
+arbitrarySHInput :: Gen ScriptInput
+arbitrarySHInput = do
+    i <- arbitrarySimpleInput
+    o <- arbitrarySimpleOutput
+    return $ ScriptHashInput (getRegularInput i) o
 
 -- | Arbitrary ScriptInput of type ScriptHashInput containing a RedeemScript
 -- of type PayMulSig and an input of type SpendMulSig. Only compressed keys
 -- are used.
-newtype ArbitraryMulSigSHCInput = ArbitraryMulSigSHCInput ScriptInput
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryMulSigSHCInput where
-    arbitrary = do
-        ArbitraryMSCOutput rdm@(PayMulSig _ m) <- arbitrary
-        sigs <- vectorOf m f
-        return $ ArbitraryMulSigSHCInput $ ScriptHashInput (SpendMulSig sigs) rdm
-      where
-        f = arbitrary >>= \(ArbitraryTxSignature _ _ sig) -> return sig
+arbitraryMulSigSHCInput :: Gen ScriptInput
+arbitraryMulSigSHCInput = do
+    rdm@(PayMulSig _ m) <- arbitraryMSCOutput
+    sigs <- map lst3 <$> vectorOf m arbitraryTxSignature
+    return $ ScriptHashInput (SpendMulSig sigs) rdm
 

--- a/haskoin-core/Network/Haskoin/Test/Transaction.hs
+++ b/haskoin-core/Network/Haskoin/Test/Transaction.hs
@@ -1,292 +1,198 @@
 {-|
   Arbitrary types for Network.Haskoin.Transaction
 -}
-module Network.Haskoin.Test.Transaction
-( ArbitrarySatoshi(..)
-, ArbitraryTx(..)
-, ArbitraryTxHash(..)
-, ArbitraryTxIn(..)
-, ArbitraryTxOut(..)
-, ArbitraryOutPoint(..)
-, ArbitraryAddrOnlyTx(..)
-, ArbitraryAddrOnlyTxIn(..)
-, ArbitraryAddrOnlyTxOut(..)
-, ArbitrarySigInput(..)
-, ArbitraryPKSigInput(..)
-, ArbitraryPKHashSigInput(..)
-, ArbitraryMSSigInput(..)
-, ArbitrarySHSigInput(..)
-, ArbitrarySigningData(..)
-, ArbitraryPartialTxs(..)
-) where
+module Network.Haskoin.Test.Transaction where
 
-import Test.QuickCheck
-    ( Arbitrary
-    , arbitrary
-    , vectorOf
-    , oneof
-    , choose
-    , elements
-    )
+import           Control.Monad
+import qualified Data.ByteString             as BS
+import           Data.List                   (nub, nubBy, permutations)
+import           Data.Word                   (Word64)
+import           Network.Haskoin.Constants
+import           Network.Haskoin.Crypto
+import           Network.Haskoin.Script
+import           Network.Haskoin.Test.Crypto
+import           Network.Haskoin.Test.Script
+import           Network.Haskoin.Transaction
+import           Network.Haskoin.Util
+import           Test.QuickCheck
 
-import Control.Monad (forM)
+newtype TestCoin = TestCoin { getTestCoin :: Word64 }
+    deriving (Eq, Show)
 
-import Data.Word (Word64)
-import Data.List (permutations, nubBy, nub)
-import qualified Data.ByteString as BS (empty)
+instance Coin TestCoin where
+    coinValue = getTestCoin
 
-import Network.Haskoin.Test.Crypto
-import Network.Haskoin.Test.Script
-
-import Network.Haskoin.Transaction
-import Network.Haskoin.Script
-import Network.Haskoin.Crypto
-import Network.Haskoin.Constants
-import Network.Haskoin.Util
-
-newtype ArbitraryTxHash = ArbitraryTxHash TxHash
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryTxHash where
-    arbitrary = do
-        ArbitraryHash256 h <- arbitrary
-        return $ ArbitraryTxHash $ TxHash h
+arbitraryTxHash :: Gen TxHash
+arbitraryTxHash = TxHash <$> arbitraryHash256
 
 -- | Arbitrary amount of Satoshi as Word64 (Between 1 and 21e14)
-newtype ArbitrarySatoshi = ArbitrarySatoshi Word64
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitrarySatoshi where
-    arbitrary = ArbitrarySatoshi <$> choose (1, maxSatoshi)
-
-instance Coin ArbitrarySatoshi where
-    coinValue (ArbitrarySatoshi v) = v
+arbitrarySatoshi :: Gen TestCoin
+arbitrarySatoshi = TestCoin <$> choose (1, maxSatoshi)
 
 -- | Arbitrary OutPoint
-newtype ArbitraryOutPoint = ArbitraryOutPoint OutPoint
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryOutPoint where
-    arbitrary = do
-        op <- do
-            ArbitraryTxHash tx <- arbitrary
-            i  <- arbitrary
-            return $ OutPoint tx i
-        return $ ArbitraryOutPoint op
+arbitraryOutPoint :: Gen OutPoint
+arbitraryOutPoint = OutPoint <$> arbitraryTxHash <*> arbitrary
 
 -- | Arbitrary TxOut
-newtype ArbitraryTxOut = ArbitraryTxOut TxOut
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryTxOut where
-    arbitrary = do
-        ArbitrarySatoshi v <- arbitrary
-        ArbitraryScriptOutput out <- arbitrary
-        return $ ArbitraryTxOut $ TxOut v $ encodeOutputBS out
+arbitraryTxOut :: Gen TxOut
+arbitraryTxOut =
+    TxOut <$> (getTestCoin <$> arbitrarySatoshi)
+          <*> (encodeOutputBS <$> arbitraryScriptOutput)
 
 -- | Arbitrary TxIn
-newtype ArbitraryTxIn = ArbitraryTxIn TxIn
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryTxIn where
-    arbitrary = do
-        ArbitraryOutPoint o <- arbitrary
-        ArbitraryScriptInput inp <- arbitrary
-        s <- arbitrary
-        return $ ArbitraryTxIn $ TxIn o (encodeInputBS inp) s
+arbitraryTxIn :: Gen TxIn
+arbitraryTxIn =
+    TxIn <$> arbitraryOutPoint
+         <*> (encodeInputBS <$> arbitraryScriptInput)
+         <*> arbitrary
 
 -- | Arbitrary Tx
-newtype ArbitraryTx = ArbitraryTx Tx
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryTx where
-    arbitrary = do
-        v <- arbitrary
-        ni <- choose (0,5)
-        no <- choose (0,5)
-        inps <- vectorOf ni $ arbitrary >>= \(ArbitraryTxIn i) -> return i
-        outs <- vectorOf no $ arbitrary >>= \(ArbitraryTxOut o) -> return o
-        let uniqueInps = nubBy (\a b -> prevOutput a == prevOutput b) inps
-        t <- arbitrary
-        return $ ArbitraryTx $ createTx v uniqueInps outs t
+arbitraryTx :: Gen Tx
+arbitraryTx = do
+    v    <- arbitrary
+    ni   <- choose (0,5)
+    no   <- choose (0,5)
+    inps <- vectorOf ni arbitraryTxIn
+    outs <- vectorOf no arbitraryTxOut
+    let uniqueInps = nubBy (\a b -> prevOutput a == prevOutput b) inps
+    t    <- arbitrary
+    return $ createTx v uniqueInps outs t
 
 -- | Arbitrary Tx containing only inputs of type SpendPKHash, SpendScriptHash
 -- (multisig) and outputs of type PayPKHash and PaySH. Only compressed
 -- public keys are used.
-newtype ArbitraryAddrOnlyTx = ArbitraryAddrOnlyTx Tx
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryAddrOnlyTx where
-    arbitrary = do
-        v <- arbitrary
-        ni <- choose (0,5)
-        no <- choose (0,5)
-        inps <- vectorOf ni $
-            arbitrary >>= \(ArbitraryAddrOnlyTxIn i) -> return i
-        outs <- vectorOf no $
-            arbitrary >>= \(ArbitraryAddrOnlyTxOut o) -> return o
-        t <- arbitrary
-        return $ ArbitraryAddrOnlyTx $ createTx v inps outs t
+arbitraryAddrOnlyTx :: Gen Tx
+arbitraryAddrOnlyTx = do
+    v    <- arbitrary
+    ni   <- choose (0,5)
+    no   <- choose (0,5)
+    inps <- vectorOf ni arbitraryAddrOnlyTxIn
+    outs <- vectorOf no arbitraryAddrOnlyTxOut
+    t    <- arbitrary
+    return $ createTx v inps outs t
 
 -- | Arbitrary TxIn that can only be of type SpendPKHash or
 -- SpendScriptHash (multisig). Only compressed public keys are used.
-newtype ArbitraryAddrOnlyTxIn = ArbitraryAddrOnlyTxIn TxIn
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryAddrOnlyTxIn where
-    arbitrary = do
-        ArbitraryOutPoint o <- arbitrary
-        inp <- oneof
-            [ arbitrary >>= \(ArbitraryPKHashCInput i) -> return i
-            , arbitrary >>= \(ArbitraryMulSigSHCInput i) -> return i
-            ]
-        s <- arbitrary
-        return $ ArbitraryAddrOnlyTxIn $ TxIn o (encodeInputBS inp) s
+arbitraryAddrOnlyTxIn :: Gen TxIn
+arbitraryAddrOnlyTxIn = do
+    o   <- arbitraryOutPoint
+    inp <- oneof [ arbitraryPKHashCInput, arbitraryMulSigSHCInput ]
+    s   <- arbitrary
+    return $ TxIn o (encodeInputBS inp) s
 
 -- | Arbitrary TxOut that can only be of type PayPKHash or PaySH
-newtype ArbitraryAddrOnlyTxOut = ArbitraryAddrOnlyTxOut TxOut
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryAddrOnlyTxOut where
-    arbitrary = do
-        ArbitrarySatoshi v <- arbitrary
-        out <- oneof
-            [ arbitrary >>= \(ArbitraryPKHashOutput o) -> return o
-            , arbitrary >>= \(ArbitrarySHOutput o) -> return o
-            ]
-        return $ ArbitraryAddrOnlyTxOut $ TxOut v $ encodeOutputBS out
+arbitraryAddrOnlyTxOut :: Gen TxOut
+arbitraryAddrOnlyTxOut = do
+    v <- getTestCoin <$> arbitrarySatoshi
+    out <- oneof [ arbitraryPKHashOutput, arbitrarySHOutput ]
+    return $ TxOut v $ encodeOutputBS out
 
 -- | Arbitrary SigInput with the corresponding private keys used
 -- to generate the ScriptOutput or RedeemScript
-data ArbitrarySigInput = ArbitrarySigInput SigInput [PrvKey]
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitrarySigInput where
-    arbitrary = do
-        (si, ks) <- oneof
-            [ arbitrary >>= \(ArbitraryPKSigInput si k) -> return (si, [k])
-            , arbitrary >>= \(ArbitraryPKHashSigInput si k) -> return (si, [k])
-            , arbitrary >>= \(ArbitraryMSSigInput si ks) -> return (si, ks)
-            , arbitrary >>= \(ArbitrarySHSigInput si ks) -> return (si, ks)
-            ]
-        return $ ArbitrarySigInput si ks
+arbitrarySigInput :: Gen (SigInput, [PrvKey])
+arbitrarySigInput =
+    oneof
+        [ arbitraryPKSigInput >>= \(si, k) -> return (si, [k])
+        , arbitraryPKHashSigInput  >>= \(si, k) -> return (si, [k])
+        , arbitraryMSSigInput
+        , arbitrarySHSigInput
+        ]
 
 -- | Arbitrary SigInput with a ScriptOutput of type PayPK
-data ArbitraryPKSigInput = ArbitraryPKSigInput SigInput PrvKey
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPKSigInput where
-    arbitrary = do
-        ArbitraryPrvKey k <- arbitrary
-        let out = PayPK $ derivePubKey k
-        ArbitraryOutPoint op <- arbitrary
-        ArbitraryValidSigHash sh <- arbitrary
-        return $ ArbitraryPKSigInput (SigInput out op sh Nothing) k
+arbitraryPKSigInput :: Gen (SigInput, PrvKey)
+arbitraryPKSigInput = do
+    k <- arbitraryPrvKey
+    let out = PayPK $ derivePubKey k
+    op <- arbitraryOutPoint
+    sh <- arbitraryValidSigHash
+    return (SigInput out op sh Nothing, k)
 
 -- | Arbitrary SigInput with a ScriptOutput of type PayPKHash
-data ArbitraryPKHashSigInput = ArbitraryPKHashSigInput SigInput PrvKey
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPKHashSigInput where
-    arbitrary = do
-        ArbitraryPrvKey k <- arbitrary
-        let out = PayPKHash $ pubKeyAddr $ derivePubKey k
-        ArbitraryOutPoint op <- arbitrary
-        ArbitraryValidSigHash sh <- arbitrary
-        return $ ArbitraryPKHashSigInput (SigInput out op sh Nothing) k
+arbitraryPKHashSigInput :: Gen (SigInput, PrvKey)
+arbitraryPKHashSigInput = do
+    k <- arbitraryPrvKey
+    let out = PayPKHash $ pubKeyAddr $ derivePubKey k
+    op <- arbitraryOutPoint
+    sh <- arbitraryValidSigHash
+    return (SigInput out op sh Nothing, k)
 
 -- | Arbitrary SigInput with a ScriptOutput of type PayMulSig
-data ArbitraryMSSigInput = ArbitraryMSSigInput SigInput [PrvKey]
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryMSSigInput where
-    arbitrary = do
-        ArbitraryMSParam m n <- arbitrary
-        ks <- map (\(ArbitraryPrvKey k) -> k) <$> vectorOf n arbitrary
-        let out = PayMulSig (map derivePubKey ks) m
-        ArbitraryOutPoint op <- arbitrary
-        ArbitraryValidSigHash sh <- arbitrary
-        perm <- choose (0,n-1)
-        let ksPerm = take m $ permutations ks !! perm
-        return $ ArbitraryMSSigInput (SigInput out op sh Nothing) ksPerm
+arbitraryMSSigInput :: Gen (SigInput, [PrvKey])
+arbitraryMSSigInput = do
+    (m,n) <- arbitraryMSParam
+    ks    <- vectorOf n arbitraryPrvKey
+    let out = PayMulSig (map derivePubKey ks) m
+    op <- arbitraryOutPoint
+    sh <- arbitraryValidSigHash
+    perm <- choose (0,n-1)
+    let ksPerm = take m $ permutations ks !! perm
+    return (SigInput out op sh Nothing, ksPerm)
 
 -- | Arbitrary SigInput with  ScriptOutput of type PaySH and a RedeemScript
-data ArbitrarySHSigInput = ArbitrarySHSigInput SigInput [PrvKey]
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitrarySHSigInput where
-    arbitrary = do
-        (rdm, ks, op, sh) <- oneof
-            [ a <$> arbitrary, b <$> arbitrary, c <$> arbitrary ]
-        let out = PayScriptHash $ scriptAddr rdm
-        return $ ArbitrarySHSigInput (SigInput out op sh $ Just rdm) ks
-      where
-        a (ArbitraryPKSigInput (SigInput o op sh _) k) = (o, [k], op, sh)
-        b (ArbitraryPKHashSigInput (SigInput o op sh _) k) = (o, [k], op, sh)
-        c (ArbitraryMSSigInput (SigInput o op sh _) ks) = (o, ks, op, sh)
+arbitrarySHSigInput :: Gen (SigInput, [PrvKey])
+arbitrarySHSigInput = do
+    (SigInput rdm op sh _, ks) <- oneof
+        [ f <$> arbitraryPKSigInput
+        , f <$> arbitraryPKHashSigInput
+        , arbitraryMSSigInput
+        ]
+    let out = PayScriptHash $ scriptAddr rdm
+    return (SigInput out op sh $ Just rdm, ks)
+  where
+    f (si, k) = (si, [k])
 
 -- | Arbitrary Tx (empty TxIn), SigInputs and PrvKeys that can be passed to
 -- signTx or detSignTx to fully sign the Tx.
-data ArbitrarySigningData = ArbitrarySigningData Tx [SigInput] [PrvKey]
-    deriving (Eq, Show, Read)
+arbitrarySigningData :: Gen (Tx, [SigInput], [PrvKey])
+arbitrarySigningData = do
+    v  <- arbitrary
+    ni <- choose (1,5)
+    no <- choose (1,5)
+    sigis <- vectorOf ni arbitrarySigInput
+    let uSigis = nubBy (\(a,_) (b,_) -> sigDataOP a == sigDataOP b) sigis
+    inps <- forM uSigis $ \(s,_) -> do
+        sq <- arbitrary
+        return $ TxIn (sigDataOP s) BS.empty sq
+    outs <- vectorOf no arbitraryTxOut
+    l    <- arbitrary
+    perm <- choose (0, length inps - 1)
+    let tx   = createTx v (permutations inps !! perm) outs l
+        keys = concatMap snd uSigis
+    return (tx, map fst uSigis, keys)
 
-instance Arbitrary ArbitrarySigningData where
-    arbitrary = do
-        v <- arbitrary
-        ni <- choose (1,5)
-        no <- choose (1,5)
-        sigis <- map f <$> vectorOf ni arbitrary
-        let uSigis = nubBy (\(a,_) (b,_) -> sigDataOP a == sigDataOP b) sigis
-        inps <- forM uSigis $ \(s,_) -> do
-            sq <- arbitrary
-            return $ TxIn (sigDataOP s) BS.empty sq
-        outs <- map (\(ArbitraryTxOut o) -> o) <$> vectorOf no arbitrary
-        l <- arbitrary
-        perm <- choose (0, length inps - 1)
-        let tx   = createTx v (permutations inps !! perm) outs l
-            keys = concat $ map snd uSigis
-        return $ ArbitrarySigningData tx (map fst uSigis) keys
-      where
-        f (ArbitrarySigInput s ks) = (s,ks)
+arbitraryEmptyTx :: Gen Tx
+arbitraryEmptyTx = do
+    v    <- arbitrary
+    no   <- choose (1,5)
+    ni   <- choose (1,5)
+    outs <- vectorOf no arbitraryTxOut
+    ops  <- vectorOf ni arbitraryOutPoint
+    t    <- arbitrary
+    s    <- arbitrary
+    return $ createTx v (map (\op -> TxIn op BS.empty s) (nub ops)) outs t
 
-data ArbitraryPartialTxs =
-    ArbitraryPartialTxs [Tx] [(ScriptOutput, OutPoint, Int, Int)]
-    deriving (Eq, Show, Read)
-
-instance Arbitrary ArbitraryPartialTxs where
-    arbitrary = do
-        tx <- arbitraryEmptyTx
-        res <- forM (map prevOutput $ txIn tx) $ \op -> do
-            (so, rdmM, prvs, m, n) <- arbitraryData
-            txs <- mapM (singleSig so rdmM tx op) prvs
-            return (txs, (so, op, m, n))
-        return $ ArbitraryPartialTxs (concat $ map fst res) (map snd res)
-      where
-        singleSig so rdmM tx op prv = do
-            ArbitraryValidSigHash sh <- arbitrary
-            let sigi = SigInput so op sh rdmM
-            return $ fromRight $ signTx tx [sigi] [prv]
-        arbitraryData = do
-            ArbitraryMSParam m n <- arbitrary
-            nPrv <- choose (m,n)
-            keys <- vectorOf n $
-                (\(ArbitraryPubKey k p) -> (k, p)) <$> arbitrary
-            perm <- choose (0, length keys - 1)
-            let pubKeys = map snd keys
-                prvKeys = take nPrv $ permutations (map fst keys) !! perm
-            let so = PayMulSig pubKeys m
-            elements [ (so, Nothing, prvKeys, m, n)
-                     , (PayScriptHash $ scriptAddr so, Just so, prvKeys, m, n)
-                     ]
-        arbitraryEmptyTx = do
-            v <- arbitrary
-            no <- choose (1,5)
-            ni <- choose (1,5)
-            outs <- vectorOf no $ (\(ArbitraryTxOut o) -> o) <$> arbitrary
-            ops <- vectorOf ni $ (\(ArbitraryOutPoint op) -> op) <$> arbitrary
-            t <- arbitrary
-            s <- arbitrary
-            return $ createTx
-                v (map (\op -> TxIn op BS.empty s) (nub ops)) outs t
-
+arbitraryPartialTxs :: Gen ([Tx], [(ScriptOutput, OutPoint, Int, Int)])
+arbitraryPartialTxs = do
+    tx <- arbitraryEmptyTx
+    res <- forM (map prevOutput $ txIn tx) $ \op -> do
+        (so, rdmM, prvs, m, n) <- arbitraryData
+        txs <- mapM (singleSig so rdmM tx op) prvs
+        return (txs, (so, op, m, n))
+    return (concatMap fst res, map snd res)
+  where
+    singleSig so rdmM tx op prv = do
+        sh <- arbitraryValidSigHash
+        let sigi = SigInput so op sh rdmM
+        return $ fromRight $ signTx tx [sigi] [prv]
+    arbitraryData = do
+        (m,n) <- arbitraryMSParam
+        nPrv  <- choose (m,n)
+        keys  <- vectorOf n arbitraryPubKey
+        perm <- choose (0, length keys - 1)
+        let pubKeys = map snd keys
+            prvKeys = take nPrv $ permutations (map fst keys) !! perm
+        let so = PayMulSig pubKeys m
+        elements [ (so, Nothing, prvKeys, m, n)
+                 , (PayScriptHash $ scriptAddr so, Just so, prvKeys, m, n)
+                 ]
 

--- a/haskoin-core/tests/Main.hs
+++ b/haskoin-core/tests/Main.hs
@@ -1,43 +1,44 @@
 module Main where
 
-import Test.Framework (defaultMain)
+import           Test.Framework                            (defaultMain)
 
 -- Util tests
-import qualified Network.Haskoin.Util.Tests (tests)
+import qualified Network.Haskoin.Util.Tests                (tests)
 
 -- Crypto tests
-import qualified Network.Haskoin.Crypto.ECDSA.Tests (tests)
-import qualified Network.Haskoin.Crypto.Base58.Tests (tests)
-import qualified Network.Haskoin.Crypto.Base58.Units (tests)
-import qualified Network.Haskoin.Crypto.Keys.Tests (tests)
+import qualified Network.Haskoin.Crypto.Base58.Tests       (tests)
+import qualified Network.Haskoin.Crypto.Base58.Units       (tests)
+import qualified Network.Haskoin.Crypto.ECDSA.Tests        (tests)
 import qualified Network.Haskoin.Crypto.ExtendedKeys.Tests (tests)
 import qualified Network.Haskoin.Crypto.ExtendedKeys.Units (tests)
-import qualified Network.Haskoin.Crypto.Hash.Tests (tests)
-import qualified Network.Haskoin.Crypto.Hash.Units (tests)
-import qualified Network.Haskoin.Crypto.Mnemonic.Tests (tests)
-import qualified Network.Haskoin.Crypto.Mnemonic.Units (tests)
-import qualified Network.Haskoin.Crypto.Units (tests)
+import qualified Network.Haskoin.Crypto.Hash.Tests         (tests)
+import qualified Network.Haskoin.Crypto.Hash.Units         (tests)
+import qualified Network.Haskoin.Crypto.Keys.Tests         (tests)
+import qualified Network.Haskoin.Crypto.Mnemonic.Tests     (tests)
+import qualified Network.Haskoin.Crypto.Mnemonic.Units     (tests)
+import qualified Network.Haskoin.Crypto.Units              (tests)
 
 -- Node tests
-import qualified Network.Haskoin.Node.Units (tests)
+import qualified Network.Haskoin.Node.Units                (tests)
 
 -- Script tests
-import qualified Network.Haskoin.Script.Tests (tests)
-import qualified Network.Haskoin.Script.Units (tests)
+import qualified Network.Haskoin.Script.Tests              (tests)
+import qualified Network.Haskoin.Script.Units              (tests)
 
 -- Transaction tests
-import qualified Network.Haskoin.Transaction.Tests (tests)
-import qualified Network.Haskoin.Transaction.Units (tests, satoshiCoreTxTests)
+import qualified Network.Haskoin.Transaction.Tests         (tests)
+import qualified Network.Haskoin.Transaction.Units         (satoshiCoreTxTests,
+                                                            tests)
 
 -- Block tests
-import qualified Network.Haskoin.Block.Tests (tests)
-import qualified Network.Haskoin.Block.Units (tests)
+import qualified Network.Haskoin.Block.Tests               (tests)
+import qualified Network.Haskoin.Block.Units               (tests)
 
 -- Json tests
-import qualified Network.Haskoin.Json.Tests (tests)
+import qualified Network.Haskoin.Json.Tests                (tests)
 
 -- Binary tests
-import qualified Network.Haskoin.Cereal.Tests (tests)
+import qualified Network.Haskoin.Cereal.Tests              (tests)
 
 main :: IO ()
 main = do

--- a/haskoin-core/tests/Network/Haskoin/Cereal/Tests.hs
+++ b/haskoin-core/tests/Network/Haskoin/Cereal/Tests.hs
@@ -1,72 +1,72 @@
 module Network.Haskoin.Cereal.Tests (tests) where
 
-import Test.Framework (Test, testGroup)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
-
-import Data.Serialize (Serialize, decode, encode)
-
-import Network.Haskoin.Test
+import           Data.Serialize
+import           Network.Haskoin.Test
+import           Network.Haskoin.Util
+import           Test.Framework
+import           Test.Framework.Providers.QuickCheck2
+import           Test.QuickCheck
 
 tests :: [Test]
 tests =
     [ testGroup "Binary encoding and decoding of utility types"
-        [ testProperty "ByteString" $ \(ArbitraryByteString x) -> metaBinary x ]
+        [ testProperty "ByteString" $ forAll arbitraryBS testId ]
     , testGroup "Binary encoding and decoding of hash types"
-        [ testProperty "Hash160" $ \(ArbitraryHash160 x) -> metaBinary x
-        , testProperty "Hash256" $ \(ArbitraryHash256 x) -> metaBinary x
-        , testProperty "Hash512" $ \(ArbitraryHash512 x) -> metaBinary x
+        [ testProperty "Hash160" $ forAll arbitraryHash160 testId
+        , testProperty "Hash256" $ forAll arbitraryHash256 testId
+        , testProperty "Hash512" $ forAll arbitraryHash512 testId
         ]
     , testGroup "Binary encoding and decoding of crypto types"
-        [ testProperty "Signature" $ \(ArbitrarySignature _ _ x) -> metaBinary x
-        , testProperty "PubKey" $ \(ArbitraryPubKey _ x) -> metaBinary x
-        , testProperty "XPrvKey" $ \(ArbitraryXPrvKey x) -> metaBinary x
-        , testProperty "XPubKey" $ \(ArbitraryXPubKey _ x) -> metaBinary x
+        [ testProperty "Signature" $ forAll arbitrarySignature $ testId . lst3
+        , testProperty "PubKey" $ forAll arbitraryPubKey $ testId . snd
+        , testProperty "XPrvKey" $ forAll arbitraryXPrvKey testId
+        , testProperty "XPubKey" $ forAll arbitraryXPubKey $ testId . snd
         ]
     , testGroup "Binary encoding and decoding of protocol types"
-        [ testProperty "VarInt" $ \(ArbitraryVarInt x) -> metaBinary x
-        , testProperty "VarString" $ \(ArbitraryVarString x) -> metaBinary x
-        , testProperty "NetworkAddress" $ \(ArbitraryNetworkAddress x) -> metaBinary x
-        , testProperty "InvType" $ \(ArbitraryInvType x) -> metaBinary x
-        , testProperty "InvVector" $ \(ArbitraryInvVector x) -> metaBinary x
-        , testProperty "Inv" $ \(ArbitraryInv x) -> metaBinary x
-        , testProperty "Version" $ \(ArbitraryVersion x) -> metaBinary x
-        , testProperty "Addr" $ \(ArbitraryAddr x) -> metaBinary x
-        , testProperty "Alert" $ \(ArbitraryAlert x) -> metaBinary x
-        , testProperty "Reject" $ \(ArbitraryReject x) -> metaBinary x
-        , testProperty "GetData" $ \(ArbitraryGetData x) -> metaBinary x
-        , testProperty "NotFound" $ \(ArbitraryNotFound x) -> metaBinary x
-        , testProperty "Ping" $ \(ArbitraryPing x) -> metaBinary x
-        , testProperty "Pong" $ \(ArbitraryPong x) -> metaBinary x
-        , testProperty "MessageCommand" $ \(ArbitraryMessageCommand x) -> metaBinary x
-        , testProperty "MessageHeader" $ \(ArbitraryMessageHeader x) -> metaBinary x
-        , testProperty "Message" $ \(ArbitraryMessage x) -> metaBinary x
+        [ testProperty "VarInt" $ forAll arbitraryVarInt testId
+        , testProperty "VarString" $ forAll arbitraryVarString testId
+        , testProperty "NetworkAddress" $ forAll arbitraryNetworkAddress testId
+        , testProperty "InvType" $ forAll arbitraryInvType testId
+        , testProperty "InvVector" $ forAll arbitraryInvVector testId
+        , testProperty "Inv" $ forAll arbitraryInv1 testId
+        , testProperty "Version" $ forAll arbitraryVersion testId
+        , testProperty "Addr" $ forAll arbitraryAddr1 testId
+        , testProperty "Alert" $ forAll arbitraryAlert testId
+        , testProperty "Reject" $ forAll arbitraryReject testId
+        , testProperty "GetData" $ forAll arbitraryGetData testId
+        , testProperty "NotFound" $ forAll arbitraryNotFound testId
+        , testProperty "Ping" $ forAll arbitraryPing testId
+        , testProperty "Pong" $ forAll arbitraryPong testId
+        , testProperty "MessageCommand" $ forAll arbitraryMessageCommand testId
+        , testProperty "MessageHeader" $ forAll arbitraryMessageHeader testId
+        , testProperty "Message" $ forAll arbitraryMessage testId
         ]
     , testGroup "Binary encoding and decoding of script types"
-        [ testProperty "ScriptOp" $ \(ArbitraryScriptOp x) -> metaBinary x
-        , testProperty "Script" $ \(ArbitraryScript x) -> metaBinary x
-        , testProperty "SigHash" $ \(ArbitrarySigHash x) -> metaBinary x
+        [ testProperty "ScriptOp" $ forAll arbitraryScriptOp testId
+        , testProperty "Script" $ forAll arbitraryScript testId
+        , testProperty "SigHash" $ forAll arbitrarySigHash testId
         ]
     , testGroup "Binary encoding and decoding of transaction types"
-        [ testProperty "TxIn" $ \(ArbitraryTxIn x) -> metaBinary x
-        , testProperty "TxOut" $ \(ArbitraryTxOut x) -> metaBinary x
-        , testProperty "OutPoint" $ \(ArbitraryOutPoint x) -> metaBinary x
-        , testProperty "Tx" $ \(ArbitraryTx x) -> metaBinary x
+        [ testProperty "TxIn" $ forAll arbitraryTxIn testId
+        , testProperty "TxOut" $ forAll arbitraryTxOut testId
+        , testProperty "OutPoint" $ forAll arbitraryOutPoint testId
+        , testProperty "Tx" $ forAll arbitraryTx testId
         ]
     , testGroup "Binary encoding and decoding of block types"
-        [ testProperty "Block" $ \(ArbitraryBlock x) -> metaBinary x
-        , testProperty "BlockHeader" $ \(ArbitraryBlockHeader x) -> metaBinary x
-        , testProperty "GetBlocks" $ \(ArbitraryGetBlocks x) -> metaBinary x
-        , testProperty "GetHeaders" $ \(ArbitraryGetHeaders x) -> metaBinary x
-        , testProperty "Headers" $ \(ArbitraryHeaders x) -> metaBinary x
-        , testProperty "MerkleBlock" $ \(ArbitraryMerkleBlock x) -> metaBinary x
+        [ testProperty "Block" $ forAll arbitraryBlock testId
+        , testProperty "BlockHeader" $ forAll arbitraryBlockHeader testId
+        , testProperty "GetBlocks" $ forAll arbitraryGetBlocks testId
+        , testProperty "GetHeaders" $ forAll arbitraryGetHeaders testId
+        , testProperty "Headers" $ forAll arbitraryHeaders testId
+        , testProperty "MerkleBlock" $ forAll arbitraryMerkleBlock testId
         ]
     , testGroup "Binary encoding and decoding of bloom types"
-        [ testProperty "BloomFlags" $ \(ArbitraryBloomFlags x) -> metaBinary x
-        , testProperty "BloomFilter" $ \(ArbitraryBloomFilter _ _ x) -> metaBinary x
-        , testProperty "FilterLoad" $ \(ArbitraryFilterLoad x) -> metaBinary x
-        , testProperty "FilterAdd" $ \(ArbitraryFilterAdd x) -> metaBinary x
+        [ testProperty "BloomFlags" $ forAll arbitraryBloomFlags testId
+        , testProperty "BloomFilter" $ forAll arbitraryBloomFilter $ testId . lst3
+        , testProperty "FilterLoad" $ forAll arbitraryFilterLoad testId
+        , testProperty "FilterAdd" $ forAll arbitraryFilterAdd testId
         ]
     ]
 
-metaBinary :: (Serialize a, Eq a) => a -> Bool
-metaBinary x = decode (encode x) == Right x
+testId :: (Serialize a, Eq a) => a -> Bool
+testId x = decode (encode x) == Right x

--- a/haskoin-core/tests/Network/Haskoin/Crypto/Base58/Tests.hs
+++ b/haskoin-core/tests/Network/Haskoin/Crypto/Base58/Tests.hs
@@ -1,39 +1,31 @@
 module Network.Haskoin.Crypto.Base58.Tests (tests) where
 
-import Test.Framework (Test, testGroup)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
-
-import Data.String (fromString)
-import Data.String.Conversions (cs)
-
-import Network.Haskoin.Test
-import Network.Haskoin.Crypto
+import           Data.String                          (fromString)
+import           Data.String.Conversions              (cs)
+import           Network.Haskoin.Crypto
+import           Network.Haskoin.Test
+import           Test.Framework
+import           Test.Framework.Providers.QuickCheck2
+import           Test.QuickCheck
 
 tests :: [Test]
 tests =
-    [ testGroup "Address and Base58"
-        [ testProperty "decode58( encode58(i) ) = i" decodeEncode58
-        , testProperty "decode58Chk( encode58Chk(i) ) = i" decodeEncode58Check
-        , testProperty "decode58( encode58(address) ) = address" decEncAddr
-        , testProperty "Read/Show address" testReadShowAddress
-        , testProperty "From string address" testFromStringAddress
-        ]
+    [ testGroup
+          "Address and Base58"
+          [ testProperty "decode58 . encode58 == id" $
+            forAll arbitraryBS $ \bs ->
+                decodeBase58 (encodeBase58 bs) == Just bs
+          , testProperty "decode58Chk . encode58Chk == id" $
+            forAll arbitraryBS $ \bs ->
+                decodeBase58Check (encodeBase58Check bs) == Just bs
+          , testProperty "base58ToAddr . addrToBase58 == id" $
+            forAll arbitraryAddress $ \a ->
+                base58ToAddr (addrToBase58 a) == Just a
+          , testProperty "Read/Show address" $
+            forAll arbitraryAddress $ \a -> read (show a) == a
+          , testProperty "From string address" $
+            forAll arbitraryAddress $ \a ->
+                fromString (cs $ addrToBase58 a) == a
+          ]
     ]
 
-decodeEncode58 :: ArbitraryByteString -> Bool
-decodeEncode58 (ArbitraryByteString bs) =
-    decodeBase58 (encodeBase58 bs) == Just bs
-
-decodeEncode58Check :: ArbitraryByteString -> Bool
-decodeEncode58Check (ArbitraryByteString bs) =
-    decodeBase58Check (encodeBase58Check bs) == Just bs
-
-decEncAddr :: ArbitraryAddress -> Bool
-decEncAddr (ArbitraryAddress a) = base58ToAddr (addrToBase58 a) == Just a
-
-
-testReadShowAddress :: ArbitraryAddress -> Bool
-testReadShowAddress (ArbitraryAddress a) = read (show a) == a
-
-testFromStringAddress :: ArbitraryAddress -> Bool
-testFromStringAddress (ArbitraryAddress a) = fromString (cs $ addrToBase58 a) == a

--- a/haskoin-core/tests/Network/Haskoin/Crypto/ECDSA/Tests.hs
+++ b/haskoin-core/tests/Network/Haskoin/Crypto/ECDSA/Tests.hs
@@ -1,40 +1,39 @@
 module Network.Haskoin.Crypto.ECDSA.Tests (tests) where
 
-import Test.Framework (Test, testGroup)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
-
-import Data.Bits (testBit)
-import qualified Data.ByteString as BS (index, length)
-import Data.Serialize (encode)
-
-import Network.Haskoin.Test
-import Network.Haskoin.Crypto
+import           Data.Bits                            (testBit)
+import qualified Data.ByteString                      as BS (index, length)
+import           Data.Serialize                       (encode)
+import           Network.Haskoin.Crypto
+import           Network.Haskoin.Test
+import           Network.Haskoin.Util
+import           Test.Framework                       (Test, testGroup)
+import           Test.Framework.Providers.QuickCheck2 (testProperty)
+import           Test.QuickCheck
 
 tests :: [Test]
 tests =
-    [ testGroup "ECDSA signatures"
-        [ testProperty "Verify signature" testVerifySig
-        , testProperty "S component <= order/2" $
-            \(ArbitrarySignature _ _ sig) -> halfOrderSig sig
-        ]
-    , testGroup "ECDSA Binary"
-        [ testProperty "Encoded signature is canonical" $
-            \(ArbitrarySignature _ _ sig) -> testIsCanonical sig
-        ]
+    [ testGroup
+          "ECDSA signatures"
+          [ testProperty "Verify signature" $
+            forAll arbitrarySignature $ \(msg, key, sig) ->
+                verifySig msg sig (derivePubKey key)
+          , testProperty "S component <= order/2" $
+            forAll arbitrarySignature $ isCanonicalHalfOrder . lst3
+          ]
+    , testGroup
+          "ECDSA Binary"
+          [ testProperty "Encoded signature is canonical" $
+            forAll arbitrarySignature $ testIsCanonical . lst3
+          , testProperty "decodeStrict . encode sig == id" $
+            forAll arbitrarySignature $
+            (\s -> decodeStrictSig (encode s) == Just s) . lst3
+          , testProperty "decode . encode sig == id" $
+            forAll arbitrarySignature $
+            (\s -> decodeDerSig (encode s) == Just s) . lst3
+          ]
     ]
 
-{- ECDSA Signatures -}
-
-halfOrderSig :: Signature -> Bool
-halfOrderSig = isCanonicalHalfOrder
-
-testVerifySig :: ArbitrarySignature -> Bool
-testVerifySig (ArbitrarySignature msg key sig) =
-    verifySig msg sig pubkey
-  where
-    pubkey = derivePubKey key
-
-{- ECDSA Binary -}
+{- ECDSA Canonical -}
 
 -- github.com/bitcoin/bitcoin/blob/master/src/script.cpp
 -- from function IsCanonicalSignature
@@ -57,7 +56,7 @@ testIsCanonical sig = not $
     -- Non-canonical signature: R length is zero
     (rlen == 0) ||
     -- Non-canonical signature: R value negative
-    (testBit (BS.index s 4) 7) ||
+    testBit (BS.index s 4) 7 ||
     -- Non-canonical signature: R value excessively padded
     (  rlen > 1
     && BS.index s 4 == 0
@@ -68,7 +67,7 @@ testIsCanonical sig = not $
     -- Non-canonical signature: S length is zero
     (slen == 0) ||
     -- Non-canonical signature: S value negative
-    (testBit (BS.index s (fromIntegral rlen+6)) 7) ||
+    testBit (BS.index s (fromIntegral rlen+6)) 7 ||
     -- Non-canonical signature: S value excessively padded
     (  slen > 1
     && BS.index s (fromIntegral rlen+6) == 0
@@ -79,3 +78,4 @@ testIsCanonical sig = not $
     len = fromIntegral $ BS.length s
     rlen = BS.index s 3
     slen = BS.index s (fromIntegral rlen + 5)
+

--- a/haskoin-core/tests/Network/Haskoin/Crypto/ExtendedKeys/Tests.hs
+++ b/haskoin-core/tests/Network/Haskoin/Crypto/ExtendedKeys/Tests.hs
@@ -1,95 +1,60 @@
 module Network.Haskoin.Crypto.ExtendedKeys.Tests (tests) where
 
-import Test.Framework (Test, testGroup)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
-
-import Data.String (fromString)
-import Data.String.Conversions (cs)
-import Data.Word (Word32)
-import Data.Bits ((.&.))
-import Data.Maybe (fromJust)
-
-import Network.Haskoin.Test
-import Network.Haskoin.Crypto
+import           Data.Bits                            ((.&.))
+import           Data.String                          (fromString)
+import           Data.String.Conversions              (cs)
+import           Data.Word                            (Word32)
+import           Network.Haskoin.Crypto
+import           Network.Haskoin.Test
+import           Test.Framework
+import           Test.Framework.Providers.QuickCheck2
+import           Test.QuickCheck                      (forAll)
 
 tests :: [Test]
 tests =
-    [ testGroup "HDW Extended Keys"
-        [ testProperty "pubkey of subkey is subkey of pubkey / prvSubKey(k,c)*G = pubSubKey(k*G,c)" pubKeyOfSubKeyIsSubKeyOfPubKey
-        , testProperty "fromB58 . toB58 prvKey" b58PrvKey
-        , testProperty "fromB58 . toB58 pubKey" b58PubKey
-        ]
-    , testGroup "From/To strings"
-        [ testProperty "Read/Show extended public key" testReadShowPubKey
-        , testProperty "Read/Show extended private key" testReadShowPrvKey
-        , testProperty "Read/Show derivation path" testReadShowDerivPath
-        , testProperty "Read/Show hard derivation path" testReadShowHardPath
-        , testProperty "Read/Show soft derivation path" testReadShowSoftPath
-        , testProperty "From string extended public key" testFromStringPubKey
-        , testProperty "From string extended private key" testFromStringPrvKey
-        , testProperty "From string derivation path" testFromStringDerivPath
-        , testProperty "From string hard derivation path" testFromStringHardPath
-        , testProperty "From string soft derivation path" testFromStringSoftPath
-        , testProperty "listToPath . pathToList == id" testPathToList
-        , testProperty "listToPath . pathToList == id (Hard)" testPathToListHard
-        , testProperty "listToPath . pathToList == id (Soft)" testPathToListSoft
-        ]
+    [ testGroup
+          "HDW Extended Keys"
+          [ testProperty "prvSubKey(k,c)*G = pubSubKey(k*G,c)" $
+            forAll arbitraryXPrvKey pubKeyOfSubKeyIsSubKeyOfPubKey
+          , testProperty "fromB58 . toB58 prvKey" $ forAll arbitraryXPrvKey $
+            \k -> xPrvImport (xPrvExport k) == Just k
+          , testProperty "fromB58 . toB58 pubKey" $ forAll arbitraryXPubKey $
+            \(_, k) -> xPubImport (xPubExport k) == Just k
+          ]
+    , testGroup
+          "From/To strings"
+          [ testProperty "Read/Show extended public key" $ forAll arbitraryXPubKey $
+            \(_, k) -> read (show k) == k
+          , testProperty "Read/Show extended private key" $ forAll arbitraryXPrvKey $
+            \k -> read (show k) == k
+          , testProperty "From string extended public key" $ forAll arbitraryXPubKey $
+            \(_, k) -> fromString (cs $ xPubExport k) == k
+          , testProperty "From string extended private key" $ forAll arbitraryXPrvKey $
+            \k -> fromString (cs $ xPrvExport k) == k
+          , testProperty "Read/Show derivation path" $ forAll arbitraryDerivPath $
+            \p -> read (show p) == p
+          , testProperty "Read/Show hard derivation path" $ forAll arbitraryHardPath $
+            \p -> read (show p) == p
+          , testProperty "Read/Show soft derivation path" $ forAll arbitrarySoftPath $
+            \p -> read (show p) == p
+          , testProperty "From string derivation path" $ forAll arbitraryDerivPath $
+            \p -> fromString (cs $ pathToStr p) == p
+          , testProperty "From string hard derivation path" $ forAll arbitraryHardPath $
+            \p -> fromString (cs $ pathToStr p) == p
+          , testProperty "From string soft derivation path" $ forAll arbitrarySoftPath $
+            \p -> fromString (cs $ pathToStr p) == p
+          , testProperty "listToPath . pathToList == id" $ forAll arbitraryDerivPath $
+            \p -> listToPath (pathToList p) == p
+          , testProperty "listToPath . pathToList == id (Hard)" $
+            forAll arbitraryHardPath $ \p -> toHard (listToPath $ pathToList p) == Just p
+          , testProperty "listToPath . pathToList == id (Soft)" $
+            forAll arbitrarySoftPath $ \p -> toSoft (listToPath $ pathToList p) == Just p
+          ]
     ]
 
-{- HDW Extended Keys -}
-
-pubKeyOfSubKeyIsSubKeyOfPubKey :: ArbitraryXPrvKey -> Word32 -> Bool
-pubKeyOfSubKeyIsSubKeyOfPubKey (ArbitraryXPrvKey k) i =
-    (deriveXPubKey $ prvSubKey k i') == (pubSubKey (deriveXPubKey k) i')
+pubKeyOfSubKeyIsSubKeyOfPubKey :: XPrvKey -> Word32 -> Bool
+pubKeyOfSubKeyIsSubKeyOfPubKey k i =
+    deriveXPubKey (prvSubKey k i') == pubSubKey (deriveXPubKey k) i'
   where
     i' = fromIntegral $ i .&. 0x7fffffff -- make it a public derivation
-
-b58PrvKey :: ArbitraryXPrvKey -> Bool
-b58PrvKey (ArbitraryXPrvKey k) = (xPrvImport $ xPrvExport k) == Just k
-
-b58PubKey :: ArbitraryXPubKey -> Bool
-b58PubKey (ArbitraryXPubKey _ k) = (xPubImport $ xPubExport k) == Just k
-
-{- Strings -}
-
-testReadShowPubKey :: ArbitraryXPubKey -> Bool
-testReadShowPubKey (ArbitraryXPubKey _ k) = read (show k) == k
-
-testReadShowPrvKey :: ArbitraryXPrvKey -> Bool
-testReadShowPrvKey (ArbitraryXPrvKey k) = read (show k) == k
-
-testFromStringPubKey :: ArbitraryXPubKey -> Bool
-testFromStringPubKey (ArbitraryXPubKey _ k) = fromString (cs $ xPubExport k) == k
-
-testFromStringPrvKey :: ArbitraryXPrvKey -> Bool
-testFromStringPrvKey (ArbitraryXPrvKey k) = fromString (cs $ xPrvExport k) == k
-
-testReadShowDerivPath :: ArbitraryDerivPath -> Bool
-testReadShowDerivPath (ArbitraryDerivPath p) = read (show p) == p
-
-testReadShowHardPath :: ArbitraryHardPath -> Bool
-testReadShowHardPath (ArbitraryHardPath p) = read (show p) == p
-
-testReadShowSoftPath :: ArbitrarySoftPath -> Bool
-testReadShowSoftPath (ArbitrarySoftPath p) = read (show p) == p
-
-testFromStringDerivPath :: ArbitraryDerivPath -> Bool
-testFromStringDerivPath (ArbitraryDerivPath k) = fromString (cs $ pathToStr k) == k
-
-testFromStringHardPath :: ArbitraryHardPath -> Bool
-testFromStringHardPath (ArbitraryHardPath k) = fromString (cs $ pathToStr k) == k
-
-testFromStringSoftPath :: ArbitrarySoftPath -> Bool
-testFromStringSoftPath (ArbitrarySoftPath k) = fromString (cs $ pathToStr k) == k
-
-testPathToList :: ArbitraryDerivPath -> Bool
-testPathToList (ArbitraryDerivPath p) = listToPath (pathToList p) == p
-
-testPathToListHard :: ArbitraryHardPath -> Bool
-testPathToListHard (ArbitraryHardPath p) =
-    p == (fromJust $ toHard $ listToPath $ pathToList p)
-
-testPathToListSoft :: ArbitrarySoftPath -> Bool
-testPathToListSoft (ArbitrarySoftPath p) =
-    p == (fromJust $ toSoft $ listToPath $ pathToList p)
 

--- a/haskoin-core/tests/Network/Haskoin/Crypto/Hash/Tests.hs
+++ b/haskoin-core/tests/Network/Haskoin/Crypto/Hash/Tests.hs
@@ -1,71 +1,52 @@
 module Network.Haskoin.Crypto.Hash.Tests (tests) where
 
-import Test.Framework (Test, testGroup)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
-
-import Data.String (fromString)
-import Data.String.Conversions (cs)
-import Data.Serialize (encode)
-import Network.Haskoin.Block
-import Network.Haskoin.Crypto
-import Network.Haskoin.Test
-import Network.Haskoin.Util
+import           Data.Serialize                       (encode)
+import           Data.String                          (fromString)
+import           Data.String.Conversions              (cs)
+import           Network.Haskoin.Block
+import           Network.Haskoin.Crypto
+import           Network.Haskoin.Test
+import           Network.Haskoin.Util
+import           Test.Framework
+import           Test.Framework.Providers.QuickCheck2
+import           Test.QuickCheck
 
 tests :: [Test]
 tests =
     [ testGroup "Hash tests"
-        [ testProperty "join512( split512(h) ) == h" joinSplit512
+        [ testProperty "join512( split512(h) ) == h" $
+          forAll arbitraryHash256 $ forAll arbitraryHash256 . joinSplit512
         , testProperty "decodeCompact . encodeCompact i == i" decEncCompact
-        , testProperty "Read/Show 64-byte hash" testReadShowHash512
-        , testProperty "From string 64-byte hash" testFromStringHash512
-        , testProperty "Read/Show 32-byte hash" testReadShowHash256
-        , testProperty "From string 32-byte hash" testFromStringHash256
-        , testProperty "Read/Show 20-byte hash" testReadShowHash160
-        , testProperty "From string 20-byte hash" testFromStringHash160
-        , testProperty "Read/Show checksum" testReadShowCheckSum32
-        , testProperty "From string checksum" testFromStringCheckSum32
+        , testProperty "Read/Show 64-byte hash" $ forAll arbitraryHash512 $
+          \h -> read (show h) == h
+        , testProperty "From string 64-byte hash" $ forAll arbitraryHash512 $
+          \h -> fromString (cs $ encodeHex $ encode h) == h
+        , testProperty "Read/Show 32-byte hash" $ forAll arbitraryHash256 $
+          \h -> read (show h) == h
+        , testProperty "From string 32-byte hash" $ forAll arbitraryHash256 $
+          \h -> fromString (cs $ encodeHex $ encode h) == h
+        , testProperty "Read/Show 20-byte hash" $ forAll arbitraryHash160 $
+          \h -> read (show h) == h
+        , testProperty "From string 20-byte hash" $ forAll arbitraryHash160 $
+          \h -> fromString (cs $ encodeHex $ encode h) == h
+        , testProperty "Read/Show checksum" $ forAll arbitraryCheckSum32 $
+          \h -> read (show h) == h
+        , testProperty "From string checksum" $ forAll arbitraryCheckSum32 $
+          \h -> fromString (cs $ encodeHex $ encode h) == h
         ]
     ]
 
-joinSplit512 :: (ArbitraryHash256, ArbitraryHash256) -> Bool
-joinSplit512 (ArbitraryHash256 a, ArbitraryHash256 b) =
-    (split512 $ join512 (a, b)) == (a, b)
+joinSplit512 :: Hash256 -> Hash256 -> Bool
+joinSplit512 a b = split512 (join512 (a, b)) == (a, b)
 
 -- After encoding and decoding, we may loose precision so the new result is >=
 -- to the old one.
 decEncCompact :: Integer -> Bool
 decEncCompact i
     -- Integer completely fits inside the mantisse
-    | (abs i) <= 0x007fffff = (decodeCompact $ encodeCompact i) == i
+    | abs i <= 0x007fffff = decodeCompact (encodeCompact i) == i
     -- Otherwise precision will be lost and the decoded result will
     -- be smaller than the original number
-    | i >= 0                = (decodeCompact $ encodeCompact i) < i
-    | otherwise             = (decodeCompact $ encodeCompact i) > i
+    | i >= 0              = decodeCompact (encodeCompact i) < i
+    | otherwise           = decodeCompact (encodeCompact i) > i
 
-
-testReadShowHash512 :: ArbitraryHash512 -> Bool
-testReadShowHash512 (ArbitraryHash512 k) = read (show k) == k
-
-testFromStringHash512 :: ArbitraryHash512 -> Bool
-testFromStringHash512 (ArbitraryHash512 k) = fromString (cs $ encodeHex $ encode k) == k
-
-
-testReadShowHash256 :: ArbitraryHash256 -> Bool
-testReadShowHash256 (ArbitraryHash256 k) = read (show k) == k
-
-testFromStringHash256 :: ArbitraryHash256 -> Bool
-testFromStringHash256 (ArbitraryHash256 k) = fromString (cs $ encodeHex $ encode k) == k
-
-
-testReadShowHash160 :: ArbitraryHash160 -> Bool
-testReadShowHash160 (ArbitraryHash160 k) = read (show k) == k
-
-testFromStringHash160 :: ArbitraryHash160 -> Bool
-testFromStringHash160 (ArbitraryHash160 k) = fromString (cs $ encodeHex $ encode k) == k
-
-
-testReadShowCheckSum32 :: ArbitraryCheckSum32 -> Bool
-testReadShowCheckSum32 (ArbitraryCheckSum32 k) = read (show k) == k
-
-testFromStringCheckSum32 :: ArbitraryCheckSum32 -> Bool
-testFromStringCheckSum32 (ArbitraryCheckSum32 k) = fromString (cs $ encodeHex $ encode k) == k

--- a/haskoin-core/tests/Network/Haskoin/Json/Tests.hs
+++ b/haskoin-core/tests/Network/Haskoin/Json/Tests.hs
@@ -1,35 +1,35 @@
 module Network.Haskoin.Json.Tests (tests) where
 
-import Test.Framework (Test, testGroup)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
-
-import Data.Aeson (FromJSON, ToJSON, decode, encode)
-import Data.HashMap.Strict (singleton)
-
-import Network.Haskoin.Test
+import           Data.Aeson
+import           Data.HashMap.Strict                  (singleton)
+import           Network.Haskoin.Test
+import           Test.Framework
+import           Test.Framework.Providers.QuickCheck2
+import           Test.QuickCheck
 
 tests :: [Test]
 tests =
-    [ testGroup "Serialize & de-serialize haskoin types to JSON"
-        [ testProperty "ScriptOutput" $ \(ArbitraryScriptOutput x) -> metaID x
-        , testProperty "OutPoint" $ \(ArbitraryOutPoint x) -> metaID x
-        , testProperty "Address" $ \(ArbitraryAddress x) -> metaID x
-        , testProperty "Tx" $ \(ArbitraryTx x) -> metaID x
-        , testProperty "TxHash" $ \(ArbitraryTxHash x) -> metaID x
-        , testProperty "BlockHash" $ \(ArbitraryBlockHash x) -> metaID x
-        , testProperty "SigHash" $ \(ArbitrarySigHash x) -> metaID x
-        , testProperty "SigInput" $ \(ArbitrarySigInput x _) -> metaID x
-        , testProperty "PubKey" $ \(ArbitraryPubKey _ x) -> metaID x
-        , testProperty "PubKeyC" $ \(ArbitraryPubKeyC _ x) -> metaID x
-        , testProperty "PubKeyU" $ \(ArbitraryPubKeyU _ x) -> metaID x
-        , testProperty "XPrvKey" $ \(ArbitraryXPrvKey x) -> metaID x
-        , testProperty "XPubKey" $ \(ArbitraryXPubKey _ x) -> metaID x
-        , testProperty "DerivPath" $ \(ArbitraryDerivPath x) -> metaID x
-        , testProperty "ParsedPath" $ \(ArbitraryParsedPath x) -> metaID x
-        ]
+    [ testGroup
+          "Serialize & de-serialize haskoin types to JSON"
+          [ testProperty "ScriptOutput" $ forAll arbitraryScriptOutput testID
+          , testProperty "OutPoint" $ forAll arbitraryOutPoint testID
+          , testProperty "Address" $ forAll arbitraryAddress testID
+          , testProperty "Tx" $ forAll arbitraryTx testID
+          , testProperty "TxHash" $ forAll arbitraryTxHash testID
+          , testProperty "BlockHash" $ forAll arbitraryBlockHash testID
+          , testProperty "SigHash" $ forAll arbitrarySigHash testID
+          , testProperty "SigInput" $ forAll arbitrarySigInput (testID . fst)
+          , testProperty "PubKey" $ forAll arbitraryPubKey (testID . snd)
+          , testProperty "PubKeyC" $ forAll arbitraryPubKeyC (testID . snd)
+          , testProperty "PubKeyU" $ forAll arbitraryPubKeyU (testID . snd)
+          , testProperty "XPrvKey" $ forAll arbitraryXPrvKey testID
+          , testProperty "XPubKey" $ forAll arbitraryXPubKey (testID . snd)
+          , testProperty "DerivPath" $ forAll arbitraryDerivPath testID
+          , testProperty "ParsedPath" $ forAll arbitraryParsedPath testID
+          ]
     ]
 
-metaID :: (FromJSON a, ToJSON a, Eq a) => a -> Bool
-metaID x = (decode . encode) (singleton ("object" :: String) x) ==
+testID :: (FromJSON a, ToJSON a, Eq a) => a -> Bool
+testID x =
+    (decode . encode) (singleton ("object" :: String) x) ==
     Just (singleton ("object" :: String) x)
-

--- a/haskoin-core/tests/Network/Haskoin/Transaction/Tests.hs
+++ b/haskoin-core/tests/Network/Haskoin/Transaction/Tests.hs
@@ -1,94 +1,95 @@
 module Network.Haskoin.Transaction.Tests (tests) where
 
-import Test.Framework (Test, testGroup)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
-
-import Data.Serialize (encode)
-import Data.String (fromString)
-import Data.String.Conversions (cs)
-import Data.Word (Word64)
-import qualified Data.ByteString as BS (length)
-
-import Network.Haskoin.Test
-import Network.Haskoin.Transaction
-import Network.Haskoin.Script
-import Network.Haskoin.Crypto
-import Network.Haskoin.Util
+import qualified Data.ByteString                      as BS
+import           Data.Serialize                       (encode)
+import           Data.String                          (fromString)
+import           Data.String.Conversions              (cs)
+import           Data.Word                            (Word64)
+import           Network.Haskoin.Crypto
+import           Network.Haskoin.Script
+import           Network.Haskoin.Test
+import           Network.Haskoin.Transaction
+import           Network.Haskoin.Util
+import           Test.Framework
+import           Test.Framework.Providers.QuickCheck2
+import           Test.QuickCheck
 
 tests :: [Test]
 tests =
-    [ testGroup "Transaction tests"
-        [ testProperty "decode . encode Txid" decEncTxid
-        , testProperty "Read/Show transaction id" testReadShowTxHash
-        , testProperty "From string transaction id" testFromStringTxHash
-        ]
-    , testGroup "Building Transactions"
-        [ testProperty "building address tx" testBuildAddrTx
-        , testProperty "testing guessTxSize function" testGuessSize
-        , testProperty "testing chooseCoins function" testChooseCoins
-        , testProperty "testing chooseMSCoins function" testChooseMSCoins
-        ]
-    , testGroup "Signing Transactions"
-        [ testProperty "Sign and validate transactions" testDetSignTx
-        , testProperty "Merge partially signed transactions" testMergeTx
-        ]
+    [ testGroup
+          "Transaction tests"
+          [ testProperty "decode . encode Txid" $
+            forAll arbitraryTxHash $ \h -> hexToTxHash (txHashToHex h) == Just h
+          , testProperty "Read/Show transaction id" $
+            forAll arbitraryTxHash $ \h -> read (show h) == h
+          , testProperty "From string transaction id" $
+            forAll arbitraryTxHash $ \h -> fromString (cs $ txHashToHex h) == h
+          ]
+    , testGroup
+          "Building Transactions"
+          [ testProperty "building address tx" $
+            forAll arbitraryAddress $ forAll arbitrarySatoshi . testBuildAddrTx
+          , testProperty "testing guessTxSize function" $
+            forAll arbitraryAddrOnlyTx testGuessSize
+          , testProperty "testing chooseCoins function" $
+            forAll (listOf arbitrarySatoshi) testChooseCoins
+          , testProperty "testing chooseMSCoins function" $
+            forAll arbitraryMSParam $
+            forAll (listOf arbitrarySatoshi) . testChooseMSCoins
+          ]
+    , testGroup
+          "Signing Transactions"
+          [ testProperty "Sign and validate transactions" $
+            forAll arbitrarySigningData testDetSignTx
+          , testProperty "Merge partially signed transactions" $
+            forAll arbitraryPartialTxs testMergeTx
+          ]
     ]
-
-{- Transaction Tests -}
-
-decEncTxid :: ArbitraryTxHash -> Bool
-decEncTxid (ArbitraryTxHash h) = hexToTxHash (txHashToHex h) == Just h
-
-testReadShowTxHash :: ArbitraryTxHash -> Bool
-testReadShowTxHash (ArbitraryTxHash h) = read (show h) == h
-
-testFromStringTxHash :: ArbitraryTxHash -> Bool
-testFromStringTxHash (ArbitraryTxHash h) = fromString (cs $ txHashToHex h) == h
 
 {- Building Transactions -}
 
-testBuildAddrTx :: ArbitraryAddress -> ArbitrarySatoshi -> Bool
-testBuildAddrTx (ArbitraryAddress a) (ArbitrarySatoshi v) = case a of
+testBuildAddrTx :: Address -> TestCoin -> Bool
+testBuildAddrTx a (TestCoin v) = case a of
     x@(PubKeyAddress _) -> Right (PayPKHash x) == out
     x@(ScriptAddress _) -> Right (PayScriptHash x) == out
   where
     tx  = buildAddrTx [] [(addrToBase58 a,v)]
-    out = decodeOutputBS $ scriptOutput $ txOut (fromRight tx) !! 0
+    out = decodeOutputBS $ scriptOutput $ head $ txOut (fromRight tx)
 
-testGuessSize :: ArbitraryAddrOnlyTx -> Bool
-testGuessSize (ArbitraryAddrOnlyTx tx) =
+testGuessSize :: Tx -> Bool
+testGuessSize tx =
     -- We compute an upper bound but it should be close enough to the real size
     -- We give 2 bytes of slack on every signature (1 on r and 1 on s)
     guess >= len && guess <= len + 2*delta
   where
-    delta    = pki + (sum $ map fst msi)
+    delta    = pki + sum (map fst msi)
     guess    = guessTxSize pki msi pkout msout
     len      = BS.length $ encode tx
     ins      = map f $ txIn tx
     f i      = fromRight $ decodeInputBS $ scriptInput i
     pki      = length $ filter isSpendPKHash ins
-    msi      = concat $ map shData ins
+    msi      = concatMap shData ins
     shData (ScriptHashInput _ (PayMulSig keys r)) = [(r,length keys)]
-    shData _ = []
+    shData _                                      = []
     out      = map (fromRight . decodeOutputBS . scriptOutput) $ txOut tx
     pkout    = length $ filter isPayPKHash out
     msout    = length $ filter isPayScriptHash out
 
-testChooseCoins :: Word64 -> Word64 -> [ArbitrarySatoshi] -> Bool
-testChooseCoins target kbfee coins = case chooseCoins target kbfee True coins of
-    Right (chosen, change) ->
-        let outSum = sum $ map coinValue chosen
-            fee    = getFee kbfee (length chosen)
-        in outSum == target + change + fee
-    Left _ ->
-        let fee = getFee kbfee (length coins)
-        in target == 0 || s < target || s < target + fee
+testChooseCoins :: [TestCoin] -> Word64 -> Word64 -> Bool
+testChooseCoins coins target kbfee =
+    case chooseCoins target kbfee True coins of
+        Right (chosen, change) ->
+            let outSum = sum $ map coinValue chosen
+                fee    = getFee kbfee (length chosen)
+            in outSum == target + change + fee
+        Left _ ->
+            let fee = getFee kbfee (length coins)
+            in target == 0 || s < target || s < target + fee
   where
     s  = sum $ map coinValue coins
 
-testChooseMSCoins :: Word64 -> Word64
-                  -> ArbitraryMSParam -> [ArbitrarySatoshi] -> Bool
-testChooseMSCoins target kbfee (ArbitraryMSParam m n) coins =
+testChooseMSCoins :: (Int, Int) -> [TestCoin] -> Word64 -> Word64 -> Bool
+testChooseMSCoins (m, n) coins target kbfee =
     case chooseMSCoins target kbfee (m,n) True coins of
         Right (chosen,change) ->
             let outSum = sum $ map coinValue chosen
@@ -98,22 +99,22 @@ testChooseMSCoins target kbfee (ArbitraryMSParam m n) coins =
             let fee = getMSFee kbfee (m,n) (length coins)
             in target == 0 || s < target + fee
   where
-    s  = sum $ map coinValue coins
+    s = sum $ map coinValue coins
 
 {- Signing Transactions -}
 
-testDetSignTx :: ArbitrarySigningData -> Bool
-testDetSignTx (ArbitrarySigningData tx sigis prv) =
-    (not $ verifyStdTx tx verData)
-        && (not $ verifyStdTx txSigP verData)
+testDetSignTx :: (Tx, [SigInput], [PrvKey]) -> Bool
+testDetSignTx (tx, sigis, prv) =
+    not (verifyStdTx tx verData)
+        && not (verifyStdTx txSigP verData)
         && verifyStdTx txSigC verData
   where
     txSigP  = fromRight $ signTx tx sigis (tail prv)
     txSigC  = fromRight $ signTx txSigP sigis [head prv]
     verData = map (\(SigInput s o _ _) -> (s,o)) sigis
 
-testMergeTx :: ArbitraryPartialTxs -> Bool
-testMergeTx (ArbitraryPartialTxs txs os) = and
+testMergeTx :: ([Tx], [(ScriptOutput, OutPoint, Int, Int)]) -> Bool
+testMergeTx (txs, os) = and
     [ isRight mergeRes
     , length (txIn mergedTx) == length os
     , if enoughSigs then isValid else not isValid
@@ -125,7 +126,7 @@ testMergeTx (ArbitraryPartialTxs txs os) = and
     mergeRes = mergeTxs txs outs
     mergedTx = fromRight mergeRes
     isValid = verifyStdTx mergedTx outs
-    enoughSigs = and $ map (\(m,c) -> c >= m) sigMap
+    enoughSigs = all (\(m,c) -> c >= m) sigMap
     sigMap = map (\((_,_,m,_), inp) -> (m, sigCnt inp)) $ zip os $ txIn mergedTx
     sigCnt inp = case decodeInputBS $ scriptInput inp of
         Right (RegularInput (SpendMulSig sigs)) -> length sigs

--- a/haskoin-core/tests/Network/Haskoin/Util/Tests.hs
+++ b/haskoin-core/tests/Network/Haskoin/Util/Tests.hs
@@ -1,51 +1,54 @@
 module Network.Haskoin.Util.Tests (tests) where
 
-import Test.Framework (Test, testGroup)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
-
-import Data.List (permutations)
-import Data.Maybe (fromJust, catMaybes)
-import Data.Foldable (toList)
-import qualified Data.Sequence as Seq (update, fromList)
-
-import Network.Haskoin.Test
-import Network.Haskoin.Util
+import qualified Data.ByteString                      as BS
+import           Data.Foldable                        (toList)
+import           Data.List                            (permutations)
+import           Data.Maybe
+import qualified Data.Sequence                        as Seq
+import           Network.Haskoin.Test
+import           Network.Haskoin.Util
+import           Test.Framework
+import           Test.Framework.Providers.QuickCheck2
+import           Test.QuickCheck
 
 tests :: [Test]
 tests =
-    [ testGroup "Utility functions"
-        [ testProperty "bsToInteger . integerToBS" getPutInteger
-        , testProperty "decodeHex . encodeHex" fromToHex
-        , testProperty "compare updateIndex with Data.Sequence" testUpdateIndex
-        , testProperty "matchTemplate" testMatchTemplate
-        , testProperty
-            "testing matchTemplate with two lists" testMatchTemplateLen
-        , testProperty "Testing Either helper functions" testEither
-        ]
+    [ testGroup
+          "Utility functions"
+          [ testProperty "bsToInteger . integerToBS" getPutInteger
+          , testProperty "decodeHex . encodeHex" $ forAll arbitraryBS fromToHex
+          , testProperty
+                "compare updateIndex with Data.Sequence"
+                testUpdateIndex
+          , testProperty "matchTemplate" testMatchTemplate
+          , testProperty
+                "testing matchTemplate with two lists"
+                testMatchTemplateLen
+          , testProperty "Testing Either helper functions" testEither
+          ]
     ]
 
 {- Various utilities -}
 
 getPutInteger :: Integer -> Bool
-getPutInteger i = (bsToInteger $ integerToBS p) == p
-  where
-    p = abs i
+getPutInteger i = bsToInteger (integerToBS $ abs i) == abs i
 
-fromToHex :: ArbitraryByteString -> Bool
-fromToHex (ArbitraryByteString bs) = (fromJust $ decodeHex $ encodeHex bs) == bs
+fromToHex :: BS.ByteString -> Bool
+fromToHex bs = decodeHex (encodeHex bs) == Just bs
 
 testUpdateIndex :: [Int] -> Int -> Int -> Bool
 testUpdateIndex xs v i =
-    (updateIndex i xs $ const v) == (toList $ Seq.update i v s)
-  where
-    s = Seq.fromList xs
+    updateIndex i xs (const v) == toList (Seq.update i v $ Seq.fromList xs)
 
 testMatchTemplate :: [Int] -> Int -> Bool
 testMatchTemplate as i = catMaybes res == bs
   where
     res = matchTemplate as bs (==)
-    idx = if length as == 0 then 0 else i `mod` length as
-    bs  = (permutations as) !! idx
+    idx =
+        if null as
+            then 0
+            else i `mod` length as
+    bs = permutations as !! idx
 
 testMatchTemplateLen :: [Int] -> [Int] -> Bool
 testMatchTemplateLen as bs = length bs == length res
@@ -53,13 +56,11 @@ testMatchTemplateLen as bs = length bs == length res
     res = matchTemplate as bs (==)
 
 testEither :: Either String Int -> Bool
-testEither e = case e of
-    (Right v) -> (isRight e)
-              && (not $ isLeft e)
-              && (fromRight e == v)
-              && (eitherToMaybe e == Just v)
-    (Left v)  -> (isLeft e)
-              && (not $ isRight e)
-              && (fromLeft e == v)
-              && (eitherToMaybe e == Nothing)
-
+testEither e =
+    case e of
+        (Right v) ->
+            isRight e &&
+            not (isLeft e) && fromRight e == v && eitherToMaybe e == Just v
+        (Left v) ->
+            isLeft e &&
+            not (isRight e) && fromLeft e == v && isNothing (eitherToMaybe e)

--- a/haskoin-wallet/tests/Network/Haskoin/Wallet/Arbitrary.hs
+++ b/haskoin-wallet/tests/Network/Haskoin/Wallet/Arbitrary.hs
@@ -10,7 +10,7 @@ instance Arbitrary AccountType where
     arbitrary = oneof
         [ return AccountRegular
         , do
-            ArbitraryMSParam m n <- arbitrary
+            (m, n) <- arbitraryMSParam
             return $ AccountMultisig m n
         ]
 


### PR DESCRIPTION
Instead of having arbitrary types for testing, we now provide arbitrary
functions of type `Gen a`. This simplifies the process of writing new
arbitrary instances for tests in other libraries like haskoin-wallet.