### PR TITLE
Use ShortByteString and cryptonite for hashes

### DIFF
--- a/haskoin-core/haskoin-core.cabal
+++ b/haskoin-core/haskoin-core.cabal
@@ -91,9 +91,11 @@ library
                  , cereal                   >= 0.5          && < 0.6
                  , conduit                  >= 1.2          && < 1.3
                  , containers               >= 0.5          && < 0.6
-                 , cryptohash               >= 0.11         && < 0.12
+                 , cryptonite               >= 0.21         && < 0.22
                  , deepseq                  >= 1.4          && < 1.5
                  , either                   >= 4.3          && < 4.5
+                 , hashable                 >= 1.2          && < 1.3
+                 , memory                   >= 0.14         && < 0.15
                  , mtl                      >= 2.2          && < 2.3
                  , murmur3                  >= 1.0          && < 1.1
                  , network                  >= 2.6          && < 2.7
@@ -104,7 +106,7 @@ library
                  , time                     >= 1.4          && < 1.7
                  , string-conversions       >= 0.4          && < 0.5
                  , vector                   >= 0.10         && < 0.13
-                 , secp256k1                >= 0.4          && < 0.5
+                 , secp256k1                >= 0.5          && < 0.6
                  , largeword                >= 1.2.4        && < 1.3
                  , entropy                  >= 0.3          && < 0.4
 
@@ -157,7 +159,7 @@ test-suite test-haskoin-core
                  , unordered-containers           >= 0.2        && < 0.3
                  , string-conversions             >= 0.4        && < 0.5
                  , largeword                      >= 1.2        && < 1.3
-                 , secp256k1                      >= 0.4        && < 0.5
+                 , secp256k1                      >= 0.5        && < 0.6
                  , safe
                  , vector
                  , scientific

--- a/haskoin-core/src/Network/Haskoin/Block/Merkle.hs
+++ b/haskoin-core/src/Network/Haskoin/Block/Merkle.hs
@@ -1,22 +1,11 @@
-module Network.Haskoin.Block.Merkle
-( MerkleBlock(..)
-, MerkleRoot
-, FlagBits
-, PartialMerkleTree
-, calcTreeHeight
-, calcTreeWidth
-, buildMerkleRoot
-, calcHash
-, buildPartialMerkle
-, extractMatches
-) where
+module Network.Haskoin.Block.Merkle where
 
 import           Control.DeepSeq                   (NFData, rnf)
 import           Control.Monad                     (forM_, replicateM)
 import           Data.Bits
 import qualified Data.ByteString                   as BS
 import           Data.Maybe
-import           Data.Serialize                    (Serialize, encode, get, put)
+import           Data.Serialize                    (Serialize, get, put)
 import           Data.Serialize.Get                (getWord32le, getWord8)
 import           Data.Serialize.Put                (putWord32le, putWord8)
 import           Data.Word                         (Word32, Word8)
@@ -25,6 +14,7 @@ import           Network.Haskoin.Constants
 import           Network.Haskoin.Crypto.Hash
 import           Network.Haskoin.Network.Types
 import           Network.Haskoin.Transaction.Types
+import           Network.Haskoin.Util
 
 type MerkleRoot        = Hash256
 type FlagBits          = [Bool]
@@ -33,18 +23,18 @@ type PartialMerkleTree = [Hash256]
 data MerkleBlock =
     MerkleBlock {
                 -- | Header information for this merkle block.
-                  merkleHeader :: !BlockHeader
+                  merkleHeader    :: !BlockHeader
                 -- | Number of transactions in the block (including
                 -- unmatched transactions).
                 , merkleTotalTxns :: !Word32
                 -- | Hashes in depth-first order. They are used to rebuild a
                 -- partial merkle tree.
-                , mHashes :: ![Hash256]
+                , mHashes         :: ![Hash256]
                 -- | Flag bits, packed per 8 in a byte. Least significant bit
                 -- first. Flag bits are used to rebuild a partial merkle
                 -- tree.
-                , mFlags :: ![Bool]
-                } deriving (Eq, Show, Read)
+                , mFlags          :: ![Bool]
+                } deriving (Eq, Show)
 
 instance NFData MerkleBlock where
     rnf (MerkleBlock m t h f) = rnf m `seq` rnf t `seq` rnf h `seq` rnf f
@@ -71,8 +61,8 @@ instance Serialize MerkleBlock where
 
 decodeMerkleFlags :: [Word8] -> [Bool]
 decodeMerkleFlags ws =
-    [ b | p <- [0..(length ws)*8-1]
-    , b <- [testBit (ws !! (p `div` 8)) (p `mod` 8)]
+    [ b | p <- [ 0 .. length ws * 8 - 1 ]
+        , b <- [ testBit (ws !! (p `div` 8)) (p `mod` 8) ]
     ]
 
 encodeMerkleFlags :: [Bool] -> [Word8]
@@ -98,7 +88,7 @@ buildMerkleRoot :: [TxHash]   -- ^ List of transaction hashes (leaf nodes).
 buildMerkleRoot txs = calcHash (calcTreeHeight $ length txs) 0 txs
 
 hash2 :: Hash256 -> Hash256 -> Hash256
-hash2 a b = doubleHash256 $ encode a `BS.append` encode b
+hash2 a b = doubleHash256 $ encodeStrict a `BS.append` encodeStrict b
 
 -- | Computes the hash of a specific node in a merkle tree.
 calcHash :: Int       -- ^ Height of the node in the merkle tree.
@@ -136,7 +126,7 @@ traverseAndBuild height pos txs
     t = map fst txs
     s = pos `shiftL` height
     e = min (length txs) $ (pos+1) `shiftL` height
-    match = or $ map snd $ take (e-s) $ drop s txs
+    match = any snd $ take (e-s) $ drop s txs
     (lb,lh) = traverseAndBuild (height-1) (pos*2) txs
     (rb,rh) | (pos*2+1) < calcTreeWidth (length txs) (height-1)
                 = traverseAndBuild (height-1) (pos*2+1) txs
@@ -145,7 +135,7 @@ traverseAndBuild height pos txs
 traverseAndExtract :: Int -> Int -> Int -> FlagBits -> PartialMerkleTree
                    -> Maybe (MerkleRoot, [TxHash], Int, Int)
 traverseAndExtract height pos ntx flags hashes
-    | length flags == 0         = Nothing
+    | null flags               = Nothing
     | height == 0 || not match = leafResult
     | isNothing leftM          = Nothing
     | (pos*2+1) >= calcTreeWidth ntx (height-1) =
@@ -156,8 +146,7 @@ traverseAndExtract height pos ntx flags hashes
   where
     leafResult
         | null hashes = Nothing
-        | otherwise = Just
-            (h, if height == 0 && match then [TxHash h] else [], 1, 1)
+        | otherwise = Just (h, [ TxHash h | height == 0 && match ], 1, 1)
     (match:fs) = flags
     (h:_)     = hashes
     leftM  = traverseAndExtract (height-1) (pos*2) ntx fs hashes
@@ -176,20 +165,20 @@ extractMatches :: FlagBits -- ^ Flag bits (produced by buildPartialMerkle).
                -> Either String (MerkleRoot, [TxHash])
                -- ^ Merkle root and the list of matching transaction hashes.
 extractMatches flags hashes ntx
-    | ntx == 0 = Left $
+    | ntx == 0 = Left
         "extractMatches: number of transactions can not be 0"
-    | ntx > maxBlockSize `div` 60 = Left $
+    | ntx > maxBlockSize `div` 60 = Left
         "extractMatches: number of transactions excessively high"
-    | length hashes > ntx = Left $
+    | length hashes > ntx = Left
         "extractMatches: More hashes provided than the number of transactions"
-    | length flags < length hashes = Left $
+    | length flags < length hashes = Left
         "extractMatches: At least one bit per node and one bit per hash"
-    | isNothing resM = Left $
+    | isNothing resM = Left
         "extractMatches: traverseAndExtract failed"
-    | (nBitsUsed+7) `div` 8 /= (length flags+7) `div` 8 = Left $
+    | (nBitsUsed+7) `div` 8 /= (length flags+7) `div` 8 = Left
         "extractMatches: All bits were not consumed"
     | nHashUsed /= length hashes = Left $
-        "extractMatches: All hashes were not consumed: " ++ (show nHashUsed)
+        "extractMatches: All hashes were not consumed: " ++ show nHashUsed
     | otherwise = return (merkRoot, matches)
   where
     resM = traverseAndExtract (calcTreeHeight ntx) 0 ntx flags hashes
@@ -198,7 +187,7 @@ extractMatches flags hashes ntx
 
 splitIn :: Int -> [a] -> [[a]]
 splitIn _ [] = []
-splitIn c xs = take c xs : (splitIn c $ drop c xs)
+splitIn c xs = take c xs : splitIn c (drop c xs)
 
 boolsToWord8 :: [Bool] -> Word8
 boolsToWord8 [] = 0

--- a/haskoin-core/src/Network/Haskoin/Constants.hs
+++ b/haskoin-core/src/Network/Haskoin/Constants.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-cse -fno-full-laziness #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-|
   Network specific constants
 -}
@@ -8,9 +9,11 @@ module Network.Haskoin.Constants
 , prodnet
 , testnet3
 , testnet5
+, regtest
   -- ** Functions
-, switchToTestnet3
-, switchToTestnet5
+, setTestnet
+, setRegtest
+, setProdnet
 , setNetwork
 , getNetwork
   -- ** Network parameters
@@ -27,139 +30,159 @@ module Network.Haskoin.Constants
 , haskoinUserAgent
 , defaultPort
 , allowMinDifficultyBlocks
+, powNoRetargetting
 , powLimit
+, bip34Block
+, bip65Height
+, bip66Height
 , targetTimespan
 , targetSpacing
 , checkpoints
 , bip44Coin
+, seeds
 ) where
 
-import Data.Bits (shiftR)
-import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as C8 (concat, pack)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.Version (showVersion)
-import Data.Word (Word8, Word32, Word64)
-import Data.LargeWord (Word256)
-import Network.Haskoin.Block.Types
-import System.IO.Unsafe (unsafePerformIO)
-import Paths_haskoin_core (version)
+import           Data.ByteString             (ByteString)
+import qualified Data.ByteString.Char8       as C8 (concat, pack)
+import           Data.IORef                  (IORef, newIORef, readIORef,
+                                              writeIORef)
+import           Data.Version                (showVersion)
+import           Data.Word                   (Word32, Word64, Word8)
+import           Network.Haskoin.Block.Types
+import           Paths_haskoin_core          (version)
+import           System.IO.Unsafe            (unsafePerformIO)
 
 data Network = Network
-    { getNetworkName                :: !String
-    , getAddrPrefix                 :: !Word8
-    , getScriptPrefix               :: !Word8
-    , getSecretPrefix               :: !Word8
-    , getExtPubKeyPrefix            :: !Word32
-    , getExtSecretPrefix            :: !Word32
-    , getNetworkMagic               :: !Word32
-    , getGenesisHeader              :: !BlockHeader
-    , getMaxBlockSize               :: !Int
-    , getMaxSatoshi                 :: !Word64
-    , getHaskoinUserAgent           :: !ByteString
-    , getDefaultPort                :: !Int
-    , getAllowMinDifficultyBlocks   :: !Bool
-    , getPowLimit                   :: !Integer
-    , getTargetTimespan             :: !Word32
-    , getTargetSpacing              :: !Word32
-    , getCheckpoints                :: ![(Int, BlockHash)]
+    { getNetworkName              :: !String
+    , getAddrPrefix               :: !Word8
+    , getScriptPrefix             :: !Word8
+    , getSecretPrefix             :: !Word8
+    , getExtPubKeyPrefix          :: !Word32
+    , getExtSecretPrefix          :: !Word32
+    , getNetworkMagic             :: !Word32
+    , getGenesisHeader            :: !BlockHeader
+    , getMaxBlockSize             :: !Int
+    , getMaxSatoshi               :: !Word64
+    , getHaskoinUserAgent         :: !ByteString
+    , getDefaultPort              :: !Int
+    , getAllowMinDifficultyBlocks :: !Bool
+    , getPowNoRetargetting        :: !Bool
+    , getPowLimit                 :: !Integer
+    , getBip34Block               :: !(BlockHeight, BlockHash)
+    , getBip65Height              :: !BlockHeight
+    , getBip66Height              :: !BlockHeight
+    , getTargetTimespan           :: !Word32
+    , getTargetSpacing            :: !Word32
+    , getCheckpoints              :: ![(BlockHeight, BlockHash)]
     , getBip44Coin                  :: !Word32
-    } deriving (Eq, Show, Read)
+    , getSeeds                    :: [String]
+    } deriving Eq
 
--- | Switch to Testnet3.  Do at start of program.
-switchToTestnet3 :: IO ()
-switchToTestnet3 = setNetwork testnet3
+setRegtest :: IO ()
+setRegtest = setNetwork regtest
 
--- | Switch to Testnet5.  Do at start of program.
-switchToTestnet5 :: IO ()
-switchToTestnet5 = setNetwork testnet5
+setTestnet :: IO ()
+setTestnet = setNetwork testnet5
 
--- | Change network constants manually.  If switching to Testnet3, use
--- switchToTestnet3 instead.
+setProdnet :: IO ()
+setProdnet = setNetwork prodnet
+
 setNetwork :: Network -> IO ()
-setNetwork = writeIORef networkRef
+setNetwork net = writeIORef networkRef net >> writeIORef networkSetRef True
 
 {-# NOINLINE networkRef #-}
--- | Use this if you want to change constants to something other than Testnet3.
 networkRef :: IORef Network
 networkRef = unsafePerformIO $ newIORef prodnet
 
-{-# NOINLINE getNetwork #-}
--- | Read current network constants record
-getNetwork :: Network
-getNetwork = unsafePerformIO $ readIORef networkRef
+{-# NOINLINE networkSetRef #-}
+networkSetRef :: IORef Bool
+networkSetRef = unsafePerformIO $ newIORef False
 
--- | Name of the bitcoin network
+{-# NOINLINE getNetwork #-}
+getNetwork :: Network
+getNetwork =
+    let (net, set) = unsafePerformIO $
+                     (,) <$> readIORef networkRef <*> readIORef networkSetRef
+    in if set
+       then net
+       else error "Use Network.Haskoin.Constants.setNetwork"
+
 networkName :: String
 networkName = getNetworkName getNetwork
 
--- | Prefix for base58 PubKey hash address
 addrPrefix :: Word8
 addrPrefix = getAddrPrefix getNetwork
 
--- | Prefix for base58 script hash address
 scriptPrefix :: Word8
 scriptPrefix = getScriptPrefix getNetwork
 
--- | Prefix for private key WIF format
 secretPrefix :: Word8
 secretPrefix = getSecretPrefix getNetwork
 
--- | Prefix for extended public keys (BIP32)
 extPubKeyPrefix :: Word32
 extPubKeyPrefix = getExtPubKeyPrefix getNetwork
 
--- | Prefix for extended private keys (BIP32)
 extSecretPrefix :: Word32
 extSecretPrefix = getExtSecretPrefix getNetwork
 
--- | Network magic bytes
 networkMagic :: Word32
 networkMagic = getNetworkMagic getNetwork
 
--- | Genesis block header information
 genesisHeader :: BlockHeader
 genesisHeader = getGenesisHeader getNetwork
 
--- | Maximum size of a block in bytes
 maxBlockSize :: Int
 maxBlockSize = getMaxBlockSize getNetwork
 
--- | Maximum number of satoshi
 maxSatoshi :: Word64
 maxSatoshi = getMaxSatoshi getNetwork
 
--- | User agent string
 haskoinUserAgent :: ByteString
 haskoinUserAgent = getHaskoinUserAgent getNetwork
 
--- | Default port
 defaultPort :: Int
 defaultPort = getDefaultPort getNetwork
 
--- | Allow relaxed difficulty transition rules
 allowMinDifficultyBlocks :: Bool
 allowMinDifficultyBlocks = getAllowMinDifficultyBlocks getNetwork
 
--- | Lower bound for the proof of work difficulty
+powNoRetargetting :: Bool
+powNoRetargetting = getPowNoRetargetting getNetwork
+
 powLimit :: Integer
 powLimit = getPowLimit getNetwork
 
--- | Time between difficulty cycles (2 weeks on average)
+-- | Version 2 blocks start here.
+bip34Block :: (BlockHeight, BlockHash)
+bip34Block = getBip34Block getNetwork
+
+-- | Version 3 blocks start here.
+bip65Height :: BlockHeight
+bip65Height = getBip65Height getNetwork
+
+-- | Version 4 blocks start here.
+bip66Height :: BlockHeight
+bip66Height = getBip66Height getNetwork
+
+-- | Time between difficulty cycles (2 weeks on average).
 targetTimespan :: Word32
 targetTimespan = getTargetTimespan getNetwork
 
--- | Time between blocks (10 minutes per block)
+-- | Time between blocks (10 minutes per block).
 targetSpacing :: Word32
 targetSpacing = getTargetSpacing getNetwork
 
--- | Checkpoints to enfore
-checkpoints :: [(Int, BlockHash)]
+-- | Checkpoints to enfore.
+checkpoints :: [(Word32, BlockHash)]
 checkpoints = getCheckpoints getNetwork
 
 -- | Bip44 coin derivation (m/44'/coin'/account'/internal/address/)
 bip44Coin :: Word32
 bip44Coin = getBip44Coin getNetwork
+
+-- | DNS seeds.
+seeds :: [String]
+seeds = getSeeds getNetwork
 
 prodnet :: Network
 prodnet = Network
@@ -170,63 +193,69 @@ prodnet = Network
     , getExtPubKeyPrefix = 0x0488b21e
     , getExtSecretPrefix = 0x0488ade4
     , getNetworkMagic = 0xf9beb4d9
-    , getGenesisHeader = createBlockHeader
-        0x01
-        "0000000000000000000000000000000000000000000000000000000000000000"
-        "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
-        1231006505
-        486604799
-        2083236893
-        -- Hash 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+    , getGenesisHeader =
+        createBlockHeader
+            0x01
+            "0000000000000000000000000000000000000000000000000000000000000000"
+            "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
+            1231006505
+            0x1d00ffff
+            2083236893
+            -- Hash 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
     , getMaxBlockSize = 2000000
     , getMaxSatoshi = 2100000000000000
     , getHaskoinUserAgent = C8.concat
         [ "/haskoin:"
         , C8.pack $ showVersion version
-        , "/"
-        ]
+        , "/" ]
     , getDefaultPort = 8333
     , getAllowMinDifficultyBlocks = False
-    , getPowLimit = fromIntegral (maxBound `shiftR` 32 :: Word256)
+    , getPowNoRetargetting = False
+    , getPowLimit =
+        0x00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    , getBip34Block =
+        ( 227931
+        , "000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8" )
+    , getBip65Height = 388381
+    , getBip66Height = 363725
     , getTargetTimespan = 14 * 24 * 60 * 60
     , getTargetSpacing = 10 * 60
     , getCheckpoints =
         [ ( 11111
-          , "0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"
-          )
+          , "0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d" )
         , ( 33333
-          , "000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"
-          )
+          , "000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6" )
         , ( 74000
-          , "0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20"
-          )
+          , "0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20" )
         , ( 105000
-          , "00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97"
-          )
+          , "00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97" )
         , ( 134444
-          , "00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe"
-          )
+          , "00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe" )
         , ( 168000
-          , "000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763"
-          )
+          , "000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763" )
         , ( 193000
-          , "000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317"
-          )
+          , "000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317" )
         , ( 210000
-          , "000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e"
-          )
+          , "000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e" )
         , ( 216116
-          , "00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e"
-          )
+          , "00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e" )
         , ( 225430
-          , "00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932"
-          )
+          , "00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932" )
         , ( 250000
-          , "000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"
-          )
+          , "000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214" )
         , ( 279000
-          , "0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40"
-          )
+          , "0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40" )
+        ]
+    , getSeeds =
+        [ "seed.mainnet.b-pay.net"        -- BitPay
+        , "seed.ob1.io"                   -- OB1
+        , "seed.blockchain.info"          -- Blockchain
+        , "bitcoin.bloqseeds.net"         -- Bloq
+        , "seed.bitcoin.sipa.be"          -- Pieter Wuille
+        , "dnsseed.bluematt.me"           -- Matt Corallo
+        , "dnsseed.bitcoin.dashjr.org"    -- Luke Dashjr
+        , "seed.bitcoinstats.com"         -- Chris Decker
+        , "seed.bitcoin.jonasschnelli.ch" -- Jonas Schnelli
         ]
     , getBip44Coin = 0
     }
@@ -240,24 +269,34 @@ testnet3 = Network
     , getExtPubKeyPrefix = 0x043587cf
     , getExtSecretPrefix = 0x04358394
     , getNetworkMagic = 0x0b110907
-    , getGenesisHeader = createBlockHeader
-        0x01
-        "0000000000000000000000000000000000000000000000000000000000000000"
-        "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
-        1296688602
-        486604799
-        414098458
-        -- Hash 000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
+    , getGenesisHeader =
+        createBlockHeader
+            0x01
+            "0000000000000000000000000000000000000000000000000000000000000000"
+            "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
+            1296688602
+            486604799
+            414098458
+            -- Hash 000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
     , getMaxBlockSize = 1000000
     , getMaxSatoshi = 2100000000000000
-    , getHaskoinUserAgent = C8.concat
-        [ "/haskoin-testnet3:"
-        , C8.pack $ showVersion version
-        , "/"
-        ]
+    , getHaskoinUserAgent =
+        C8.concat
+            [ "/haskoin-testnet3:"
+            , C8.pack $ showVersion version
+            , "/"
+            ]
     , getDefaultPort = 18333
     , getAllowMinDifficultyBlocks = True
-    , getPowLimit = fromIntegral (maxBound `shiftR` 32 :: Word256)
+    , getPowNoRetargetting = False
+    , getPowLimit =
+        0x00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    , getBip34Block =
+        ( 21111
+        , "0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8"
+        )
+    , getBip65Height = 581885
+    , getBip66Height = 330776
     , getTargetTimespan = 14 * 24 * 60 * 60
     , getTargetSpacing = 10 * 60
     , getCheckpoints =
@@ -265,8 +304,14 @@ testnet3 = Network
           , "000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70"
           )
         ]
+    , getSeeds =
+        [ "testnet-seed.bitcoin.jonasschnelli.ch"
+        , "seed.tbtc.petertodd.org"
+        , "testnet-seed.bluematt.me"
+        , "testnet-seed.bitcoin.schildbach.de"
+        ]
     , getBip44Coin = 1
-    }
+}
 
 testnet5 :: Network
 testnet5 = Network
@@ -294,12 +339,64 @@ testnet5 = Network
         ]
     , getDefaultPort = 18555
     , getAllowMinDifficultyBlocks = True
-    , getPowLimit = fromIntegral (maxBound `shiftR` 32 :: Word256)
+    , getPowNoRetargetting = False
+    , getPowLimit =
+        0x00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    , getBip34Block =
+        ( 10001
+        , "00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8" )
+    , getBip65Height = 10001
+    , getBip66Height = 10001
     , getTargetTimespan = 14 * 24 * 60 * 60
     , getTargetSpacing = 10 * 60
     , getCheckpoints =
         [ ( 10001
           , "00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8" )
         ]
+    , getSeeds =
+      [ "seed.testnet5.b-pay.net"
+      , "bitcoin-testnet.bloqseeds.net" -- Bloq
+      ]
     , getBip44Coin = 1
     }
+
+regtest :: Network
+regtest = Network
+    { getNetworkName = "regtest"
+    , getAddrPrefix = 111
+    , getScriptPrefix = 196
+    , getSecretPrefix = 239
+    , getExtPubKeyPrefix = 0x043587cf
+    , getExtSecretPrefix = 0x04358394
+    , getNetworkMagic = 0xfabfb5da
+    , getGenesisHeader = createBlockHeader
+        -- 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
+        0x01
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
+        1296688602
+        0x207fffff
+        2
+    , getMaxBlockSize = 2000000
+    , getMaxSatoshi = 2100000000000000
+    , getHaskoinUserAgent = C8.concat
+        [ "/haskoin-regtest:"
+        , C8.pack $ showVersion version
+        , "/" ]
+    , getDefaultPort = 18444
+    , getAllowMinDifficultyBlocks = True
+    , getPowNoRetargetting = True
+    , getPowLimit =
+        0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    , getBip34Block =
+        ( 100000000
+        , "0000000000000000000000000000000000000000000000000000000000000000" )
+    , getBip65Height = 1351
+    , getBip66Height = 1251
+    , getTargetTimespan = 14 * 24 * 60 * 60
+    , getTargetSpacing = 10 * 60
+    , getCheckpoints = []
+    , getSeeds = [ "localhost" ]
+    , getBip44Coin = 1
+    }
+

--- a/haskoin-core/src/Network/Haskoin/Crypto.hs
+++ b/haskoin-core/src/Network/Haskoin/Crypto.hs
@@ -66,6 +66,10 @@ module Network.Haskoin.Crypto
 , Hash512(getHash512)
 , Hash256(getHash256)
 , Hash160(getHash160)
+, hash512ToBS
+, hash256ToBS
+, hash160ToBS
+, hashSHA1ToBS
 , bsToCheckSum32
 , bsToHash512
 , bsToHash256
@@ -74,7 +78,7 @@ module Network.Haskoin.Crypto
 , hash512
 , hash256
 , hash160
-, sha1
+, hashSHA1
 , doubleHash256
 , hmac512
 , hmac256

--- a/haskoin-core/src/Network/Haskoin/Crypto/Hash.hs
+++ b/haskoin-core/src/Network/Haskoin/Crypto/Hash.hs
@@ -1,18 +1,25 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Hashing functions and HMAC DRBG definition
 module Network.Haskoin.Crypto.Hash
 ( Hash512(getHash512)
 , Hash256(getHash256)
 , Hash160(getHash160)
+, HashSHA1(getHashSHA1)
 , CheckSum32(getCheckSum32)
-, bsToHash512
-, bsToHash256
-, bsToHash160
 , hash512
 , hash256
 , hash160
-, sha1
-, doubleHash256
+, hashSHA1
+, hash512ToBS
+, hash256ToBS
+, hash160ToBS
+, hashSHA1ToBS
+, bsToHash512
+, bsToHash256
+, bsToHash160
+, bsToHashSHA1
 , bsToCheckSum32
+, doubleHash256
 , checkSum32
 , hmac512
 , hmac256
@@ -25,202 +32,206 @@ module Network.Haskoin.Crypto.Hash
 , WorkingState
 ) where
 
-import           Control.DeepSeq         (NFData, rnf)
-import           Control.Monad           (guard, (<=<))
-import           Crypto.Hash             (Digest, RIPEMD160, SHA1, SHA256,
-                                          SHA512, hash)
-import           Crypto.MAC.HMAC         (hmac)
-import           Data.Byteable           (toBytes)
+import           Control.DeepSeq         (NFData)
+import           Control.Monad           (guard)
+import           Crypto.Hash             (RIPEMD160 (..), SHA1 (..),
+                                          SHA256 (..), SHA512 (..), hashWith)
+import           Crypto.MAC.HMAC         (HMAC, hmac)
+import           Data.ByteArray          (ByteArrayAccess)
+import qualified Data.ByteArray          as BA
 import           Data.ByteString         (ByteString)
 import qualified Data.ByteString         as BS
-import           Data.Maybe              (fromMaybe)
-import           Data.Serialize          (Serialize, get, put)
-import           Data.Serialize.Get      (getByteString)
-import           Data.Serialize.Put      (putByteString)
+import           Data.ByteString.Short   (ShortByteString)
+import qualified Data.ByteString.Short   as BSS
+import           Data.Hashable           (Hashable)
+import           Data.Serialize          (Serialize (..))
+import qualified Data.Serialize.Get      as Get
+import qualified Data.Serialize.Put      as Put
 import           Data.String             (IsString, fromString)
 import           Data.String.Conversions (cs)
-import           Data.Word               (Word16)
-import           Text.Read               (Lexeme (Ident, String), lexP, parens,
-                                          pfail, readPrec)
-
+import           Data.Word               (Word16, Word32)
 import           Network.Haskoin.Util
 
-newtype CheckSum32 = CheckSum32 { getCheckSum32 :: ByteString }
-    deriving (Eq, Ord)
+newtype CheckSum32 = CheckSum32 { getCheckSum32 :: Word32 }
+    deriving (Eq, Ord, Serialize, NFData, Show, Hashable)
 
-newtype Hash512 = Hash512 { getHash512 :: ByteString }
-    deriving (Eq, Ord)
+newtype Hash512 = Hash512 { getHash512 :: ShortByteString }
+    deriving (Eq, Ord, NFData, Hashable)
 
-newtype Hash256 = Hash256 { getHash256 :: ByteString }
-    deriving (Eq, Ord)
+newtype Hash256 = Hash256 { getHash256 :: ShortByteString }
+    deriving (Eq, Ord, NFData, Hashable)
 
-newtype Hash160 = Hash160 { getHash160 :: ByteString }
-    deriving (Eq, Ord)
+newtype Hash160 = Hash160 { getHash160 :: ShortByteString }
+    deriving (Eq, Ord, NFData, Hashable)
 
-
-instance NFData CheckSum32 where
-    rnf (CheckSum32 bs) = rnf bs
-
-instance Show CheckSum32 where
-    showsPrec d (CheckSum32 bs) = showParen (d > 10) $
-        showString "CheckSum32 " . shows (encodeHex bs)
-
-instance Read CheckSum32 where
-    readPrec = parens $ do
-        Ident "CheckSum32" <- lexP
-        String str <- lexP
-        maybe pfail return $ bsToCheckSum32 =<< decodeHex (cs str)
-
-instance IsString CheckSum32 where
-    fromString =
-        fromMaybe e . (bsToCheckSum32 <=< decodeHex) . cs
-      where
-        e = error "Could not decode checksum"
-
-instance Serialize CheckSum32 where
-    get = CheckSum32 <$> getByteString 4
-    put (CheckSum32 bs) = putByteString bs
-
-
-instance NFData Hash512 where
-    rnf (Hash512 bs) = rnf bs
+newtype HashSHA1 = HashSHA1 { getHashSHA1 :: ShortByteString }
+    deriving (Eq, Ord, NFData, Hashable)
 
 instance Show Hash512 where
-    showsPrec d (Hash512 bs) = showParen (d > 10) $
-        showString "Hash512 " . shows (encodeHex bs)
-
-instance Read Hash512 where
-    readPrec = parens $ do
-        Ident "Hash512" <- lexP
-        String str <- lexP
-        maybe pfail return $ bsToHash512 =<< decodeHex (cs str)
-
-instance IsString Hash512 where
-    fromString =
-        fromMaybe e . (bsToHash512 <=< decodeHex) . cs
-      where
-        e = error "Could not decode 64-byte hash"
-
-instance Serialize Hash512 where
-    get = Hash512 <$> getByteString 64
-    put (Hash512 bs) = putByteString bs
-
-
-instance NFData Hash256 where
-    rnf (Hash256 bs) = rnf bs
+    show = cs . encodeHex . hash512ToBS
 
 instance Show Hash256 where
-    showsPrec d (Hash256 bs) = showParen (d > 10) $
-        showString "Hash256 " . shows (encodeHex bs)
-
-instance Read Hash256 where
-    readPrec = parens $ do
-        Ident "Hash256" <- lexP
-        String str <- lexP
-        maybe pfail return $ bsToHash256 =<< decodeHex (cs str)
-
-instance IsString Hash256 where
-    fromString =
-        fromMaybe e . (bsToHash256 <=< decodeHex) . cs
-      where
-        e = error "Could not decode 32-byte hash"
-
-instance Serialize Hash256 where
-    get = Hash256 <$> getByteString 32
-    put (Hash256 bs) = putByteString bs
-
-
-instance NFData Hash160 where
-    rnf (Hash160 bs) = rnf bs
+    show = cs . encodeHex . hash256ToBS
 
 instance Show Hash160 where
-    showsPrec d (Hash160 bs) = showParen (d > 10) $
-        showString "Hash160 " . shows (encodeHex bs)
+    show = cs . encodeHex . hash160ToBS
 
-instance Read Hash160 where
-    readPrec = parens $ do
-        Ident "Hash160" <- lexP
-        String str <- lexP
-        maybe pfail return $ bsToHash160 =<< decodeHex (cs str)
+instance Show HashSHA1 where
+    show = cs . encodeHex . hashSHA1ToBS
+
+instance IsString Hash512 where
+    fromString str =
+        case decodeHex $ cs str of
+            Nothing -> e
+            Just bs ->
+                case BS.length bs of
+                    64 -> Hash512 (BSS.toShort bs)
+                    _  -> e
+      where
+        e = error "Could not decode hash from hex string"
+
+instance Serialize Hash512 where
+    get = do
+        bs <- Get.getByteString 64
+        return $ Hash512 $ BSS.toShort bs
+    put = Put.putByteString . hash512ToBS
+
+instance IsString Hash256 where
+    fromString str =
+        case decodeHex $ cs str of
+            Nothing -> e
+            Just bs ->
+                case BS.length bs of
+                    32 -> Hash256 (BSS.toShort bs)
+                    _  -> e
+      where
+        e = error "Could not decode hash from hex string"
+
+instance Serialize Hash256 where
+    get = do
+        bs <- Get.getByteString 32
+        return $ Hash256 $ BSS.toShort bs
+    put = Put.putByteString . hash256ToBS
 
 instance IsString Hash160 where
-    fromString =
-        fromMaybe e . (bsToHash160 <=< decodeHex) . cs
+    fromString str =
+        case decodeHex $ cs str of
+            Nothing -> e
+            Just bs ->
+                case BS.length bs of
+                    20 -> Hash160 (BSS.toShort bs)
+                    _  -> e
       where
-        e = error "Could not decode 20-byte hash"
+        e = error "Could not decode hash from hex string"
 
 instance Serialize Hash160 where
-    get = Hash160 <$> getByteString 20
-    put (Hash160 bs) = putByteString bs
+    get = do
+        bs <- Get.getByteString 20
+        return $ Hash160 $ BSS.toShort bs
+    put = Put.putByteString . hash160ToBS
 
+instance IsString HashSHA1 where
+    fromString str =
+        case decodeHex $ cs str of
+            Nothing -> e
+            Just bs ->
+                case BS.length bs of
+                    20 -> HashSHA1 (BSS.toShort bs)
+                    _  -> e
+      where
+        e = error "Could not decode hash from hex string"
 
-bsToHash512 :: ByteString -> Maybe Hash512
-bsToHash512 bs = guard (BS.length bs == 64) >> return (Hash512 bs)
+instance Serialize HashSHA1 where
+    get = do
+        bs <- Get.getByteString 20
+        return $ HashSHA1 $ BSS.toShort bs
+    put = Put.putByteString . hashSHA1ToBS
 
-bsToHash256 :: ByteString -> Maybe Hash256
-bsToHash256 bs = guard (BS.length bs == 32) >> return (Hash256 bs)
+hash512 :: ByteArrayAccess b => b -> Hash512
+hash512 = Hash512 . BSS.toShort . BA.convert . hashWith SHA512
 
-bsToHash160 :: ByteString -> Maybe Hash160
-bsToHash160 bs = guard (BS.length bs == 20) >> return (Hash160 bs)
+hash256 :: ByteArrayAccess b => b -> Hash256
+hash256 = Hash256 . BSS.toShort . BA.convert . hashWith SHA256
 
--- | Compute SHA-512.
-hash512 :: ByteString -> Hash512
-hash512 = Hash512 . (toBytes :: Digest SHA512 -> ByteString) . hash
+hash160 :: ByteArrayAccess b => b -> Hash160
+hash160 = Hash160 . BSS.toShort . BA.convert. hashWith RIPEMD160
 
--- | Compute SHA-256.
-hash256 :: ByteString -> Hash256
-hash256 = Hash256 . (toBytes :: Digest SHA256 -> ByteString) . hash
+hashSHA1 :: ByteArrayAccess b => b -> HashSHA1
+hashSHA1 = HashSHA1 . BSS.toShort . BA.convert . hashWith SHA1
 
--- | Compute RIPEMD-160.
-hash160 :: ByteString -> Hash160
-hash160 = Hash160 . (toBytes :: Digest RIPEMD160 -> ByteString) . hash
+hash512ToBS :: Hash512 -> ByteString
+hash512ToBS (Hash512 bs) = BSS.fromShort bs
 
--- | Compute SHA1
-sha1 :: ByteString -> Hash160
-sha1 = Hash160 . (toBytes :: Digest SHA1 -> ByteString) . hash
+hash256ToBS :: Hash256 -> ByteString
+hash256ToBS (Hash256 bs) = BSS.fromShort bs
+
+hash160ToBS :: Hash160 -> ByteString
+hash160ToBS (Hash160 bs) = BSS.fromShort bs
+
+hashSHA1ToBS :: HashSHA1 -> ByteString
+hashSHA1ToBS (HashSHA1 bs) = BSS.fromShort bs
+
+bsToHash512 :: ByteArrayAccess b => b -> Maybe Hash512
+bsToHash512 bs = do
+    guard $ BA.length bs == 64
+    return $ Hash512 $ BSS.toShort $ BA.convert bs
+
+bsToHash256 :: ByteArrayAccess b => b -> Maybe Hash256
+bsToHash256 bs = do
+    guard $ BA.length bs == 32
+    return $ Hash256 $ BSS.toShort $ BA.convert bs
+
+bsToHash160 :: ByteArrayAccess b => b -> Maybe Hash160
+bsToHash160 bs = do
+    guard $ BA.length bs == 20
+    return $ Hash160 $ BSS.toShort $ BA.convert bs
+
+bsToHashSHA1 :: ByteArrayAccess b => b -> Maybe HashSHA1
+bsToHashSHA1 bs = do
+    guard $ BA.length bs == 20
+    return $ HashSHA1 $ BSS.toShort $ BA.convert bs
+
+bsToCheckSum32 :: ByteString -> Maybe CheckSum32
+bsToCheckSum32 = decodeMaybeStrict
 
 -- | Compute two rounds of SHA-256.
-doubleHash256 :: ByteString -> Hash256
-doubleHash256 = hash256 . getHash256 . hash256
+doubleHash256 :: ByteArrayAccess b => b -> Hash256
+doubleHash256 =
+    Hash256 . BSS.toShort . BA.convert . hashWith SHA256 . hashWith SHA256
 
 {- CheckSum -}
 
-bsToCheckSum32 :: ByteString -> Maybe CheckSum32
-bsToCheckSum32 bs = guard (BS.length bs == 4) >> return (CheckSum32 bs)
-
 -- | Computes a 32 bit checksum.
-checkSum32 :: ByteString -> CheckSum32
-checkSum32 bs =
-    CheckSum32 $ BS.take 4 bs'
-  where
-    Hash256 bs' = doubleHash256 bs
+checkSum32 :: ByteArrayAccess b => b -> CheckSum32
+checkSum32 = decodeStrict
+             . BS.take 4
+             . BA.convert
+             . hashWith SHA256
+             . hashWith SHA256
 
 {- HMAC -}
 
 -- | Computes HMAC over SHA-512.
 hmac512 :: ByteString -> ByteString -> Hash512
 hmac512 key msg =
-    Hash512 $ hmac f 128 key msg
-  where
-    f bs = let Hash512 bs' = hash512 bs in bs'
+    Hash512 $ BSS.toShort $ BA.convert (hmac key msg :: HMAC SHA512)
 
 -- | Computes HMAC over SHA-256.
-hmac256 :: ByteString -> ByteString -> Hash256
+hmac256 :: (ByteArrayAccess k, ByteArrayAccess m) => k -> m -> Hash256
 hmac256 key msg =
-    Hash256 $ hmac f 64 key msg
-  where
-    f bs = let Hash256 bs' = hash256 bs in bs'
+    Hash256 $ BSS.toShort $ BA.convert (hmac key msg :: HMAC SHA256)
 
 -- | Split a 'Hash512' into a pair of 'Hash256'.
 split512 :: Hash512 -> (Hash256, Hash256)
-split512 (Hash512 bs) =
-    (Hash256 a, Hash256 b)
+split512 h =
+    (Hash256 (BSS.toShort a), Hash256 (BSS.toShort b))
   where
-    (a, b) = BS.splitAt 32 bs
+    (a, b) = BS.splitAt 32 $ hash512ToBS h
 
 -- | Join a pair of 'Hash256' into a 'Hash512'.
 join512 :: (Hash256, Hash256) -> Hash512
-join512 (Hash256 a, Hash256 b) = Hash512 $ a `BS.append` b
+join512 (a, b) =
+    Hash512 $ BSS.toShort $ hash256ToBS a `BS.append` hash256ToBS b
 
 
 {- 10.1.2 HMAC_DRBG with HMAC-SHA256
@@ -236,20 +247,22 @@ type Nonce           = ByteString
 type PersString      = ByteString
 
 -- 10.1.2.2 HMAC DRBG Update FUnction
-hmacDRBGUpd :: ProvidedData -> ByteString -> ByteString
+hmacDRBGUpd :: ProvidedData
+            -> ByteString
+            -> ByteString
             -> (ByteString, ByteString)
 hmacDRBGUpd info k0 v0
     | BS.null info = (k1, v1)        -- 10.1.2.2.3
     | otherwise    = (k2, v2)        -- 10.1.2.2.6
   where
     -- 10.1.2.2.1
-    Hash256 k1 = hmac256 k0 $ v0 `BS.append` (0 `BS.cons` info)
+    k1 = hash256ToBS . hmac256 k0 $ v0 `BS.append` (0 `BS.cons` info)
     -- 10.1.2.2.2
-    Hash256 v1 = hmac256 k1 v0
+    v1 = hash256ToBS $ hmac256 k1 v0
     -- 10.1.2.2.4
-    Hash256 k2 = hmac256 k1 $ v1 `BS.append` (1 `BS.cons` info)
+    k2 = hash256ToBS $ hmac256 k1 $ v1 `BS.append` (1 `BS.cons` info)
     -- 10.1.2.2.5
-    Hash256 v2 = hmac256 k2 v1
+    v2 = hash256ToBS $ hmac256 k2 v1
 
 -- 10.1.2.3 HMAC DRBG Instantiation
 hmacDRBGNew :: EntropyInput -> Nonce -> PersString -> WorkingState
@@ -280,7 +293,9 @@ hmacDRBGRsd (k, v, _) seed info
     (k0, v0) = hmacDRBGUpd s k v     -- 10.1.2.4.2
 
 -- 10.1.2.5 HMAC DRBG Generation
-hmacDRBGGen :: WorkingState -> Word16 -> AdditionalInput
+hmacDRBGGen :: WorkingState
+            -> Word16
+            -> AdditionalInput
             -> (WorkingState, Maybe ByteString)
 hmacDRBGGen (k0, v0, c0) bytes info
     | bytes * 8 > 7500 = error "Maximum bits per request is 7500"
@@ -289,11 +304,11 @@ hmacDRBGGen (k0, v0, c0) bytes info
   where
     (k1, v1)  | BS.null info = (k0, v0)
               | otherwise    = hmacDRBGUpd info k0 v0   -- 10.1.2.5.2
-    (tmp, v2) = go (fromIntegral bytes) k1 v1 BS.empty -- 10.1.2.5.3/4
-    res       = BS.take (fromIntegral bytes) tmp       -- 10.1.2.5.5
-    (k2, v3)  = hmacDRBGUpd info k1 v2                 -- 10.1.2.5.6
-    c1        = c0 + 1                                 -- 10.1.2.5.7
-    go l k v acc | BS.length acc >= l = (acc,v)
-                 | otherwise = let vn = getHash256 $ hmac256 k v
+    (tmp, v2) = go (fromIntegral bytes) k1 v1 BS.empty  -- 10.1.2.5.3/4
+    res       = BS.take (fromIntegral bytes) tmp        -- 10.1.2.5.5
+    (k2, v3)  = hmacDRBGUpd info k1 v2                  -- 10.1.2.5.6
+    c1        = c0 + 1                                  -- 10.1.2.5.7
+    go l k v acc | BS.length acc >= l = (acc, v)
+                 | otherwise = let vn = hash256ToBS $ hmac256 k v
                                in go l k vn (acc `BS.append` vn)
 

--- a/haskoin-core/src/Network/Haskoin/Crypto/Mnemonic.hs
+++ b/haskoin-core/src/Network/Haskoin/Crypto/Mnemonic.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -- | Mnemonic keys (BIP-39). Only the English dictionary in the BIP is
 -- supported.
 module Network.Haskoin.Crypto.Mnemonic
@@ -20,12 +21,13 @@ module Network.Haskoin.Crypto.Mnemonic
 ) where
 
 import           Control.Monad           (when)
-import qualified Crypto.Hash.SHA256      as SHA256
+import           Crypto.Hash             (SHA256 (..), hashWith)
 import           Crypto.PBKDF.ByteString (sha512PBKDF2)
 import           Data.Bits               (shiftL, shiftR, (.&.))
+import qualified Data.ByteArray          as BA
 import           Data.ByteString         (ByteString)
 import qualified Data.ByteString         as BS
-import qualified Data.ByteString.Char8   as C
+import qualified Data.ByteString.Char8   as C (unwords, words)
 import           Data.List
 import qualified Data.Map.Strict         as M
 import           Data.Maybe
@@ -82,7 +84,7 @@ fromMnemonic ms = do
     sh cs_a cs_b = show cs_a ++ " /= " ++ show cs_b
 
 calcCS :: Int -> Entropy -> Checksum
-calcCS len = getBits len . SHA256.hash
+calcCS len = getBits len . BA.convert . hashWith SHA256
 
 numCS :: Int -> Entropy -> Integer
 numCS len =

--- a/haskoin-core/src/Network/Haskoin/Network/Types.hs
+++ b/haskoin-core/src/Network/Haskoin/Network/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 module Network.Haskoin.Network.Types
 ( Addr(..)
 , NetworkAddressTime
@@ -17,59 +19,45 @@ module Network.Haskoin.Network.Types
 , VarString(..)
 , Version(..)
 , MessageCommand(..)
+, commandToString
+, stringToCommand
+, nodeNone
+, nodeNetwork
+, nodeGetUTXO
+, nodeBloom
+, nodeWitness
+, nodeXThin
 ) where
 
-import Control.DeepSeq (NFData, rnf)
-import Control.Monad (replicateM, liftM2, forM_, unless)
-
-import Data.Word (Word32, Word64)
-import Data.Serialize (Serialize, get, put)
-import Data.Serialize.Get
-    ( Get
-    , getWord8
-    , getWord16le
-    , getWord16be
-    , getWord32be
-    , getWord32host
-    , getWord32le
-    , getWord64le
-    , getByteString
-    , isEmpty
-    )
-import Data.Serialize.Put
-    ( Put
-    , putWord8
-    , putWord16le
-    , putWord16be
-    , putWord32be
-    , putWord32host
-    , putWord32le
-    , putWord64le
-    , putByteString
-    )
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-    ( length
-    , takeWhile
-    , empty
-    , null
-    , take
-    )
-import Data.ByteString.Char8 as C (replicate)
-import Data.String.Conversions (cs)
-import Network.Socket (SockAddr (SockAddrInet, SockAddrInet6))
-
-import Network.Haskoin.Crypto.Hash
+import           Control.DeepSeq             (NFData, rnf)
+import           Control.Monad               (forM_, liftM2, replicateM, unless)
+import           Data.Bits                   (shiftL)
+import           Data.ByteString             (ByteString)
+import qualified Data.ByteString             as BS
+import           Data.ByteString.Char8       as C (replicate)
+import           Data.Monoid                 ((<>))
+import           Data.Serialize              (Serialize, get, put)
+import           Data.Serialize.Get          (Get, getByteString, getWord16be,
+                                              getWord16le, getWord32be,
+                                              getWord32host, getWord32le,
+                                              getWord64le, getWord8, isEmpty)
+import           Data.Serialize.Put          (Put, putByteString, putWord16be,
+                                              putWord16le, putWord32be,
+                                              putWord32host, putWord32le,
+                                              putWord64le, putWord8)
+import           Data.String.Conversions     (cs)
+import           Data.Word                   (Word32, Word64)
+import           Network.Haskoin.Crypto.Hash
+import           Network.Socket              (SockAddr (..))
 
 -- | Network address with a timestamp
 type NetworkAddressTime = (Word32, NetworkAddress)
 
 -- | Provides information on known nodes in the bitcoin network. An 'Addr'
 -- type is sent inside a 'Message' as a response to a 'GetAddr' message.
-data Addr =
-    Addr {
-           -- List of addresses of other nodes on the network with timestamps.
-           addrList :: ![NetworkAddressTime]
+newtype Addr =
+    Addr { -- List of addresses of other nodes on the network with timestamps.
+           addrList :: [NetworkAddressTime]
          }
     deriving (Eq, Show)
 
@@ -110,11 +98,10 @@ instance Serialize Alert where
 -- object referenced by the hash. Usually, 'GetData' messages are sent after a
 -- node receives an 'Inv' message to obtain information on unknown object
 -- hashes.
-data GetData =
-    GetData {
-              -- | List of object hashes
-              getDataList :: ![InvVector]
-            } deriving (Eq, Show, Read)
+newtype GetData =
+    GetData { -- | List of object hashes
+              getDataList :: [InvVector]
+            } deriving (Eq, Show)
 
 instance NFData GetData where
     rnf (GetData l) = rnf l
@@ -132,11 +119,11 @@ instance Serialize GetData where
 -- | 'Inv' messages are used by nodes to advertise their knowledge of new
 -- objects by publishing a list of hashes. 'Inv' messages can be sent
 -- unsolicited or in response to a 'GetBlocks' message.
-data Inv =
+newtype Inv =
     Inv {
         -- | Inventory vectors
-          invList :: ![InvVector]
-        } deriving (Eq, Show, Read)
+          invList :: [InvVector]
+        } deriving (Eq, Show)
 
 instance NFData Inv where
     rnf (Inv l) = rnf l
@@ -187,7 +174,7 @@ data InvVector =
                 invType :: !InvType
                 -- | Hash of the object referenced by this inventory vector
               , invHash :: !Hash256
-              } deriving (Eq, Show, Read)
+              } deriving (Eq, Show)
 
 instance NFData InvVector where
     rnf (InvVector t h) = rnf t `seq` rnf h
@@ -202,10 +189,9 @@ instance Serialize InvVector where
 -- timestamps are sent together with the 'NetworkAddress' such as in the 'Addr'
 -- data type.
 data NetworkAddress =
-    NetworkAddress {
-                   -- | Bitmask of services available for this address
+    NetworkAddress { -- | Bitmask of services available for this address
                      naServices :: !Word64
-                   -- | IPv6 address and port
+                     -- | IPv6 address and port
                    , naAddress  :: !SockAddr
                    } deriving (Eq, Show)
 
@@ -253,11 +239,10 @@ instance Serialize NetworkAddress where
 -- whe one of the requested objects could not be retrieved. This could happen,
 -- for example, if a tranasaction was requested and was not available in the
 -- memory pool of the receiving node.
-data NotFound =
-    NotFound {
-             -- | Inventory vectors related to this request
-               notFoundList :: ![InvVector]
-             } deriving (Eq, Show, Read)
+newtype NotFound =
+    NotFound { -- | Inventory vectors related to this request
+               notFoundList :: [InvVector]
+             } deriving (Eq, Show)
 
 instance NFData NotFound where
     rnf (NotFound l) = rnf l
@@ -275,8 +260,7 @@ instance Serialize NotFound where
 -- | A Ping message is sent to bitcoin peers to check if a TCP\/IP connection
 -- is still valid.
 newtype Ping =
-    Ping {
-           -- | A random nonce used to identify the recipient of the ping
+    Ping { -- | A random nonce used to identify the recipient of the ping
            -- request once a Pong response is received.
            pingNonce :: Word64
          } deriving (Eq, Show, Read)
@@ -438,7 +422,7 @@ data Version =
             , addrRecv    :: !NetworkAddress
               -- | Network address of the node sending this message.
             , addrSend    :: !NetworkAddress
-              -- | Randomly generated identifying sent with every version
+              -- | Randomly generated identifier sent with every version
               -- message. This nonce is used to detect connection to self.
             , verNonce    :: !Word64
               -- | User agent
@@ -526,18 +510,20 @@ data MessageCommand
     | MCAlert
     | MCMempool
     | MCReject
+    | MCSendHeaders
     deriving (Eq, Show, Read)
 
 instance NFData MessageCommand where rnf x = seq x ()
 
 instance Serialize MessageCommand where
-
     get = go =<< getByteString 12
       where
-        go bs = case stringToCommand $ unpackCommand bs of
-            Just cmd -> return cmd
-            Nothing  -> fail "get MessageCommand : Invalid command"
-
+        go bs =
+            let str = unpackCommand bs
+            in case stringToCommand str of
+                Just cmd -> return cmd
+                Nothing  -> fail $ cs $
+                    "get MessageCommand: Invalid command: " <> str
     put mc = putByteString $ packCommand $ commandToString mc
 
 
@@ -564,6 +550,7 @@ stringToCommand str = case str of
     "alert"       -> Just MCAlert
     "mempool"     -> Just MCMempool
     "reject"      -> Just MCReject
+    "sendheaders" -> Just MCSendHeaders
     _             -> Nothing
 
 commandToString :: MessageCommand -> ByteString
@@ -589,6 +576,7 @@ commandToString mc = case mc of
     MCAlert       -> "alert"
     MCMempool     -> "mempool"
     MCReject      -> "reject"
+    MCSendHeaders -> "sendheaders"
 
 packCommand :: ByteString -> ByteString
 packCommand s = BS.take 12 $
@@ -597,3 +585,20 @@ packCommand s = BS.take 12 $
 unpackCommand :: ByteString -> ByteString
 unpackCommand = BS.takeWhile (/= 0)
 
+nodeNone :: Word64
+nodeNone = 0
+
+nodeNetwork :: Word64
+nodeNetwork = 1
+
+nodeGetUTXO :: Word64
+nodeGetUTXO = 1 `shiftL` 1
+
+nodeBloom :: Word64
+nodeBloom = 1 `shiftL` 2
+
+nodeWitness :: Word64
+nodeWitness = 1 `shiftL` 3
+
+nodeXThin :: Word64
+nodeXThin = 1 `shiftL` 4

--- a/haskoin-core/src/Network/Haskoin/Transaction/Types.hs
+++ b/haskoin-core/src/Network/Haskoin/Transaction/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Network.Haskoin.Transaction.Types
 ( Tx
 , createTx
@@ -15,81 +16,37 @@ module Network.Haskoin.Transaction.Types
 , nosigTxHash
 ) where
 
-import Control.DeepSeq (NFData, rnf)
-import Control.Monad (liftM2, replicateM, forM_, mzero, (<=<))
-
-import Data.Aeson (Value(String), FromJSON, ToJSON, parseJSON, toJSON, withText)
-import Data.Word (Word32, Word64)
-import Data.Serialize (Serialize, get, put, encode)
-import Data.Serialize.Get
-    ( getWord32le
-    , getWord64le
-    , getByteString
-    , remaining
-    , lookAhead
-    )
-import Data.Serialize.Put
-    ( putWord32le
-    , putWord64le
-    , putByteString
-    )
-import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-    ( length
-    , empty
-    , reverse
-    )
-import Data.Maybe (fromMaybe)
-import Data.String (IsString, fromString)
-import Data.String.Conversions (cs)
-import Text.Read (readPrec, parens, lexP, pfail)
-import qualified Text.Read as Read (Lexeme(Ident, String))
-import Network.Haskoin.Util
-import Network.Haskoin.Crypto.Hash
-import Network.Haskoin.Network.Types
+import           Control.DeepSeq             (NFData, rnf)
+import           Control.Monad               (forM_, liftM2, mzero, replicateM,
+                                              (<=<))
+import           Data.Aeson                  (FromJSON, ToJSON, Value (String),
+                                              parseJSON, toJSON, withText)
+import           Data.ByteString             (ByteString)
+import qualified Data.ByteString             as BS
+import           Data.Hashable               (Hashable)
+import           Data.Maybe                  (fromMaybe, maybe)
+import           Data.Serialize              (Serialize, get, put)
+import           Data.Serialize.Get          (getByteString, getWord32le,
+                                              getWord64le)
+import           Data.Serialize.Put          (putByteString, putWord32le,
+                                              putWord64le)
+import           Data.String                 (IsString, fromString)
+import           Data.String.Conversions     (cs)
+import           Data.Word                   (Word32, Word64)
+import           Network.Haskoin.Crypto.Hash
+import           Network.Haskoin.Network.Types
+import           Network.Haskoin.Util
 
 newtype TxHash = TxHash { getTxHash :: Hash256 }
-    deriving (Eq, Ord)
-
-instance NFData TxHash where
-    rnf  = rnf . getHash256 . getTxHash
-
-instance Read TxHash where
-    readPrec = parens $ do
-        Read.Ident "TxHash" <- lexP
-        Read.String str <- lexP
-        maybe pfail return $ hexToTxHash $ cs str
+    deriving (Eq, Ord, NFData, Hashable, Serialize)
 
 instance Show TxHash where
-    showsPrec d h = showParen (d > 10) $
-        showString "TxHash " . shows (txHashToHex h)
+    show = cs . txHashToHex
 
 instance IsString TxHash where
-    fromString =
-        TxHash . fromMaybe e . bsToHash256
-               . BS.reverse . fromMaybe e' . decodeHex . cs
-      where
-        e = error "Could not read transaction hash from decoded hex string"
-        e' = error "Colud not decode hex string with transaction hash"
-
-instance Serialize TxHash where
-    get = TxHash <$> get
-    put = put . getTxHash
-
-nosigTxHash :: Tx -> TxHash
-nosigTxHash tx =
-    TxHash $ doubleHash256 $ encode tx{ _txIn = map clearInput $ txIn tx }
-  where
-    clearInput ti = ti{ scriptInput = BS.empty }
-
-txHashToHex :: TxHash -> ByteString
-txHashToHex (TxHash h) = encodeHex $ BS.reverse $ getHash256 h
-
-hexToTxHash :: ByteString -> Maybe TxHash
-hexToTxHash hex = do
-    bs <- BS.reverse <$> decodeHex hex
-    h <- bsToHash256 bs
-    return $ TxHash h
+    fromString s =
+        let e = error "Could not read transaction hash from hex string"
+        in fromMaybe e $ hexToTxHash $ cs s
 
 instance FromJSON TxHash where
     parseJSON = withText "Transaction id" $ \t ->
@@ -98,91 +55,71 @@ instance FromJSON TxHash where
 instance ToJSON TxHash where
     toJSON = String . cs . txHashToHex
 
+nosigTxHash :: Tx -> TxHash
+nosigTxHash tx =
+    TxHash $ doubleHash256 $ encodeStrict tx { txIn = map clearInput $ txIn tx }
+  where
+    clearInput ti = ti { scriptInput = BS.empty }
+
+txHashToHex :: TxHash -> ByteString
+txHashToHex (TxHash h) = encodeHex $ BS.reverse $ hash256ToBS h
+
+hexToTxHash :: ByteString -> Maybe TxHash
+hexToTxHash hex = do
+    bs <- BS.reverse <$> decodeHex hex
+    h <- bsToHash256 bs
+    return $ TxHash h
+
 -- | Data type representing a bitcoin transaction
 data Tx = Tx
     { -- | Transaction data format version
-      _txVersion  :: !Word32
+      txVersion  :: !Word32
       -- | List of transaction inputs
-    , _txIn       :: ![TxIn]
+    , txIn       :: ![TxIn]
       -- | List of transaction outputs
-    , _txOut      :: ![TxOut]
+    , txOut      :: ![TxOut]
       -- | The block number of timestamp at which this transaction is locked
-    , _txLockTime :: !Word32
-     -- | Hash of the transaction
-    , _txHash     :: !TxHash
+    , txLockTime :: !Word32
     } deriving (Eq)
 
-txVersion :: Tx -> Word32
-txVersion = _txVersion
-
-txIn :: Tx -> [TxIn]
-txIn = _txIn
-
-txOut :: Tx -> [TxOut]
-txOut = _txOut
-
-txLockTime :: Tx -> Word32
-txLockTime = _txLockTime
-
 txHash :: Tx -> TxHash
-txHash = _txHash
+txHash = TxHash . doubleHash256 . encodeStrict
 
 createTx :: Word32 -> [TxIn] -> [TxOut] -> Word32 -> Tx
 createTx v is os l =
-    Tx { _txVersion  = v
-       , _txIn       = is
-       , _txOut      = os
-       , _txLockTime = l
-       , _txHash     = TxHash $ doubleHash256 $ encode tx
+    Tx { txVersion  = v
+       , txIn       = is
+       , txOut      = os
+       , txLockTime = l
        }
-  where
-    tx = Tx { _txVersion  = v
-            , _txIn       = is
-            , _txOut      = os
-            , _txLockTime = l
-            , _txHash     = fromString $ replicate 64 '0'
-            }
 
 instance Show Tx where
-    showsPrec d tx = showParen (d > 10) $
-        showString "Tx " . shows (encodeHex $ encode tx)
-
-instance Read Tx where
-    readPrec = parens $ do
-        Read.Ident "Tx" <- lexP
-        Read.String str <- lexP
-        maybe pfail return $ decodeToMaybe =<< decodeHex (cs str)
+    show = show . encodeHex . encodeStrict
 
 instance IsString Tx where
     fromString =
-        fromMaybe e . (decodeToMaybe <=< decodeHex) . cs
+        fromMaybe e . (decodeMaybeStrict <=< decodeHex) . cs
       where
         e = error "Could not read transaction from hex string"
 
 instance NFData Tx where
-    rnf (Tx v i o l t) = rnf v `seq` rnf i `seq` rnf o `seq` rnf l `seq` rnf t
+    rnf (Tx v i o l) = rnf v `seq` rnf i `seq` rnf o `seq` rnf l
 
 instance Serialize Tx where
     get = do
-        start <- remaining
-        (v, is, os, l, end) <- lookAhead $ do
-            v  <- getWord32le
-            is <- replicateList =<< get
-            os <- replicateList =<< get
-            l  <- getWord32le
-            end <- remaining
-            return (v, is, os, l, end)
-        bs <- getByteString $ fromIntegral $ start - end
-        return $ Tx { _txVersion  = v
-                    , _txIn       = is
-                    , _txOut      = os
-                    , _txLockTime = l
-                    , _txHash     = TxHash $ doubleHash256 bs
-                    }
+        v  <- getWord32le
+        is <- replicateList =<< get
+        os <- replicateList =<< get
+        l  <- getWord32le
+        return Tx { txVersion  = v
+                  , txIn       = is
+                  , txOut      = os
+                  , txLockTime = l
+                  }
       where
         replicateList (VarInt c) = replicateM (fromIntegral c) get
 
-    put (Tx v is os l _) = do
+    put (Tx v is os l) = do
         putWord32le v
         put $ VarInt $ fromIntegral $ length is
         forM_ is put
@@ -192,10 +129,10 @@ instance Serialize Tx where
 
 instance FromJSON Tx where
     parseJSON = withText "Tx" $
-        maybe mzero return . (decodeToMaybe <=< decodeHex) . cs
+        maybe mzero return . (decodeMaybeStrict <=< decodeHex) . cs
 
 instance ToJSON Tx where
-    toJSON = String . cs . encodeHex . encode
+    toJSON = String . cs . encodeHex . encodeStrict
 
 -- | Data type representing a transaction input.
 data TxIn =
@@ -205,11 +142,10 @@ data TxIn =
            -- | Script providing the requirements of the previous transaction
            -- output to spend those coins.
          , scriptInput  :: !ByteString
-           -- | Transaction version as defined by the sender of the
-           -- transaction. The intended use is for replacing transactions with
-           -- new information before the transaction is included in a block.
+           -- | BIP-68:
+           -- Relative lock-time using consensus-enforced sequence numbers
          , txInSequence :: !Word32
-         } deriving (Eq, Show, Read)
+         } deriving (Eq, Show)
 
 instance NFData TxIn where
     rnf (TxIn p i s) = rnf p `seq` rnf i `seq` rnf s
@@ -242,7 +178,7 @@ instance Serialize TxOut where
     get = do
         val <- getWord64le
         (VarInt len) <- get
-        TxOut val <$> (getByteString $ fromIntegral len)
+        TxOut val <$> getByteString (fromIntegral len)
 
     put (TxOut o s) = do
         putWord64le o
@@ -257,21 +193,20 @@ data OutPoint = OutPoint
       -- | The position of the specific output in the transaction.
       -- The first output position is 0.
     , outPointIndex :: !Word32
-    } deriving (Read, Show, Eq)
+    } deriving (Show, Eq)
 
 instance NFData OutPoint where
     rnf (OutPoint h i) = rnf h `seq` rnf i
 
 instance FromJSON OutPoint where
     parseJSON = withText "OutPoint" $
-        maybe mzero return . (decodeToMaybe <=< decodeHex) . cs
+        maybe mzero return . (decodeMaybeStrict <=< decodeHex) . cs
 
 instance ToJSON OutPoint where
-    toJSON = String . cs . encodeHex . encode
+    toJSON = String . cs . encodeHex . encodeStrict
 
 instance Serialize OutPoint where
     get = do
         (h,i) <- liftM2 (,) get getWord32le
         return $ OutPoint h i
     put (OutPoint h i) = put h >> putWord32le i
-

--- a/haskoin-core/src/Network/Haskoin/Util.hs
+++ b/haskoin-core/src/Network/Haskoin/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-|
   This module defines various utility functions used across the
   Network.Haskoin modules.
@@ -9,6 +10,10 @@ module Network.Haskoin.Util
 , integerToBS
 , encodeHex
 , decodeHex
+, decodeStrict
+, encodeStrict
+, decodeMaybeStrict
+, decodeEitherStrict
 
   -- * Maybe and Either monad helpers
 , isLeft
@@ -21,7 +26,6 @@ module Network.Haskoin.Util
 , liftMaybe
 
   -- * Various helpers
-, decodeToMaybe
 , updateIndex
 , matchTemplate
 
@@ -30,36 +34,36 @@ module Network.Haskoin.Util
 , snd3
 , lst3
 
-  -- * MonadState
-, modify'
-
   -- * JSON Utilities
 , dropFieldLabel
 , dropSumLabels
 
 ) where
 
-import Control.Monad (guard)
-import Control.Monad.Trans.Either (EitherT, hoistEither)
-import Control.Monad.State (MonadState, get, put)
-
-import Data.Serialize (Serialize, decode)
-import Data.Word (Word8)
-import Data.Bits ((.|.), shiftL, shiftR)
-import Data.Char (toLower)
-import Data.Aeson.Types
-    (Options(..), SumEncoding(..), defaultOptions, defaultTaggedObject)
-
-import Data.ByteString (ByteString)
-import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString as BS
-    (pack, empty, foldr', reverse, unfoldr)
+import           Control.Monad               (guard)
+import           Control.Monad.Trans.Either  (EitherT, hoistEither)
+import           Data.Aeson.Types            (Options (..), SumEncoding (..),
+                                              defaultOptions,
+                                              defaultTaggedObject)
+import           Data.Bits                   (shiftL, shiftR, (.|.))
+import           Data.ByteString             (ByteString)
+import qualified Data.ByteString             as BS
+import qualified Data.ByteString.Base16      as B16
+import           Data.Char                   (toLower)
+import           Data.Serialize              (Serialize, decode, encode)
+import           Data.Word                   (Word8)
 
 -- ByteString helpers
 
+decodeStrict :: Serialize a => ByteString -> a
+decodeStrict = either error id . decode
+
+decodeEitherStrict :: Serialize a => ByteString -> Either String a
+decodeEitherStrict = decode
+
 -- | Decode a big endian Integer from a bytestring.
 bsToInteger :: ByteString -> Integer
-bsToInteger = BS.foldr' f 0 . BS.reverse
+bsToInteger = BS.foldr f 0 . BS.reverse
   where
     f w n = toInteger w .|. shiftL n 8
 
@@ -72,6 +76,12 @@ integerToBS i
   where
     f 0 = Nothing
     f x = Just (fromInteger x :: Word8, x `shiftR` 8)
+
+encodeStrict :: Serialize b => b -> ByteString
+encodeStrict = encode
+
+decodeMaybeStrict :: Serialize b => ByteString -> Maybe b
+decodeMaybeStrict = either (const Nothing) Just . decode
 
 encodeHex :: ByteString -> ByteString
 encodeHex = B16.encode
@@ -98,18 +108,18 @@ isLeft = not . isRight
 -- 'Left'
 fromRight :: Either a b -> b
 fromRight (Right b) = b
-fromRight _ = error "Either.fromRight: Left"
+fromRight _         = error "Either.fromRight: Left"
 
 -- | Extract the 'Left' value from an 'Either' value. Fails if the value is 'Right'
 fromLeft :: Either a b -> a
 fromLeft (Left a) = a
-fromLeft _ = error "Either.fromLeft: Right"
+fromLeft _        = error "Either.fromLeft: Right"
 
 -- | Transforms an 'Either' value into a 'Maybe' value. 'Right' is mapped to 'Just'
 -- and 'Left' is mapped to 'Nothing'. The value inside 'Left' is lost.
 eitherToMaybe :: Either a b -> Maybe b
 eitherToMaybe (Right b) = Just b
-eitherToMaybe _ = Nothing
+eitherToMaybe _         = Nothing
 
 -- | Transforms a 'Maybe' value into an 'Either' value. 'Just' is mapped to
 -- 'Right' and 'Nothing' is mapped to 'Left'. You also pass in an error value
@@ -126,10 +136,6 @@ liftMaybe :: Monad m => b -> Maybe a -> EitherT b m a
 liftMaybe err = liftEither . maybeToEither err
 
 -- Various helpers
-
--- Helper function to decode Data.Serialize into Maybe
-decodeToMaybe :: Serialize a => ByteString -> Maybe a
-decodeToMaybe bs = eitherToMaybe $ decode bs
 
 -- | Applies a function to only one element of a list defined by its index.  If
 -- the index is out of the bounds of the list, the original list is returned.
@@ -168,10 +174,6 @@ snd3 (_,b,_) = b
 -- | Returns the last value of a triple.
 lst3 :: (a,b,c) -> c
 lst3 (_,_,c) = c
-
--- | Strict evaluation of the new state
-modify' :: MonadState s m => (s -> s) -> m ()
-modify' f = get >>= \x -> put $! f x
 
 dropFieldLabel :: Int -> Options
 dropFieldLabel n = defaultOptions

--- a/haskoin-core/test/Main.hs
+++ b/haskoin-core/test/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import           Network.Haskoin.Constants                 (setProdnet)
 import           Test.Framework                            (defaultMain)
 
 -- Util tests
@@ -18,7 +19,7 @@ import qualified Network.Haskoin.Crypto.Mnemonic.Tests     (tests)
 import qualified Network.Haskoin.Crypto.Mnemonic.Units     (tests)
 import qualified Network.Haskoin.Crypto.Units              (tests)
 
--- Node tests
+-- Network tests
 import qualified Network.Haskoin.Network.Units             (tests)
 
 -- Script tests
@@ -42,6 +43,7 @@ import qualified Network.Haskoin.Cereal.Tests              (tests)
 
 main :: IO ()
 main = do
+  setProdnet
   satoshiTxTests <- Network.Haskoin.Transaction.Units.satoshiCoreTxTests
   defaultMain
     (  Network.Haskoin.Json.Tests.tests

--- a/haskoin-core/test/Network/Haskoin/Block/Tests.hs
+++ b/haskoin-core/test/Network/Haskoin/Block/Tests.hs
@@ -17,8 +17,6 @@ tests =
           [ testProperty "decode . encode block hash" $
             forAll arbitraryBlockHash $ \h ->
                 hexToBlockHash (blockHashToHex h) == Just h
-          , testProperty "Read/Show block hash" $
-            forAll arbitraryBlockHash $ \h -> read (show h) == h
           , testProperty "From string block hash" $
             forAll arbitraryBlockHash $ \h ->
                 fromString (cs $ blockHashToHex h) == h

--- a/haskoin-core/test/Network/Haskoin/Crypto/Hash/Tests.hs
+++ b/haskoin-core/test/Network/Haskoin/Crypto/Hash/Tests.hs
@@ -17,21 +17,11 @@ tests =
         [ testProperty "join512( split512(h) ) == h" $
           forAll arbitraryHash256 $ forAll arbitraryHash256 . joinSplit512
         , testProperty "decodeCompact . encodeCompact i == i" decEncCompact
-        , testProperty "Read/Show 64-byte hash" $ forAll arbitraryHash512 $
-          \h -> read (show h) == h
         , testProperty "From string 64-byte hash" $ forAll arbitraryHash512 $
           \h -> fromString (cs $ encodeHex $ encode h) == h
-        , testProperty "Read/Show 32-byte hash" $ forAll arbitraryHash256 $
-          \h -> read (show h) == h
         , testProperty "From string 32-byte hash" $ forAll arbitraryHash256 $
           \h -> fromString (cs $ encodeHex $ encode h) == h
-        , testProperty "Read/Show 20-byte hash" $ forAll arbitraryHash160 $
-          \h -> read (show h) == h
         , testProperty "From string 20-byte hash" $ forAll arbitraryHash160 $
-          \h -> fromString (cs $ encodeHex $ encode h) == h
-        , testProperty "Read/Show checksum" $ forAll arbitraryCheckSum32 $
-          \h -> read (show h) == h
-        , testProperty "From string checksum" $ forAll arbitraryCheckSum32 $
           \h -> fromString (cs $ encodeHex $ encode h) == h
         ]
     ]
@@ -44,9 +34,9 @@ joinSplit512 a b = split512 (join512 (a, b)) == (a, b)
 decEncCompact :: Integer -> Bool
 decEncCompact i
     -- Integer completely fits inside the mantisse
-    | abs i <= 0x007fffff = decodeCompact (encodeCompact i) == i
+    | abs i <= 0x007fffff = decodeCompact (encodeCompact i) == (i, False)
     -- Otherwise precision will be lost and the decoded result will
     -- be smaller than the original number
-    | i >= 0              = decodeCompact (encodeCompact i) < i
-    | otherwise           = decodeCompact (encodeCompact i) > i
+    | i >= 0              = fst (decodeCompact (encodeCompact i)) < i
+    | otherwise           = fst (decodeCompact (encodeCompact i)) > i
 

--- a/haskoin-core/test/Network/Haskoin/Crypto/Units.hs
+++ b/haskoin-core/test/Network/Haskoin/Crypto/Units.hs
@@ -1,24 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Network.Haskoin.Crypto.Units (tests) where
 
-import Test.HUnit (Assertion, assertBool)
-import Test.Framework (Test, testGroup)
-import Test.Framework.Providers.HUnit (testCase)
-
-import Control.Monad (replicateM_)
-import Control.Monad.Trans (liftIO)
-
-import Data.Maybe (fromJust, isJust, isNothing)
-import Data.ByteString (ByteString)
-import qualified Data.ByteString.Lazy as B 
-import qualified Data.Binary as Bin
-import qualified Data.ByteString.Char8 as C (pack)
-
-import qualified Crypto.Secp256k1 as EC (SecKey, exportCompactSig)
-
-import Network.Haskoin.Crypto
-import Network.Haskoin.Util
-import Network.Haskoin.Internals (PrvKeyI(..), PubKeyI(..), Signature(..))
+import           Control.Monad                  (replicateM_)
+import           Control.Monad.Trans            (liftIO)
+import qualified Crypto.Secp256k1               as EC (SecKey, exportCompactSig)
+import           Data.ByteString                (ByteString)
+import qualified Data.ByteString.Char8          as C (pack)
+import           Data.Maybe                     (fromJust, isJust, isNothing)
+import           Network.Haskoin.Crypto
+import           Network.Haskoin.Internals      (PrvKeyI (..), PubKeyI (..),
+                                                 Signature (..))
+import           Network.Haskoin.Util
+import           Test.Framework                 (Test, testGroup)
+import           Test.Framework.Providers.HUnit (testCase)
+import           Test.HUnit                     (Assertion, assertBool)
 
 -- Unit tests copied from bitcoind implementation
 -- https://github.com/bitcoin/bitcoin/blob/master/src/test/key_tests.cpp
@@ -52,7 +47,7 @@ strAddressBad = "1HV9Lc3sNHZxwj4Zk6fB38tEmBryq2cBiF"
 
 sigMsg :: [ByteString]
 sigMsg =
-    [ mconcat ["Very secret message ", (C.pack $ show (i :: Int)), ": 11"]
+    [ mconcat ["Very secret message ", C.pack (show (i :: Int)), ": 11"]
     | i <- [0..15]
     ]
 
@@ -92,10 +87,9 @@ tests =
         , testCase "Check public key compression" checkKeyCompressed
         , testCase "Check matching address" checkMatchingAddress
         ] ++
-        ( map (\x -> (testCase ("Check sig: " ++ (show x))
-                (checkSignatures $ doubleHash256 x))) sigMsg )
+        map (\x -> testCase ("Check sig: " ++ show x) $ checkSignatures (doubleHash256 x)) sigMsg
     , testGroup "Trezor RFC 6979 Test Vectors"
-        [ testCase "RFC 6979 Test Vector 1" (testSigning $ detVec !! 0)
+        [ testCase "RFC 6979 Test Vector 1" (testSigning $ head detVec)
         , testCase "RFC 6979 Test Vector 2" (testSigning $ detVec !! 1)
         , testCase "RFC 6979 Test Vector 3" (testSigning $ detVec !! 2)
         , testCase "RFC 6979 Test Vector 4" (testSigning $ detVec !! 3)
@@ -151,10 +145,10 @@ checkKeyCompressed = do
 
 checkMatchingAddress :: Assertion
 checkMatchingAddress = do
-    assertBool "Key 1"  $ addr1  == (addrToBase58 $ pubKeyAddr pub1)
-    assertBool "Key 2"  $ addr2  == (addrToBase58 $ pubKeyAddr pub2)
-    assertBool "Key 1C" $ addr1C == (addrToBase58 $ pubKeyAddr pub1C)
-    assertBool "Key 2C" $ addr2C == (addrToBase58 $ pubKeyAddr pub2C)
+    assertBool "Key 1"  $ addr1  == addrToBase58 (pubKeyAddr pub1)
+    assertBool "Key 2"  $ addr2  == addrToBase58 (pubKeyAddr pub2)
+    assertBool "Key 1C" $ addr1C == addrToBase58 (pubKeyAddr pub1C)
+    assertBool "Key 2C" $ addr2C == addrToBase58 (pubKeyAddr pub2C)
 
 checkSignatures :: Hash256 -> Assertion
 checkSignatures h = do
@@ -245,4 +239,4 @@ testSigning (prv, msg, str) = do
     msg' = hash256 msg
     prv' = makePrvKey prv
     compact = EC.exportCompactSig g
-    res = B.toStrict $ Bin.encode compact
+    res = encodeStrict compact

--- a/haskoin-core/test/Network/Haskoin/Transaction/Tests.hs
+++ b/haskoin-core/test/Network/Haskoin/Transaction/Tests.hs
@@ -1,7 +1,6 @@
 module Network.Haskoin.Transaction.Tests (tests) where
 
 import qualified Data.ByteString                      as BS
-import           Data.Serialize                       (encode)
 import           Data.String                          (fromString)
 import           Data.String.Conversions              (cs)
 import           Data.Word                            (Word64)
@@ -20,8 +19,6 @@ tests =
           "Transaction tests"
           [ testProperty "decode . encode Txid" $
             forAll arbitraryTxHash $ \h -> hexToTxHash (txHashToHex h) == Just h
-          , testProperty "Read/Show transaction id" $
-            forAll arbitraryTxHash $ \h -> read (show h) == h
           , testProperty "From string transaction id" $
             forAll arbitraryTxHash $ \h -> fromString (cs $ txHashToHex h) == h
           ]
@@ -64,7 +61,7 @@ testGuessSize tx =
   where
     delta    = pki + sum (map fst msi)
     guess    = guessTxSize pki msi pkout msout
-    len      = BS.length $ encode tx
+    len      = BS.length $ encodeStrict tx
     ins      = map f $ txIn tx
     f i      = fromRight $ decodeInputBS $ scriptInput i
     pki      = length $ filter isSpendPKHash ins

--- a/haskoin-node/src/Network/Haskoin/Node/Checkpoints.hs
+++ b/haskoin-node/src/Network/Haskoin/Node/Checkpoints.hs
@@ -6,6 +6,7 @@ module Network.Haskoin.Node.Checkpoints
 
 import qualified Data.IntMap.Strict as M (IntMap, fromList, lookup)
 
+import Control.Arrow
 import Network.Haskoin.Block
 import Network.Haskoin.Constants
 
@@ -17,7 +18,7 @@ checkpointMap = M.fromList checkpointList
 -- | Checkpoints from bitcoind reference implementation /src/checkpoints.cpp
 -- presented as a list.
 checkpointList :: [(Int, BlockHash)]
-checkpointList = checkpoints
+checkpointList = map (first fromIntegral) checkpoints
 
 -- | Verify that a block hash at a given height either matches an existing
 -- checkpoint or is not a checkpoint.

--- a/haskoin-node/test/Main.hs
+++ b/haskoin-node/test/Main.hs
@@ -2,12 +2,15 @@ module Main where
 
 import Test.Framework (defaultMain)
 
+import Network.Haskoin.Constants
 import qualified Network.Haskoin.Node.Tests (tests)
 import qualified Network.Haskoin.Node.Units (tests)
 
 main :: IO ()
-main = defaultMain
-    (  Network.Haskoin.Node.Tests.tests
-    ++ Network.Haskoin.Node.Units.tests
-    )
+main = do
+    setProdnet
+    defaultMain
+        (  Network.Haskoin.Node.Tests.tests
+        ++ Network.Haskoin.Node.Units.tests
+        )
 

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Client.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Client.hs
@@ -22,7 +22,7 @@ import System.Console.GetOpt
     , ArgOrder (Permute)
     )
 
-import Control.Monad (when, forM_)
+import Control.Monad (forM_)
 import Control.Monad.Trans (liftIO)
 import qualified Control.Monad.Reader as R (runReaderT)
 
@@ -181,7 +181,9 @@ clientMain :: IO ()
 clientMain = getArgs >>= \args -> case getOpt Permute options args of
     (fs, commands, []) -> do
         cfg <- getConfig fs
-        when (configTestnet cfg) switchToTestnet5
+        if configTestnet cfg
+            then setTestnet
+            else setProdnet
         setWorkDir cfg
         dispatchCommand cfg commands
     (_, _, msgs) -> forM_ (msgs ++ usage) putStrLn

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
@@ -408,7 +408,7 @@ getHexTx = do
         Haskeline.getInputLine ""
     let txM = case hexM of
             Nothing -> error "No action due to EOF"
-            Just hex -> decodeToMaybe =<< decodeHex (cs hex)
+            Just hex -> decodeMaybeStrict =<< decodeHex (cs hex)
     case txM of
         Just tx -> return tx
         Nothing -> error "Could not parse transaction"
@@ -712,7 +712,7 @@ encodeTxInJSON (TxIn o s i) = object $
     , "script"     .= encodeScriptJSON sp
     ] ++ decoded
   where
-    sp = fromMaybe (Script []) $ decodeToMaybe s
+    sp = fromMaybe (Script []) $ decodeMaybeStrict s
     decoded = either (const []) f $ decodeInputBS s
     f inp = ["decoded-script" .= encodeScriptInputJSON inp]
 
@@ -723,7 +723,7 @@ encodeTxOutJSON (TxOut v s) = object $
     , "script"     .= encodeScriptJSON sp
     ] ++ decoded
   where
-    sp = fromMaybe (Script []) $ decodeToMaybe s
+    sp = fromMaybe (Script []) $ decodeMaybeStrict s
     decoded = either (const [])
                  (\out -> ["decoded-script" .= encodeScriptOutputJSON out])
                  (decodeOutputBS s)
@@ -1006,7 +1006,7 @@ printBlockInfo BlockInfo{..} =
   where
     blockDiff :: Word32 -> Double
     blockDiff target = getTarget (blockBits genesisHeader) / getTarget target
-    getTarget   = fromIntegral . decodeCompact
+    getTarget   = fromIntegral . fst . decodeCompact
     versionData = integerToBS (fromIntegral blockInfoVersion)
     formatUTCTime = Time.formatTime Time.defaultTimeLocale
         "%Y-%m-%d %H:%M:%S (UTC)"

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Types.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Types.hs
@@ -396,7 +396,7 @@ data JsonTx = JsonTx
     , jsonTxBestBlock       :: !(Maybe BlockHash)
     , jsonTxBestBlockHeight :: !(Maybe BlockHeight)
     }
-    deriving (Eq, Show, Read)
+    deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 6) ''JsonTx)
 
@@ -413,7 +413,7 @@ data JsonCoin = JsonCoin
     -- Optional spender
     , jsonCoinSpendingTx :: !(Maybe JsonTx)
     }
-    deriving (Eq, Show, Read)
+    deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 8) ''JsonCoin)
 
@@ -422,7 +422,7 @@ $(deriveJSON (dropFieldLabel 8) ''JsonCoin)
 data TxCompleteRes = TxCompleteRes
     { txCompleteTx       :: !Tx
     , txCompleteComplete :: !Bool
-    } deriving (Eq, Show, Read)
+    } deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 10) ''TxCompleteRes)
 
@@ -450,7 +450,7 @@ data JsonSyncBlock = JsonSyncBlock
     , jsonSyncBlockHeight :: !BlockHeight
     , jsonSyncBlockPrev   :: !BlockHash
     , jsonSyncBlockTxs    :: ![JsonTx]
-    } deriving (Eq, Show, Read)
+    } deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 13) ''JsonSyncBlock)
 
@@ -458,14 +458,14 @@ data JsonBlock = JsonBlock
     { jsonBlockHash   :: !BlockHash
     , jsonBlockHeight :: !BlockHeight
     , jsonBlockPrev   :: !BlockHash
-    } deriving (Eq, Show, Read)
+    } deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 9) ''JsonBlock)
 
 data Notif
     = NotifBlock !JsonBlock
     | NotifTx    !JsonTx
-    deriving (Eq, Show, Read)
+    deriving (Eq, Show)
 
 $(deriveJSON (dropSumLabels 5 5 "type") ''Notif)
 

--- a/haskoin-wallet/test/Main.hs
+++ b/haskoin-wallet/test/Main.hs
@@ -8,9 +8,8 @@ import qualified Network.Haskoin.Wallet.Tests (tests)
 import Network.Haskoin.Constants
 
 main :: IO ()
-main | networkName == "prodnet" = defaultMain
+main = setProdnet >> defaultMain
         (  Network.Haskoin.Wallet.Tests.tests
         ++ Network.Haskoin.Wallet.Units.tests
         )
-     | otherwise = error "Tests are only available on prodnet"
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,10 +5,13 @@ packages:
 - haskoin-core
 - haskoin-node
 - haskoin-wallet
+- location:
+   git: https://github.com/haskoin/secp256k1-haskell.git
+   commit: 438682e1b3d157192189afc3f592cc06d33c8ea5
+  extra-dep: true
 extra-deps:
 - daemons-0.2.1
 - pbkdf-1.1.1.1
-- secp256k1-0.4.8
 - murmur3-1.0.3
 - concurrent-extra-0.7.0.10
 ### uncomment below for lts-7.18 compatibility


### PR DESCRIPTION
- Must set network before using constants (Prodnet no longer default).
- Reduce memory fragmentation by using ShortByteString for hashes.
- Use cryptonite instead of deprecated cryptohash for hashes.
- Add Regtest network support.
- Bump secp256k1 library version.
- Improve encodeCompact and decodeCompact functions.
- Refactor visited files.
- Add extra data to network constants.
- Change serialisation functions.
- Add sendheaders message.
- Remove transaction and block hash from type.
- Additional minor changes.