### PR TITLE
BIP 144 - serialization/deserialization of transaction

### DIFF
--- a/haskoin-core/src/Network/Haskoin/Test.hs
+++ b/haskoin-core/src/Network/Haskoin/Test.hs
@@ -92,6 +92,7 @@ module Network.Haskoin.Test
 , arbitraryTxHash
 , arbitraryTxIn
 , arbitraryTxOut
+, arbitraryWitness
 , arbitraryOutPoint
 , arbitraryAddrOnlyTx
 , arbitraryAddrOnlyTxIn

--- a/haskoin-core/src/Network/Haskoin/Transaction.hs
+++ b/haskoin-core/src/Network/Haskoin/Transaction.hs
@@ -15,6 +15,7 @@ module Network.Haskoin.Transaction
 , TxIn(..)
 , TxOut(..)
 , OutPoint(..)
+, Witness(..)
 , TxHash(..)
 , hexToTxHash
 , txHashToHex

--- a/haskoin-core/src/Network/Haskoin/Transaction/Builder.hs
+++ b/haskoin-core/src/Network/Haskoin/Transaction/Builder.hs
@@ -225,7 +225,7 @@ buildTx :: [OutPoint] -> [(ScriptOutput, Word64)] -> Either String Tx
 buildTx xs ys =
     mapM fo ys >>= \os -> return $ createTx 1 (map fi xs) os 0
   where
-    fi outPoint = TxIn outPoint BS.empty maxBound
+    fi outPoint = TxIn outPoint BS.empty (Witness []) maxBound
     fo (o, v)
         | v <= 2100000000000000 = return $ TxOut v $ encodeOutputBS o
         | otherwise =

--- a/haskoin-core/test/Network/Haskoin/Cereal/Tests.hs
+++ b/haskoin-core/test/Network/Haskoin/Cereal/Tests.hs
@@ -48,6 +48,7 @@ tests =
         ]
     , testGroup "Binary encoding and decoding of transaction types"
         [ testProperty "TxIn" $ forAll arbitraryTxIn testId
+        , testProperty "Witness" $ forAll arbitraryWitness testId
         , testProperty "TxOut" $ forAll arbitraryTxOut testId
         , testProperty "OutPoint" $ forAll arbitraryOutPoint testId
         , testProperty "Tx" $ forAll arbitraryTx testId

--- a/haskoin-core/test/Network/Haskoin/Script/Tests.hs
+++ b/haskoin-core/test/Network/Haskoin/Script/Tests.hs
@@ -364,6 +364,7 @@ buildCreditTx scriptPubKey =
                 }
     txI = TxIn { prevOutput = nullOutPoint
                , scriptInput = encode $ Script [ OP_0, OP_0 ]
+               , witness = Witness []
                , txInSequence = maxSeqNum
                }
 
@@ -379,6 +380,7 @@ buildSpendTx scriptSig creditTx =
                                        , outPointIndex = 0
                                        }
                , scriptInput  = scriptSig
+               , witness = Witness []
                , txInSequence = maxSeqNum
                }
     txO = TxOut { outValue = 0, scriptOutput = BS.empty }

--- a/haskoin-wallet/test/Network/Haskoin/Wallet/Units.hs
+++ b/haskoin-wallet/test/Network/Haskoin/Wallet/Units.hs
@@ -377,7 +377,7 @@ fakeTx :: [(TxHash, Word32)] -> [(BS.ByteString, Word64)] -> Tx
 fakeTx xs ys =
     createTx 1 txi txo 0
   where
-    txi = map (\(h,p) -> TxIn (OutPoint h p) (BS.pack [1]) maxBound) xs
+    txi = map (\(h,p) -> TxIn (OutPoint h p) (BS.pack [1]) (Witness []) maxBound) xs
     f = encodeOutputBS . PayPKHash . fromJust . base58ToAddr
     txo = map (\(a,v) -> TxOut v $ f a ) ys
 
@@ -1195,7 +1195,7 @@ testImportMultisig = do
         }
     let fundingTx = createTx
             1
-            [ TxIn (OutPoint tid1 0) (BS.pack [1]) maxBound ] -- dummy input
+            [ TxIn (OutPoint tid1 0) (BS.pack [1]) (Witness []) maxBound ] -- dummy input
             [ TxOut 10000000 $
               encodeOutputBS $ PayScriptHash $ fromJust $
               base58ToAddr "32SupmLrYyZMSPfL4tgkuUCyvbzEyBfqxd"
@@ -1407,7 +1407,7 @@ testDeleteUnsignedTx = do
         }
     let fundingTx = createTx
             1
-            [ TxIn (OutPoint tid1 0) (BS.pack [1]) maxBound ] -- dummy input
+            [ TxIn (OutPoint tid1 0) (BS.pack [1]) (Witness []) maxBound ] -- dummy input
             [ TxOut 10000000 $
               encodeOutputBS $ PayScriptHash $ fromJust $
               base58ToAddr "32SupmLrYyZMSPfL4tgkuUCyvbzEyBfqxd"


### PR DESCRIPTION
This PR makes several modifications across `haskoin` in order to support serialization / de-serialization of transaction defined in BIP 144.

The changes are briefly summarized below:
- Add new serialization function for transactions with witness data
- Add new datatype Witness and store it in TxIn
- JSON encoder for witness data

Here is an example of a transaction taken from [BIP 143](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki):
```
01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000
```
The serialization above can be quickly checked with `hw decode`. In the output there is a new field called `witness` inside each input.