### PR TITLE
Fix bug in `Network.Haskoin.Crypto.Mnemonic.numCS`

### DIFF
--- a/haskoin-core/src/Network/Haskoin/Crypto/Mnemonic.hs
+++ b/haskoin-core/src/Network/Haskoin/Crypto/Mnemonic.hs
@@ -85,7 +85,7 @@ numCS len =
     shiftCS . bsToInteger
   where
     shiftCS = case 8 - len `mod` 8 of
-        0 -> id
+        8 -> id
         x -> flip shiftR x
 
 -- | Turn any sequence of characters into a 512-bit seed.  Does not have to be


### PR DESCRIPTION
Added tests to demonstrate checksum validation failures for checksum lengths of 8.

1. [Failing tests added; bug not fixed](https://travis-ci.org/mhuesch/haskoin/jobs/296074693)
2. [Bug fixed; tests pass](https://travis-ci.org/mhuesch/haskoin/builds/296073520)