### PR TITLE
Rework network constants and add regtest support

### DIFF
--- a/haskoin-core/src/Network/Haskoin/Block/Types.hs
+++ b/haskoin-core/src/Network/Haskoin/Block/Types.hs
@@ -1,5 +1,7 @@
 module Network.Haskoin.Block.Types
 ( Block(..)
+, BlockHeight
+, Timestamp
 , BlockHeader
 , createBlockHeader
 , blockVersion
@@ -33,8 +35,8 @@ import           Data.ByteString                   (ByteString)
 import qualified Data.ByteString                   as BS (length, reverse)
 import           Data.Maybe                        (fromMaybe)
 import           Data.Serialize                    (Serialize, encode, get, put)
-import           Data.Serialize.Get                (getWord32le, lookAhead,
-                                                    remaining, getByteString)
+import           Data.Serialize.Get                (getByteString, getWord32le,
+                                                    lookAhead, remaining)
 import           Data.Serialize.Put                (Put, putWord32le)
 import           Data.String                       (IsString, fromString)
 import           Data.String.Conversions           (cs)
@@ -47,15 +49,19 @@ import           Text.Read                         (lexP, parens, pfail,
                                                     readPrec)
 import qualified Text.Read                         as Read (Lexeme (Ident, String))
 
+
+type BlockHeight = Word32
+type Timestamp = Word32
+
 -- | Data type describing a block in the bitcoin protocol. Blocks are sent in
 -- response to 'GetData' messages that are requesting information from a
 -- block hash.
 data Block =
     Block {
             -- | Header information for this block.
-            blockHeader     :: !BlockHeader
+            blockHeader :: !BlockHeader
             -- | List of transactions pertaining to this block.
-          , blockTxns       :: ![Tx]
+          , blockTxns   :: ![Tx]
           } deriving (Eq, Show)
 
 instance NFData Block where

--- a/haskoin-core/src/Network/Haskoin/Constants.hs
+++ b/haskoin-core/src/Network/Haskoin/Constants.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-cse -fno-full-laziness #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-|
   Network specific constants
 -}
@@ -7,8 +8,11 @@ module Network.Haskoin.Constants
   Network(..)
 , prodnet
 , testnet3
+, regtest
   -- ** Functions
-, switchToTestnet3
+, setTestnet
+, setRegtest
+, setProdnet
 , setNetwork
 , getNetwork
   -- ** Network parameters
@@ -25,135 +29,159 @@ module Network.Haskoin.Constants
 , haskoinUserAgent
 , defaultPort
 , allowMinDifficultyBlocks
+, powNoRetargetting
 , powLimit
+, bip34Block
+, bip65Height
+, bip66Height
 , targetTimespan
 , targetSpacing
 , checkpoints
 , bip44Coin
+, seeds
 ) where
 
-import Data.Bits (shiftR)
-import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as C8 (concat, pack)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.Version (showVersion)
-import Data.Word (Word8, Word32, Word64)
-import Data.LargeWord (Word256)
-import Network.Haskoin.Block.Types
-import System.IO.Unsafe (unsafePerformIO)
-import Paths_haskoin_core (version)
+import           Data.ByteString             (ByteString)
+import qualified Data.ByteString.Char8       as C8 (concat, pack)
+import           Data.IORef                  (IORef, newIORef, readIORef,
+                                              writeIORef)
+import           Data.Version                (showVersion)
+import           Data.Word                   (Word32, Word64, Word8)
+import           Network.Haskoin.Block.Types
+import           Paths_haskoin_core          (version)
+import           System.IO.Unsafe            (unsafePerformIO)
 
 data Network = Network
-    { getNetworkName                :: !String
-    , getAddrPrefix                 :: !Word8
-    , getScriptPrefix               :: !Word8
-    , getSecretPrefix               :: !Word8
-    , getExtPubKeyPrefix            :: !Word32
-    , getExtSecretPrefix            :: !Word32
-    , getNetworkMagic               :: !Word32
-    , getGenesisHeader              :: !BlockHeader
-    , getMaxBlockSize               :: !Int
-    , getMaxSatoshi                 :: !Word64
-    , getHaskoinUserAgent           :: !ByteString
-    , getDefaultPort                :: !Int
-    , getAllowMinDifficultyBlocks   :: !Bool
-    , getPowLimit                   :: !Integer
-    , getTargetTimespan             :: !Word32
-    , getTargetSpacing              :: !Word32
-    , getCheckpoints                :: ![(Int, BlockHash)]
-    , getBip44Coin                  :: !Word32
-    } deriving (Eq, Show)
+    { getNetworkName              :: !String
+    , getAddrPrefix               :: !Word8
+    , getScriptPrefix             :: !Word8
+    , getSecretPrefix             :: !Word8
+    , getExtPubKeyPrefix          :: !Word32
+    , getExtSecretPrefix          :: !Word32
+    , getNetworkMagic             :: !Word32
+    , getGenesisHeader            :: !BlockHeader
+    , getMaxBlockSize             :: !Int
+    , getMaxSatoshi               :: !Word64
+    , getHaskoinUserAgent         :: !ByteString
+    , getDefaultPort              :: !Int
+    , getAllowMinDifficultyBlocks :: !Bool
+    , getPowNoRetargetting        :: !Bool
+    , getPowLimit                 :: !Integer
+    , getBip34Block               :: !(BlockHeight, BlockHash)
+    , getBip65Height              :: !BlockHeight
+    , getBip66Height              :: !BlockHeight
+    , getTargetTimespan           :: !Word32
+    , getTargetSpacing            :: !Word32
+    , getCheckpoints              :: ![(BlockHeight, BlockHash)]
+    , getBip44Coin                :: !Word32
+    , getSeeds                    :: [String]
+    } deriving Eq
 
--- | Switch to Testnet3.  Do at start of program.
-switchToTestnet3 :: IO ()
-switchToTestnet3 = setNetwork testnet3
+setRegtest :: IO ()
+setRegtest = setNetwork regtest
 
--- | Change network constants manually.  If switching to Testnet3, use
--- switchToTestnet3 instead.
+setTestnet :: IO ()
+setTestnet = setNetwork testnet3
+
+setProdnet :: IO ()
+setProdnet = setNetwork prodnet
+
 setNetwork :: Network -> IO ()
-setNetwork = writeIORef networkRef
+setNetwork net = writeIORef networkRef net >> writeIORef networkSetRef True
 
 {-# NOINLINE networkRef #-}
--- | Use this if you want to change constants to something other than Testnet3.
 networkRef :: IORef Network
 networkRef = unsafePerformIO $ newIORef prodnet
 
-{-# NOINLINE getNetwork #-}
--- | Read current network constants record
-getNetwork :: Network
-getNetwork = unsafePerformIO $ readIORef networkRef
+{-# NOINLINE networkSetRef #-}
+networkSetRef :: IORef Bool
+networkSetRef = unsafePerformIO $ newIORef False
 
--- | Name of the bitcoin network
+{-# NOINLINE getNetwork #-}
+getNetwork :: Network
+getNetwork =
+    let (net, set) = unsafePerformIO $
+                     (,) <$> readIORef networkRef <*> readIORef networkSetRef
+    in if set
+       then net
+       else error "Use Network.Haskoin.Constants.setNetwork"
+
 networkName :: String
 networkName = getNetworkName getNetwork
 
--- | Prefix for base58 PubKey hash address
 addrPrefix :: Word8
 addrPrefix = getAddrPrefix getNetwork
 
--- | Prefix for base58 script hash address
 scriptPrefix :: Word8
 scriptPrefix = getScriptPrefix getNetwork
 
--- | Prefix for private key WIF format
 secretPrefix :: Word8
 secretPrefix = getSecretPrefix getNetwork
 
--- | Prefix for extended public keys (BIP32)
 extPubKeyPrefix :: Word32
 extPubKeyPrefix = getExtPubKeyPrefix getNetwork
 
--- | Prefix for extended private keys (BIP32)
 extSecretPrefix :: Word32
 extSecretPrefix = getExtSecretPrefix getNetwork
 
--- | Network magic bytes
 networkMagic :: Word32
 networkMagic = getNetworkMagic getNetwork
 
--- | Genesis block header information
 genesisHeader :: BlockHeader
 genesisHeader = getGenesisHeader getNetwork
 
--- | Maximum size of a block in bytes
 maxBlockSize :: Int
 maxBlockSize = getMaxBlockSize getNetwork
 
--- | Maximum number of satoshi
 maxSatoshi :: Word64
 maxSatoshi = getMaxSatoshi getNetwork
 
--- | User agent string
 haskoinUserAgent :: ByteString
 haskoinUserAgent = getHaskoinUserAgent getNetwork
 
--- | Default port
 defaultPort :: Int
 defaultPort = getDefaultPort getNetwork
 
--- | Allow relaxed difficulty transition rules
 allowMinDifficultyBlocks :: Bool
 allowMinDifficultyBlocks = getAllowMinDifficultyBlocks getNetwork
 
--- | Lower bound for the proof of work difficulty
+powNoRetargetting :: Bool
+powNoRetargetting = getPowNoRetargetting getNetwork
+
 powLimit :: Integer
 powLimit = getPowLimit getNetwork
 
--- | Time between difficulty cycles (2 weeks on average)
+-- | Version 2 blocks start here.
+bip34Block :: (BlockHeight, BlockHash)
+bip34Block = getBip34Block getNetwork
+
+-- | Version 3 blocks start here.
+bip65Height :: BlockHeight
+bip65Height = getBip65Height getNetwork
+
+-- | Version 4 blocks start here.
+bip66Height :: BlockHeight
+bip66Height = getBip66Height getNetwork
+
+-- | Time between difficulty cycles (2 weeks on average).
 targetTimespan :: Word32
 targetTimespan = getTargetTimespan getNetwork
 
--- | Time between blocks (10 minutes per block)
+-- | Time between blocks (10 minutes per block).
 targetSpacing :: Word32
 targetSpacing = getTargetSpacing getNetwork
 
--- | Checkpoints to enfore
-checkpoints :: [(Int, BlockHash)]
+-- | Checkpoints to enfore.
+checkpoints :: [(Word32, BlockHash)]
 checkpoints = getCheckpoints getNetwork
 
 -- | Bip44 coin derivation (m/44'/coin'/account'/internal/address/)
 bip44Coin :: Word32
 bip44Coin = getBip44Coin getNetwork
+
+-- | DNS seeds.
+seeds :: [String]
+seeds = getSeeds getNetwork
 
 prodnet :: Network
 prodnet = Network
@@ -164,63 +192,69 @@ prodnet = Network
     , getExtPubKeyPrefix = 0x0488b21e
     , getExtSecretPrefix = 0x0488ade4
     , getNetworkMagic = 0xf9beb4d9
-    , getGenesisHeader = createBlockHeader
-        0x01
-        "0000000000000000000000000000000000000000000000000000000000000000"
-        "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
-        1231006505
-        486604799
-        2083236893
-        -- Hash 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-    , getMaxBlockSize = 2000000
+    , getGenesisHeader =
+        createBlockHeader
+            0x01
+            "0000000000000000000000000000000000000000000000000000000000000000"
+            "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
+            1231006505
+            0x1d00ffff
+            2083236893
+            -- Hash 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+    , getMaxBlockSize = 1000000
     , getMaxSatoshi = 2100000000000000
     , getHaskoinUserAgent = C8.concat
         [ "/haskoin:"
         , C8.pack $ showVersion version
-        , "/"
-        ]
+        , "/" ]
     , getDefaultPort = 8333
     , getAllowMinDifficultyBlocks = False
-    , getPowLimit = fromIntegral (maxBound `shiftR` 32 :: Word256)
+    , getPowNoRetargetting = False
+    , getPowLimit =
+        0x00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    , getBip34Block =
+        ( 227931
+        , "000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8" )
+    , getBip65Height = 388381
+    , getBip66Height = 363725
     , getTargetTimespan = 14 * 24 * 60 * 60
     , getTargetSpacing = 10 * 60
     , getCheckpoints =
         [ ( 11111
-          , "0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"
-          )
+          , "0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d" )
         , ( 33333
-          , "000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"
-          )
+          , "000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6" )
         , ( 74000
-          , "0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20"
-          )
+          , "0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20" )
         , ( 105000
-          , "00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97"
-          )
+          , "00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97" )
         , ( 134444
-          , "00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe"
-          )
+          , "00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe" )
         , ( 168000
-          , "000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763"
-          )
+          , "000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763" )
         , ( 193000
-          , "000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317"
-          )
+          , "000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317" )
         , ( 210000
-          , "000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e"
-          )
+          , "000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e" )
         , ( 216116
-          , "00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e"
-          )
+          , "00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e" )
         , ( 225430
-          , "00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932"
-          )
+          , "00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932" )
         , ( 250000
-          , "000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"
-          )
+          , "000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214" )
         , ( 279000
-          , "0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40"
-          )
+          , "0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40" )
+        ]
+    , getSeeds =
+        [ "seed.mainnet.b-pay.net"        -- BitPay
+        , "seed.ob1.io"                   -- OB1
+        , "seed.blockchain.info"          -- Blockchain
+        , "bitcoin.bloqseeds.net"         -- Bloq
+        , "seed.bitcoin.sipa.be"          -- Pieter Wuille
+        , "dnsseed.bluematt.me"           -- Matt Corallo
+        , "dnsseed.bitcoin.dashjr.org"    -- Luke Dashjr
+        , "seed.bitcoinstats.com"         -- Chris Decker
+        , "seed.bitcoin.jonasschnelli.ch" -- Jonas Schnelli
         ]
     , getBip44Coin = 0
     }
@@ -234,24 +268,34 @@ testnet3 = Network
     , getExtPubKeyPrefix = 0x043587cf
     , getExtSecretPrefix = 0x04358394
     , getNetworkMagic = 0x0b110907
-    , getGenesisHeader = createBlockHeader
-        0x01
-        "0000000000000000000000000000000000000000000000000000000000000000"
-        "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
-        1296688602
-        486604799
-        414098458
-        -- Hash 000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
+    , getGenesisHeader =
+        createBlockHeader
+            0x01
+            "0000000000000000000000000000000000000000000000000000000000000000"
+            "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
+            1296688602
+            486604799
+            414098458
+            -- Hash 000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
     , getMaxBlockSize = 1000000
     , getMaxSatoshi = 2100000000000000
-    , getHaskoinUserAgent = C8.concat
-        [ "/haskoin-testnet3:"
-        , C8.pack $ showVersion version
-        , "/"
-        ]
+    , getHaskoinUserAgent =
+        C8.concat
+            [ "/haskoin-testnet3:"
+            , C8.pack $ showVersion version
+            , "/"
+            ]
     , getDefaultPort = 18333
     , getAllowMinDifficultyBlocks = True
-    , getPowLimit = fromIntegral (maxBound `shiftR` 32 :: Word256)
+    , getPowNoRetargetting = False
+    , getPowLimit =
+        0x00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    , getBip34Block =
+        ( 21111
+        , "0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8"
+        )
+    , getBip65Height = 581885
+    , getBip66Height = 330776
     , getTargetTimespan = 14 * 24 * 60 * 60
     , getTargetSpacing = 10 * 60
     , getCheckpoints =
@@ -259,5 +303,52 @@ testnet3 = Network
           , "000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70"
           )
         ]
+    , getSeeds =
+        [ "testnet-seed.bitcoin.jonasschnelli.ch"
+        , "seed.tbtc.petertodd.org"
+        , "testnet-seed.bluematt.me"
+        , "testnet-seed.bitcoin.schildbach.de"
+        ]
+    , getBip44Coin = 1
+}
+
+regtest :: Network
+regtest = Network
+    { getNetworkName = "regtest"
+    , getAddrPrefix = 111
+    , getScriptPrefix = 196
+    , getSecretPrefix = 239
+    , getExtPubKeyPrefix = 0x043587cf
+    , getExtSecretPrefix = 0x04358394
+    , getNetworkMagic = 0xfabfb5da
+    , getGenesisHeader = createBlockHeader
+        -- 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
+        0x01
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a"
+        1296688602
+        0x207fffff
+        2
+    , getMaxBlockSize = 1000000
+    , getMaxSatoshi = 2100000000000000
+    , getHaskoinUserAgent = C8.concat
+        [ "/haskoin-regtest:"
+        , C8.pack $ showVersion version
+        , "/" ]
+    , getDefaultPort = 18444
+    , getAllowMinDifficultyBlocks = True
+    , getPowNoRetargetting = True
+    , getPowLimit =
+        0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    , getBip34Block =
+        ( 100000000
+        , "0000000000000000000000000000000000000000000000000000000000000000" )
+    , getBip65Height = 1351
+    , getBip66Height = 1251
+    , getTargetTimespan = 14 * 24 * 60 * 60
+    , getTargetSpacing = 10 * 60
+    , getCheckpoints = []
+    , getSeeds = [ "localhost" ]
     , getBip44Coin = 1
     }
+

--- a/haskoin-core/test/Main.hs
+++ b/haskoin-core/test/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import           Network.Haskoin.Constants                 (setProdnet)
 import           Test.Framework                            (defaultMain)
 
 -- Util tests
@@ -18,7 +19,7 @@ import qualified Network.Haskoin.Crypto.Mnemonic.Tests     (tests)
 import qualified Network.Haskoin.Crypto.Mnemonic.Units     (tests)
 import qualified Network.Haskoin.Crypto.Units              (tests)
 
--- Node tests
+-- Network tests
 import qualified Network.Haskoin.Network.Units             (tests)
 
 -- Script tests
@@ -42,6 +43,7 @@ import qualified Network.Haskoin.Cereal.Tests              (tests)
 
 main :: IO ()
 main = do
+  setProdnet
   satoshiTxTests <- Network.Haskoin.Transaction.Units.satoshiCoreTxTests
   defaultMain
     (  Network.Haskoin.Json.Tests.tests

--- a/haskoin-node/src/Network/Haskoin/Node/Checkpoints.hs
+++ b/haskoin-node/src/Network/Haskoin/Node/Checkpoints.hs
@@ -4,24 +4,26 @@ module Network.Haskoin.Node.Checkpoints
 , verifyCheckpoint
 ) where
 
-import qualified Data.IntMap.Strict as M (IntMap, fromList, lookup)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M (fromList, lookup)
 
+import Data.Word (Word32)
 import Network.Haskoin.Block
 import Network.Haskoin.Constants
 
 -- | Checkpoints from bitcoind reference implementation /src/checkpoints.cpp
 -- presented as an IntMap.
-checkpointMap :: M.IntMap BlockHash
+checkpointMap :: Map Word32 BlockHash
 checkpointMap = M.fromList checkpointList
 
 -- | Checkpoints from bitcoind reference implementation /src/checkpoints.cpp
 -- presented as a list.
-checkpointList :: [(Int, BlockHash)]
+checkpointList :: [(Word32, BlockHash)]
 checkpointList = checkpoints
 
 -- | Verify that a block hash at a given height either matches an existing
 -- checkpoint or is not a checkpoint.
-verifyCheckpoint :: Int -> BlockHash -> Bool
+verifyCheckpoint :: Word32 -> BlockHash -> Bool
 verifyCheckpoint height hash = case M.lookup height checkpointMap of
     Just value -> hash == value
     Nothing    -> True

--- a/haskoin-node/test/Main.hs
+++ b/haskoin-node/test/Main.hs
@@ -2,12 +2,15 @@ module Main where
 
 import Test.Framework (defaultMain)
 
+import Network.Haskoin.Constants
 import qualified Network.Haskoin.Node.Tests (tests)
 import qualified Network.Haskoin.Node.Units (tests)
 
 main :: IO ()
-main = defaultMain
-    (  Network.Haskoin.Node.Tests.tests
-    ++ Network.Haskoin.Node.Units.tests
-    )
+main = do
+    setProdnet
+    defaultMain
+        (  Network.Haskoin.Node.Tests.tests
+        ++ Network.Haskoin.Node.Units.tests
+        )
 

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Client.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Client.hs
@@ -22,7 +22,7 @@ import System.Console.GetOpt
     , ArgOrder (Permute)
     )
 
-import Control.Monad (when, forM_)
+import Control.Monad (forM_)
 import Control.Monad.Trans (liftIO)
 import qualified Control.Monad.Reader as R (runReaderT)
 
@@ -181,7 +181,9 @@ clientMain :: IO ()
 clientMain = getArgs >>= \args -> case getOpt Permute options args of
     (fs, commands, []) -> do
         cfg <- getConfig fs
-        when (configTestnet cfg) switchToTestnet5
+        if configTestnet cfg
+            then setTestnet
+            else setProdnet
         setWorkDir cfg
         dispatchCommand cfg commands
     (_, _, msgs) -> forM_ (msgs ++ usage) putStrLn

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
@@ -408,7 +408,7 @@ getHexTx = do
         Haskeline.getInputLine ""
     let txM = case hexM of
             Nothing -> error "No action due to EOF"
-            Just hex -> decodeToMaybe =<< decodeHex (cs hex)
+            Just hex -> eitherToMaybe . S.decode =<< decodeHex (cs hex)
     case txM of
         Just tx -> return tx
         Nothing -> error "Could not parse transaction"
@@ -712,7 +712,7 @@ encodeTxInJSON (TxIn o s i) = object $
     , "script"     .= encodeScriptJSON sp
     ] ++ decoded
   where
-    sp = fromMaybe (Script []) $ decodeToMaybe s
+    sp = either (const $ Script []) id $ S.decode s
     decoded = either (const []) f $ decodeInputBS s
     f inp = ["decoded-script" .= encodeScriptInputJSON inp]
 
@@ -723,7 +723,7 @@ encodeTxOutJSON (TxOut v s) = object $
     , "script"     .= encodeScriptJSON sp
     ] ++ decoded
   where
-    sp = fromMaybe (Script []) $ decodeToMaybe s
+    sp = either (const $ Script []) id $ S.decode s
     decoded = either (const [])
                  (\out -> ["decoded-script" .= encodeScriptOutputJSON out])
                  (decodeOutputBS s)

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Types.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Types.hs
@@ -396,7 +396,7 @@ data JsonTx = JsonTx
     , jsonTxBestBlock       :: !(Maybe BlockHash)
     , jsonTxBestBlockHeight :: !(Maybe BlockHeight)
     }
-    deriving (Eq, Show, Read)
+    deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 6) ''JsonTx)
 
@@ -413,7 +413,7 @@ data JsonCoin = JsonCoin
     -- Optional spender
     , jsonCoinSpendingTx :: !(Maybe JsonTx)
     }
-    deriving (Eq, Show, Read)
+    deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 8) ''JsonCoin)
 
@@ -422,7 +422,7 @@ $(deriveJSON (dropFieldLabel 8) ''JsonCoin)
 data TxCompleteRes = TxCompleteRes
     { txCompleteTx       :: !Tx
     , txCompleteComplete :: !Bool
-    } deriving (Eq, Show, Read)
+    } deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 10) ''TxCompleteRes)
 
@@ -450,7 +450,7 @@ data JsonSyncBlock = JsonSyncBlock
     , jsonSyncBlockHeight :: !BlockHeight
     , jsonSyncBlockPrev   :: !BlockHash
     , jsonSyncBlockTxs    :: ![JsonTx]
-    } deriving (Eq, Show, Read)
+    } deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 13) ''JsonSyncBlock)
 
@@ -458,14 +458,14 @@ data JsonBlock = JsonBlock
     { jsonBlockHash   :: !BlockHash
     , jsonBlockHeight :: !BlockHeight
     , jsonBlockPrev   :: !BlockHash
-    } deriving (Eq, Show, Read)
+    } deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 9) ''JsonBlock)
 
 data Notif
     = NotifBlock !JsonBlock
     | NotifTx    !JsonTx
-    deriving (Eq, Show, Read)
+    deriving (Eq, Show)
 
 $(deriveJSON (dropSumLabels 5 5 "type") ''Notif)
 

--- a/haskoin-wallet/test/Main.hs
+++ b/haskoin-wallet/test/Main.hs
@@ -8,9 +8,8 @@ import qualified Network.Haskoin.Wallet.Tests (tests)
 import Network.Haskoin.Constants
 
 main :: IO ()
-main | networkName == "prodnet" = defaultMain
+main = setProdnet >> defaultMain
         (  Network.Haskoin.Wallet.Tests.tests
         ++ Network.Haskoin.Wallet.Units.tests
         )
-     | otherwise = error "Tests are only available on prodnet"
 


### PR DESCRIPTION
Changes add more information per network and also require setting the network at the start of a program, no longer defaulting to the Bitcoin production network.