### PR TITLE
Remove unnecessary functions and refactor

### DIFF
--- a/haskoin-core/src/Network/Haskoin/Block/Headers.hs
+++ b/haskoin-core/src/Network/Haskoin/Block/Headers.hs
@@ -109,7 +109,7 @@ addBlockHeaderMemory bn s@HeaderMemory{..} =
 getBlockHeaderMemory :: BlockHash -> HeaderMemory -> Maybe BlockNode
 getBlockHeaderMemory bh HeaderMemory{..} = do
     bs <- shortBlockHash bh `HashMap.lookup` memoryHeaderMap
-    either (const Nothing) return . decode $ fromShort bs
+    eitherToMaybe . decode $ fromShort bs
 
 shortBlockHash :: BlockHash -> ShortBlockHash
 shortBlockHash = either error id . decode . BS.take 8 . encode

--- a/haskoin-core/src/Network/Haskoin/Block/Merkle.hs
+++ b/haskoin-core/src/Network/Haskoin/Block/Merkle.hs
@@ -4,6 +4,7 @@ import           Control.DeepSeq                   (NFData, rnf)
 import           Control.Monad                     (forM_, replicateM, when)
 import           Data.Bits
 import qualified Data.ByteString                   as BS
+import           Data.Either                       (isRight)
 import           Data.Maybe
 import           Data.Serialize                    (Serialize, encode, get, put)
 import           Data.Serialize.Get                (getWord32le, getWord8)
@@ -14,7 +15,6 @@ import           Network.Haskoin.Constants
 import           Network.Haskoin.Crypto.Hash
 import           Network.Haskoin.Network.Types
 import           Network.Haskoin.Transaction.Types
-import           Network.Haskoin.Util
 
 type MerkleRoot        = Hash256
 type FlagBits          = [Bool]

--- a/haskoin-core/src/Network/Haskoin/Block/Types.hs
+++ b/haskoin-core/src/Network/Haskoin/Block/Types.hs
@@ -29,7 +29,8 @@ import           Data.ByteString                   (ByteString)
 import qualified Data.ByteString                   as BS
 import           Data.Hashable                     (Hashable)
 import           Data.Maybe                        (fromMaybe)
-import           Data.Serialize                    (Serialize, encode, get, put)
+import           Data.Serialize                    (Serialize, decode, encode,
+                                                    get, put)
 import           Data.Serialize.Get                (getWord32le)
 import           Data.Serialize.Put                (Put, putWord32le)
 import           Data.String                       (IsString, fromString)
@@ -92,7 +93,7 @@ blockHashToHex (BlockHash h) = encodeHex $ BS.reverse $ hash256ToBS h
 hexToBlockHash :: ByteString -> Maybe BlockHash
 hexToBlockHash hex = do
     bs <- BS.reverse <$> decodeHex hex
-    h <- bsToHash256 bs
+    h <- eitherToMaybe (decode bs)
     return $ BlockHash h
 
 -- | Data type recording information on a 'Block'. The hash of a block is

--- a/haskoin-core/src/Network/Haskoin/Crypto.hs
+++ b/haskoin-core/src/Network/Haskoin/Crypto.hs
@@ -70,10 +70,6 @@ module Network.Haskoin.Crypto
 , hash256ToBS
 , hash160ToBS
 , hashSHA1ToBS
-, bsToCheckSum32
-, bsToHash512
-, bsToHash256
-, bsToHash160
 , checkSum32
 , hash512
 , hash256

--- a/haskoin-core/src/Network/Haskoin/Crypto/Base58.hs
+++ b/haskoin-core/src/Network/Haskoin/Crypto/Base58.hs
@@ -16,8 +16,7 @@ import           Data.Aeson                  (FromJSON, ToJSON, Value (String),
 import           Data.ByteString             (ByteString)
 import qualified Data.ByteString             as BS
 import qualified Data.ByteString.Char8       as C
-import           Data.Maybe                  (fromJust, fromMaybe, isJust,
-                                              listToMaybe)
+import           Data.Maybe                  (fromMaybe, isJust, listToMaybe)
 import           Data.Serialize              (Serialize, decode, encode, get,
                                               put)
 import           Data.Serialize.Get          (getByteString, getWord8)
@@ -103,7 +102,7 @@ instance Serialize Address where
     get = do
         pfx <- getWord8
         bs <- getByteString 20
-        let addr = fromJust (bsToHash160 bs)
+        addr <- either (fail "Could not decode address") return (decode bs)
         f pfx addr
       where
         f x a | x == addrPrefix   = return (PubKeyAddress a)

--- a/haskoin-core/src/Network/Haskoin/Crypto/ExtendedKeys.hs
+++ b/haskoin-core/src/Network/Haskoin/Crypto/ExtendedKeys.hs
@@ -80,6 +80,7 @@ import           Data.Aeson                    (FromJSON, ToJSON,
 import           Data.Bits                     (clearBit, setBit, testBit)
 import           Data.ByteString               (ByteString)
 import qualified Data.ByteString               as BS
+import           Data.Either                   (fromRight)
 import           Data.List                     (foldl')
 import           Data.List.Split               (splitOn)
 import           Data.Maybe                    (fromMaybe)
@@ -296,14 +297,14 @@ xPubID = hash160 . hash256ToBS . hash256 . encode . xPubKey
 -- | Computes the key fingerprint of an extended private key.
 xPrvFP :: XPrvKey -> Word32
 xPrvFP =
-    either (const err) id . decode . BS.take 4 . hash160ToBS . xPrvID
+    fromRight err . decode . BS.take 4 . hash160ToBS . xPrvID
   where
     err = error "Could not decode xPrvFP"
 
 -- | Computes the key fingerprint of an extended public key.
 xPubFP :: XPubKey -> Word32
 xPubFP =
-    either (const err) id . decode . BS.take 4 . hash160ToBS . xPubID
+    fromRight err . decode . BS.take 4 . hash160ToBS . xPubID
   where
     err = error "Could not decode xPubFP"
 

--- a/haskoin-core/src/Network/Haskoin/Crypto/Hash.hs
+++ b/haskoin-core/src/Network/Haskoin/Crypto/Hash.hs
@@ -14,11 +14,6 @@ module Network.Haskoin.Crypto.Hash
 , hash256ToBS
 , hash160ToBS
 , hashSHA1ToBS
-, bsToHash512
-, bsToHash256
-, bsToHash160
-, bsToHashSHA1
-, bsToCheckSum32
 , doubleHash256
 , checkSum32
 , hmac512
@@ -33,7 +28,6 @@ module Network.Haskoin.Crypto.Hash
 ) where
 
 import           Control.DeepSeq         (NFData)
-import           Control.Monad           (guard)
 import           Crypto.Hash             (RIPEMD160 (..), SHA1 (..),
                                           SHA256 (..), SHA512 (..), hashWith)
 import           Crypto.MAC.HMAC         (HMAC, hmac)
@@ -43,6 +37,7 @@ import           Data.ByteString         (ByteString)
 import qualified Data.ByteString         as BS
 import           Data.ByteString.Short   (ShortByteString)
 import qualified Data.ByteString.Short   as BSS
+import           Data.Either             (fromRight)
 import           Data.Hashable           (Hashable)
 import           Data.Serialize          (Serialize (..), decode)
 import qualified Data.Serialize.Get      as Get
@@ -171,29 +166,6 @@ hash160ToBS (Hash160 bs) = BSS.fromShort bs
 hashSHA1ToBS :: HashSHA1 -> ByteString
 hashSHA1ToBS (HashSHA1 bs) = BSS.fromShort bs
 
-bsToHash512 :: ByteArrayAccess b => b -> Maybe Hash512
-bsToHash512 bs = do
-    guard $ BA.length bs == 64
-    return $ Hash512 $ BSS.toShort $ BA.convert bs
-
-bsToHash256 :: ByteArrayAccess b => b -> Maybe Hash256
-bsToHash256 bs = do
-    guard $ BA.length bs == 32
-    return $ Hash256 $ BSS.toShort $ BA.convert bs
-
-bsToHash160 :: ByteArrayAccess b => b -> Maybe Hash160
-bsToHash160 bs = do
-    guard $ BA.length bs == 20
-    return $ Hash160 $ BSS.toShort $ BA.convert bs
-
-bsToHashSHA1 :: ByteArrayAccess b => b -> Maybe HashSHA1
-bsToHashSHA1 bs = do
-    guard $ BA.length bs == 20
-    return $ HashSHA1 $ BSS.toShort $ BA.convert bs
-
-bsToCheckSum32 :: ByteString -> Maybe CheckSum32
-bsToCheckSum32 = either (const Nothing) Just . decode
-
 -- | Compute two rounds of SHA-256.
 doubleHash256 :: ByteArrayAccess b => b -> Hash256
 doubleHash256 =
@@ -203,7 +175,7 @@ doubleHash256 =
 
 -- | Computes a 32 bit checksum.
 checkSum32 :: ByteArrayAccess b => b -> CheckSum32
-checkSum32 = fromRight
+checkSum32 = fromRight (error "Colud not decode bytes as CheckSum32")
              . decode
              . BS.take 4
              . BA.convert

--- a/haskoin-core/src/Network/Haskoin/Test/Crypto.hs
+++ b/haskoin-core/src/Network/Haskoin/Test/Crypto.hs
@@ -5,8 +5,9 @@ module Network.Haskoin.Test.Crypto where
 
 import           Crypto.Secp256k1                    ()
 import           Data.Bits                           (clearBit)
+import           Data.Either                         (fromRight)
 import           Data.List                           (foldl')
-import           Data.Maybe                          (fromJust)
+import           Data.Serialize                      (decode)
 import           Data.Word                           (Word32)
 import           Network.Haskoin.Crypto.Base58
 import           Network.Haskoin.Crypto.ECDSA
@@ -17,16 +18,21 @@ import           Network.Haskoin.Test.Util
 import           Test.QuickCheck
 
 arbitraryHash160 :: Gen Hash160
-arbitraryHash160 = (fromJust . bsToHash160) <$> arbitraryBSn 20
+arbitraryHash160 =
+    (fromRight (error "Could not decode Hash160") . decode) <$> arbitraryBSn 20
 
 arbitraryHash256 :: Gen Hash256
-arbitraryHash256 = (fromJust . bsToHash256) <$> arbitraryBSn 32
+arbitraryHash256 =
+    (fromRight (error "Could not decode Hash256") . decode) <$> arbitraryBSn 32
 
 arbitraryHash512 :: Gen Hash512
-arbitraryHash512 = (fromJust . bsToHash512) <$> arbitraryBSn 64
+arbitraryHash512 =
+    (fromRight (error "Could not decode Hash512") . decode) <$> arbitraryBSn 64
 
 arbitraryCheckSum32 :: Gen CheckSum32
-arbitraryCheckSum32 = (fromJust . bsToCheckSum32) <$> arbitraryBSn 4
+arbitraryCheckSum32 =
+    (fromRight (error "Could not decode CheckSum32") . decode) <$>
+    arbitraryBSn 4
 
 arbitraryPrvKey :: Gen PrvKey
 arbitraryPrvKey = oneof [ toPrvKeyG <$> arbitraryPrvKeyC

--- a/haskoin-core/src/Network/Haskoin/Transaction/Types.hs
+++ b/haskoin-core/src/Network/Haskoin/Transaction/Types.hs
@@ -69,7 +69,7 @@ txHashToHex (TxHash h) = encodeHex $ BS.reverse $ hash256ToBS h
 hexToTxHash :: ByteString -> Maybe TxHash
 hexToTxHash hex = do
     bs <- BS.reverse <$> decodeHex hex
-    h <- bsToHash256 bs
+    h <- either (const Nothing) Just (decode bs)
     return $ TxHash h
 
 -- | Data type representing a bitcoin transaction

--- a/haskoin-core/src/Network/Haskoin/Util.hs
+++ b/haskoin-core/src/Network/Haskoin/Util.hs
@@ -12,10 +12,6 @@ module Network.Haskoin.Util
 , decodeHex
 
   -- * Maybe and Either monad helpers
-, isLeft
-, isRight
-, fromRight
-, fromLeft
 , eitherToMaybe
 , maybeToEither
 , liftEither
@@ -77,26 +73,6 @@ decodeHex bs =
 
 -- Maybe and Either monad helpers
 
--- | Returns 'True' if the 'Either' value is 'Right'
-isRight :: Either a b -> Bool
-isRight (Right _) = True
-isRight _         = False
-
--- | Returns 'True' if the 'Either' value is 'Left'
-isLeft :: Either a b -> Bool
-isLeft = not . isRight
-
--- | Extract the 'Right' value from an 'Either' value. Fails if the value is
--- 'Left'
-fromRight :: Either a b -> b
-fromRight (Right b) = b
-fromRight _         = error "Either.fromRight: Left"
-
--- | Extract the 'Left' value from an 'Either' value. Fails if the value is 'Right'
-fromLeft :: Either a b -> a
-fromLeft (Left a) = a
-fromLeft _        = error "Either.fromLeft: Right"
-
 -- | Transforms an 'Either' value into a 'Maybe' value. 'Right' is mapped to 'Just'
 -- and 'Left' is mapped to 'Nothing'. The value inside 'Left' is lost.
 eitherToMaybe :: Either a b -> Maybe b
@@ -109,11 +85,11 @@ eitherToMaybe _         = Nothing
 maybeToEither :: b -> Maybe a -> Either b a
 maybeToEither err = maybe (Left err) Right
 
--- | Lift a 'Either' computation into the 'EitherT' monad
+-- | Lift a 'Either' computation into the 'ExceptT' monad
 liftEither :: Monad m => Either b a -> ExceptT b m a
 liftEither = ExceptT . return
 
--- | Lift a 'Maybe' computation into the 'EitherT' monad
+-- | Lift a 'Maybe' computation into the 'ExceptT' monad
 liftMaybe :: Monad m => b -> Maybe a -> ExceptT b m a
 liftMaybe err = liftEither . maybeToEither err
 

--- a/haskoin-core/test/Network/Haskoin/Block/Tests.hs
+++ b/haskoin-core/test/Network/Haskoin/Block/Tests.hs
@@ -1,11 +1,11 @@
 module Network.Haskoin.Block.Tests (tests) where
 
+import           Data.Either                          (fromRight)
 import           Data.String                          (fromString)
 import           Data.String.Conversions              (cs)
 import           Network.Haskoin.Block
 import           Network.Haskoin.Test
 import           Network.Haskoin.Transaction
-import           Network.Haskoin.Util
 import           Test.Framework
 import           Test.Framework.Providers.QuickCheck2
 import           Test.QuickCheck
@@ -45,4 +45,6 @@ buildExtractTree txs =
     r == buildMerkleRoot (map fst txs) && m == map fst (filter snd txs)
   where
     (f, h) = buildPartialMerkle txs
-    (r, m) = fromRight $ extractMatches f h (length txs)
+    (r, m) =
+        fromRight (error "Could not extract matches from Merkle tree") $
+        extractMatches f h (length txs)

--- a/haskoin-core/test/Network/Haskoin/Crypto/ExtendedKeys/Units.hs
+++ b/haskoin-core/test/Network/Haskoin/Crypto/ExtendedKeys/Units.hs
@@ -4,6 +4,7 @@ module Network.Haskoin.Crypto.ExtendedKeys.Units (tests) where
 import qualified Data.Aeson                     as Aeson (decode, encode)
 import           Data.ByteString                (ByteString)
 import qualified Data.ByteString.Lazy.Char8     as B8
+import           Data.Either                    (isLeft)
 import           Data.Maybe                     (fromJust, isJust, isNothing)
 import           Data.Serialize                 (encode)
 import           Data.String                    (fromString)

--- a/haskoin-core/test/Network/Haskoin/Util/Tests.hs
+++ b/haskoin-core/test/Network/Haskoin/Util/Tests.hs
@@ -1,6 +1,8 @@
 module Network.Haskoin.Util.Tests (tests) where
 
 import qualified Data.ByteString                      as BS
+import           Data.Either                          (fromLeft, fromRight,
+                                                       isLeft, isRight)
 import           Data.Foldable                        (toList)
 import           Data.List                            (permutations)
 import           Data.Maybe
@@ -60,7 +62,11 @@ testEither e =
     case e of
         (Right v) ->
             isRight e &&
-            not (isLeft e) && fromRight e == v && eitherToMaybe e == Just v
+            not (isLeft e) &&
+            fromRight (error "Unexpected Left") e == v &&
+            eitherToMaybe e == Just v
         (Left v) ->
             isLeft e &&
-            not (isRight e) && fromLeft e == v && isNothing (eitherToMaybe e)
+            not (isRight e) &&
+            fromLeft (error "Unexpected Right") e == v &&
+            isNothing (eitherToMaybe e)

--- a/haskoin-node/src/Network/Haskoin/Node/HeaderTree.hs
+++ b/haskoin-node/src/Network/Haskoin/Node/HeaderTree.hs
@@ -51,6 +51,7 @@ import           Control.Monad.State                   (evalStateT, get, put)
 import           Control.Monad.Trans                   (MonadIO, lift)
 import           Data.Bits                             (shiftL)
 import qualified Data.ByteString                       as BS (take)
+import           Data.Either                           (fromRight)
 import           Data.Function                         (on)
 import           Data.List                             (find, maximumBy, sort)
 import           Data.Maybe                            (fromMaybe, isNothing,
@@ -76,7 +77,6 @@ import           Network.Haskoin.Crypto
 import           Network.Haskoin.Node.Checkpoints
 import           Network.Haskoin.Node.HeaderTree.Model
 import           Network.Haskoin.Node.HeaderTree.Types
-import           Network.Haskoin.Util
 
 data BlockChainAction
     = BestChain  { actionNodes :: ![NodeBlock] }
@@ -89,7 +89,9 @@ data BlockChainAction
     deriving (Show, Eq)
 
 shortHash :: BlockHash -> ShortHash
-shortHash = fromRight . decode . BS.take 8 . hash256ToBS . getBlockHash
+shortHash =
+    fromRight (error "Could not decdoe block hash") .
+    decode . BS.take 8 . hash256ToBS . getBlockHash
 
 nHeader :: NodeBlock -> BlockHeader
 nHeader = getNodeHeader . nodeBlockHeader

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Accounts.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Accounts.hs
@@ -77,7 +77,6 @@ import           Network.Haskoin.Block
 import           Network.Haskoin.Constants
 import           Network.Haskoin.Crypto
 import           Network.Haskoin.Network
-import           Network.Haskoin.Node.HeaderTree
 import           Network.Haskoin.Script
 
 import           Network.Haskoin.Wallet.Model

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Model.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Model.hs
@@ -45,7 +45,6 @@ import Network.Haskoin.Transaction
 import Network.Haskoin.Script
 import Network.Haskoin.Crypto
 import Network.Haskoin.Network
-import Network.Haskoin.Node.HeaderTree
 
 share [ mkPersist sqlSettings
       , mkMigrate "migrateWallet"


### PR DESCRIPTION
* Remove unnecessary `bsToHash256` and related functions and just use `Serialize` instances for this.
* Remove obsolete `fromRight` and `fromLeft` utility functions and replace by upstream.
* Do conversions between `Either` and `Maybe` types using provided utility functions.
* Reformat some of the code altered to improve legibility.