### PR TITLE
Change how scripts and addresses relate

### DIFF
--- a/haskoin-core/src/Network/Haskoin/Crypto/ExtendedKeys.hs
+++ b/haskoin-core/src/Network/Haskoin/Crypto/ExtendedKeys.hs
@@ -100,8 +100,6 @@ import           Network.Haskoin.Crypto.Hash
 import           Network.Haskoin.Crypto.Keys
 import           Network.Haskoin.Script.Parser
 import           Network.Haskoin.Util
-import           Text.Read                     (lexP, parens, pfail, readPrec)
-import qualified Text.Read                     as Read
 
 {- See BIP32 for details: https://en.bitcoin.it/wiki/BIP_0032 -}
 
@@ -399,7 +397,7 @@ deriveAddrs k =
 -- public, soft derivation.
 deriveMSAddr :: [XPubKey] -> Int -> KeyIndex -> (Address, RedeemScript)
 deriveMSAddr keys m i =
-    (scriptAddr rdm, rdm)
+    (p2shAddr rdm, rdm)
   where
     rdm = sortMulSig $ PayMulSig k m
     k   = map (toPubKeyG . xPubKey . flip pubSubKey i) keys

--- a/haskoin-core/src/Network/Haskoin/Script.hs
+++ b/haskoin-core/src/Network/Haskoin/Script.hs
@@ -20,6 +20,8 @@ module Network.Haskoin.Script
 , encodeOutputBS
 , decodeOutput
 , decodeOutputBS
+, addressToScript
+, addressToScriptBS
 , isPayPK
 , isPayPKHash
 , isPayMulSig

--- a/haskoin-core/src/Network/Haskoin/Script.hs
+++ b/haskoin-core/src/Network/Haskoin/Script.hs
@@ -20,6 +20,7 @@ module Network.Haskoin.Script
 , encodeOutputBS
 , decodeOutput
 , decodeOutputBS
+, addressToOutput
 , addressToScript
 , addressToScriptBS
 , scriptToAddress
@@ -28,7 +29,7 @@ module Network.Haskoin.Script
 , isPayPKHash
 , isPayMulSig
 , isPayScriptHash
-, scriptAddr
+, p2shAddr
 , sortMulSig
 
   -- **Script Inputs

--- a/haskoin-core/src/Network/Haskoin/Script.hs
+++ b/haskoin-core/src/Network/Haskoin/Script.hs
@@ -22,6 +22,8 @@ module Network.Haskoin.Script
 , decodeOutputBS
 , addressToScript
 , addressToScriptBS
+, scriptToAddress
+, scriptToAddressBS
 , isPayPK
 , isPayPKHash
 , isPayMulSig

--- a/haskoin-core/src/Network/Haskoin/Script/Parser.hs
+++ b/haskoin-core/src/Network/Haskoin/Script/Parser.hs
@@ -140,16 +140,10 @@ addressToScriptBS = encode . addressToScript
 
 -- | Encode an output script as an address if it has such representation.
 scriptToAddress :: Script -> Maybe Address
-scriptToAddress s =
-    case decodeOutput s of
-        Left _ -> Nothing
-        Right output -> eitherToMaybe (outputAddress output)
+scriptToAddress = eitherToMaybe . (outputAddress <=< decodeOutput)
 
 scriptToAddressBS :: ByteString -> Maybe Address
-scriptToAddressBS s =
-    case decodeOutputBS s of
-        Left _ -> Nothing
-        Right output -> eitherToMaybe (outputAddress output)
+scriptToAddressBS = eitherToMaybe . (outputAddress <=< decodeOutputBS)
 
 -- | Computes a 'Script' from a 'ScriptOutput'. The 'Script' is a list of
 -- 'ScriptOp' can can be used to build a 'Tx'.

--- a/haskoin-core/src/Network/Haskoin/Script/Parser.hs
+++ b/haskoin-core/src/Network/Haskoin/Script/Parser.hs
@@ -12,6 +12,8 @@ module Network.Haskoin.Script.Parser
 , decodeInputBS
 , addressToScript
 , addressToScriptBS
+, scriptToAddress
+, scriptToAddressBS
 , encodeOutput
 , encodeOutputBS
 , decodeOutput
@@ -131,6 +133,19 @@ addressToScript (ScriptAddress h) = encodeOutput (PayScriptHash h)
 -- | Encode address as output script in ByteString form.
 addressToScriptBS :: Address -> ByteString
 addressToScriptBS = encode . addressToScript
+
+-- | Encode an output script as an address if it has such representation.
+scriptToAddress :: Script -> Maybe Address
+scriptToAddress s =
+    case decodeOutput s of
+        Left _ -> Nothing
+        Right output -> eitherToMaybe (outputAddress output)
+
+scriptToAddressBS :: ByteString -> Maybe Address
+scriptToAddressBS s =
+    case decodeOutputBS s of
+        Left _ -> Nothing
+        Right output -> eitherToMaybe (outputAddress output)
 
 -- | Computes a 'Script' from a 'ScriptOutput'. The 'Script' is a list of
 -- 'ScriptOp' can can be used to build a 'Tx'.

--- a/haskoin-core/src/Network/Haskoin/Test/Script.hs
+++ b/haskoin-core/src/Network/Haskoin/Test/Script.hs
@@ -222,7 +222,7 @@ arbitraryPKOutput =  PayPK . snd <$> arbitraryPubKey
 
 -- | Arbitrary ScriptOutput of type PayPKHash
 arbitraryPKHashOutput :: Gen ScriptOutput
-arbitraryPKHashOutput = PayPKHash <$> arbitraryPubKeyAddress
+arbitraryPKHashOutput = PayPKHash . getAddrHash <$> arbitraryPubKeyAddress
 
 -- | Arbitrary ScriptOutput of type PayMS
 arbitraryMSOutput :: Gen ScriptOutput
@@ -240,7 +240,7 @@ arbitraryMSCOutput = do
 
 -- | Arbitrary ScriptOutput of type PayScriptHash
 arbitrarySHOutput :: Gen ScriptOutput
-arbitrarySHOutput = PayScriptHash <$> arbitraryScriptAddress
+arbitrarySHOutput = PayScriptHash . getAddrHash <$> arbitraryScriptAddress
 
 -- | Arbitrary ScriptOutput of type DataCarrier
 arbitraryDCOutput :: Gen ScriptOutput

--- a/haskoin-core/src/Network/Haskoin/Test/Script.hs
+++ b/haskoin-core/src/Network/Haskoin/Test/Script.hs
@@ -222,7 +222,7 @@ arbitraryPKOutput =  PayPK . snd <$> arbitraryPubKey
 
 -- | Arbitrary ScriptOutput of type PayPKHash
 arbitraryPKHashOutput :: Gen ScriptOutput
-arbitraryPKHashOutput = PayPKHash . getAddrHash <$> arbitraryPubKeyAddress
+arbitraryPKHashOutput = PayPKHash <$> arbitraryHash160
 
 -- | Arbitrary ScriptOutput of type PayMS
 arbitraryMSOutput :: Gen ScriptOutput

--- a/haskoin-core/src/Network/Haskoin/Test/Transaction.hs
+++ b/haskoin-core/src/Network/Haskoin/Test/Transaction.hs
@@ -110,7 +110,7 @@ arbitraryPKSigInput = do
 arbitraryPKHashSigInput :: Gen (SigInput, PrvKey)
 arbitraryPKHashSigInput = do
     k <- arbitraryPrvKey
-    let out = PayPKHash $ pubKeyAddr $ derivePubKey k
+    let out = PayPKHash $ getAddrHash $ pubKeyAddr $ derivePubKey k
     op <- arbitraryOutPoint
     sh <- arbitraryValidSigHash
     return (SigInput out op sh Nothing, k)
@@ -135,7 +135,7 @@ arbitrarySHSigInput = do
         , f <$> arbitraryPKHashSigInput
         , arbitraryMSSigInput
         ]
-    let out = PayScriptHash $ scriptAddr rdm
+    let out = PayScriptHash $ getAddrHash $ scriptAddr rdm
     return (SigInput out op sh $ Just rdm, ks)
   where
     f (si, k) = (si, [k])
@@ -195,5 +195,9 @@ arbitraryPartialTxs = do
         let so = PayMulSig pubKeys m
         elements
             [ (so, Nothing, prvKeys, m, n)
-            , (PayScriptHash $ scriptAddr so, Just so, prvKeys, m, n)
+            , ( PayScriptHash $ getAddrHash $ scriptAddr so
+              , Just so
+              , prvKeys
+              , m
+              , n)
             ]

--- a/haskoin-core/src/Network/Haskoin/Test/Transaction.hs
+++ b/haskoin-core/src/Network/Haskoin/Test/Transaction.hs
@@ -135,7 +135,7 @@ arbitrarySHSigInput = do
         , f <$> arbitraryPKHashSigInput
         , arbitraryMSSigInput
         ]
-    let out = PayScriptHash $ getAddrHash $ scriptAddr rdm
+    let out = PayScriptHash $ getAddrHash $ p2shAddr rdm
     return (SigInput out op sh $ Just rdm, ks)
   where
     f (si, k) = (si, [k])
@@ -195,7 +195,7 @@ arbitraryPartialTxs = do
         let so = PayMulSig pubKeys m
         elements
             [ (so, Nothing, prvKeys, m, n)
-            , ( PayScriptHash $ getAddrHash $ scriptAddr so
+            , ( PayScriptHash $ getAddrHash $ p2shAddr so
               , Just so
               , prvKeys
               , m

--- a/haskoin-core/src/Network/Haskoin/Transaction/Builder.hs
+++ b/haskoin-core/src/Network/Haskoin/Transaction/Builder.hs
@@ -202,8 +202,7 @@ buildAddrTx xs ys =
     buildTx xs =<< mapM f ys
   where
     f (s, v) = case base58ToAddr s of
-        Just (PubKeyAddress h) -> return (PayPKHash h, v)
-        Just (ScriptAddress h) -> return (PayScriptHash h, v)
+        Just a -> return (addressToOutput a, v)
         _ -> Left $ "buildAddrTx: Invalid address " ++ cs s
 
 -- | Build a transaction by providing a list of outpoints as inputs
@@ -403,7 +402,7 @@ verifyStdInput tx i =
                 r    = getOutputMulSigRequired so
             in  countMulSig tx out i pubs sigs == r
         Right (ScriptHashInput si rdm) ->
-            scriptAddr rdm == ScriptAddress (getOutputHash so) &&
+            p2shAddr rdm == ScriptAddress (getOutputHash so) &&
             go (encodeInputBS $ RegularInput si) rdm
         _ -> False
       where

--- a/haskoin-core/src/Network/Haskoin/Transaction/Builder.hs
+++ b/haskoin-core/src/Network/Haskoin/Transaction/Builder.hs
@@ -202,8 +202,8 @@ buildAddrTx xs ys =
     buildTx xs =<< mapM f ys
   where
     f (s, v) = case base58ToAddr s of
-        Just a@(PubKeyAddress _) -> return (PayPKHash a,v)
-        Just a@(ScriptAddress _) -> return (PayScriptHash a,v)
+        Just (PubKeyAddress h) -> return (PayPKHash h, v)
+        Just (ScriptAddress h) -> return (PayScriptHash h, v)
         _ -> Left $ "buildAddrTx: Invalid address " ++ cs s
 
 -- | Build a transaction by providing a list of outpoints as inputs
@@ -294,8 +294,8 @@ sigKeys so rdmM keys =
     case (so, rdmM) of
         (PayPK p, Nothing) -> return $
             map fst $ maybeToList $ find ((== p) . snd) zipKeys
-        (PayPKHash a, Nothing) -> return $
-            map fst $ maybeToList $ find ((== a) . pubKeyAddr . snd) zipKeys
+        (PayPKHash h, Nothing) -> return $
+            map fst $ maybeToList $ find ((== h) . getAddrHash . pubKeyAddr . snd) zipKeys
         (PayMulSig ps r, Nothing) -> return $
             map fst $ take r $ filter ((`elem` ps) . snd) zipKeys
         (PayScriptHash _, Just rdm) ->
@@ -395,7 +395,7 @@ verifyStdInput tx i =
             let pub = getOutputPubKey so
             in  verifySig (txSigHash tx out i sh) sig pub
         Right (RegularInput (SpendPKHash (TxSignature sig sh) pub)) ->
-            let a = getOutputAddress so
+            let a = PubKeyAddress (getOutputHash so)
             in pubKeyAddr pub == a &&
                 verifySig (txSigHash tx out i sh) sig pub
         Right (RegularInput (SpendMulSig sigs)) ->
@@ -403,7 +403,7 @@ verifyStdInput tx i =
                 r    = getOutputMulSigRequired so
             in  countMulSig tx out i pubs sigs == r
         Right (ScriptHashInput si rdm) ->
-            scriptAddr rdm == getOutputAddress so &&
+            scriptAddr rdm == ScriptAddress (getOutputHash so) &&
             go (encodeInputBS $ RegularInput si) rdm
         _ -> False
       where

--- a/haskoin-core/test/Network/Haskoin/Script/Units.hs
+++ b/haskoin-core/test/Network/Haskoin/Script/Units.hs
@@ -66,7 +66,7 @@ runMulSigVector (a, ops) = assertBool "    >  MultiSig Vector" $ a == b
   where
     s = fromJust $ either (const Nothing) return . decode =<< decodeHex ops
     b =
-        addrToBase58 . scriptAddr . fromRight (error "Could not decode output") $
+        addrToBase58 . p2shAddr . fromRight (error "Could not decode output") $
         decodeOutput s
 
 testSigDecode :: ByteString -> Assertion

--- a/haskoin-core/test/Network/Haskoin/Transaction/Tests.hs
+++ b/haskoin-core/test/Network/Haskoin/Transaction/Tests.hs
@@ -49,8 +49,8 @@ tests =
 testBuildAddrTx :: Address -> TestCoin -> Bool
 testBuildAddrTx a (TestCoin v) =
     case a of
-        x@(PubKeyAddress _) -> Right (PayPKHash x) == out
-        x@(ScriptAddress _) -> Right (PayScriptHash x) == out
+        PubKeyAddress h -> Right (PayPKHash h) == out
+        ScriptAddress h -> Right (PayScriptHash h) == out
   where
     tx = buildAddrTx [] [(addrToBase58 a, v)]
     out =

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
@@ -767,36 +767,45 @@ encodeScriptInputJSON si = case si of
         ]
 
 encodeScriptOutputJSON :: ScriptOutput -> Value
-encodeScriptOutputJSON so = case so of
-    PayPK p -> object
-        [ "pay2pubkey" .= object
-          [ "pubkey" .= (cs $ encodeHex (S.encode p) :: T.Text) ]
-        ]
-    PayPKHash a -> object
-        [ "pay2pubkeyhash" .= object
-            [ "address-hex" .=
-              (cs $ encodeHex (S.encode $ getAddrHash a) :: T.Text)
-            , "address-base58" .= (cs $ addrToBase58 a :: T.Text)
-            ]
-        ]
-    PayMulSig ks r -> object
-        [ "pay2mulsig" .= object
-            [ "required-keys" .= r
-            , "pubkeys" .= (map (cs . encodeHex . S.encode) ks :: [T.Text])
-            ]
-        ]
-    PayScriptHash a -> object
-        [ "pay2scripthash" .= object
-            [ "address-hex" .= (cs $ encodeHex $
-                S.encode $ getAddrHash a :: T.Text)
-            , "address-base58" .= (cs (addrToBase58 a) :: T.Text)
-            ]
-        ]
-    DataCarrier bs -> object
-        [ "op_return" .= object
-            [ "data" .= (cs $ encodeHex bs :: T.Text)
-            ]
-        ]
+encodeScriptOutputJSON so =
+    case so of
+        PayPK p ->
+            object
+                [ "pay2pubkey" .=
+                  object ["pubkey" .= (cs $ encodeHex (S.encode p) :: T.Text)]
+                ]
+        PayPKHash h ->
+            object
+                [ "pay2pubkeyhash" .=
+                  object
+                      [ "address-hex" .= (cs $ encodeHex (S.encode h) :: T.Text)
+                      , "address-base58" .=
+                        (cs (addrToBase58 (PubKeyAddress h)) :: T.Text)
+                      ]
+                ]
+        PayMulSig ks r ->
+            object
+                [ "pay2mulsig" .=
+                  object
+                      [ "required-keys" .= r
+                      , "pubkeys" .=
+                        (map (cs . encodeHex . S.encode) ks :: [T.Text])
+                      ]
+                ]
+        PayScriptHash h ->
+            object
+                [ "pay2scripthash" .=
+                  object
+                      [ "address-hex" .= (cs $ encodeHex $ S.encode h :: T.Text)
+                      , "address-base58" .=
+                        (cs (addrToBase58 (ScriptAddress h)) :: T.Text)
+                      ]
+                ]
+        DataCarrier bs ->
+            object
+                [ "op_return" .=
+                  object ["data" .= (cs $ encodeHex bs :: T.Text)]
+                ]
 
 encodeSigJSON :: TxSignature -> Value
 encodeSigJSON ts@(TxSignature _ sh) = object

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
@@ -762,7 +762,7 @@ encodeScriptInputJSON si = case si of
             [ "scriptinput" .= encodeScriptInputJSON (RegularInput s)
             , "redeem" .= encodeScriptOutputJSON r
             , "raw-redeem" .= (cs $ encodeHex (encodeOutputBS r) :: T.Text)
-            , "sender-address" .= (cs $ addrToBase58 (scriptAddr r) :: T.Text)
+            , "sender-address" .= (cs $ addrToBase58 (p2shAddr r) :: T.Text)
             ]
         ]
 

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Types.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Types.hs
@@ -368,7 +368,7 @@ data JsonAddr = JsonAddr
     -- Optional Balance
     , jsonAddrBalance :: !(Maybe BalanceInfo)
     }
-    deriving (Eq, Show, Read)
+    deriving (Eq, Show)
 
 $(deriveJSON (dropFieldLabel 8) ''JsonAddr)
 

--- a/haskoin-wallet/test/Network/Haskoin/Wallet/Units.hs
+++ b/haskoin-wallet/test/Network/Haskoin/Wallet/Units.hs
@@ -378,7 +378,7 @@ fakeTx xs ys =
     createTx 1 txi txo 0
   where
     txi = map (\(h,p) -> TxIn (OutPoint h p) (BS.pack [1]) maxBound) xs
-    f = encodeOutputBS . PayPKHash . fromJust . base58ToAddr
+    f = addressToScriptBS . fromJust . base58ToAddr
     txo = map (\(a,v) -> TxOut v $ f a ) ys
 
 testDerivations :: App ()
@@ -1197,7 +1197,7 @@ testImportMultisig = do
             1
             [ TxIn (OutPoint tid1 0) (BS.pack [1]) maxBound ] -- dummy input
             [ TxOut 10000000 $
-              encodeOutputBS $ PayScriptHash $ fromJust $
+              addressToScriptBS $ fromJust $
               base58ToAddr "32SupmLrYyZMSPfL4tgkuUCyvbzEyBfqxd"
             ]
             0
@@ -1409,7 +1409,7 @@ testDeleteUnsignedTx = do
             1
             [ TxIn (OutPoint tid1 0) (BS.pack [1]) maxBound ] -- dummy input
             [ TxOut 10000000 $
-              encodeOutputBS $ PayScriptHash $ fromJust $
+              addressToScriptBS $ fromJust $
               base58ToAddr "32SupmLrYyZMSPfL4tgkuUCyvbzEyBfqxd"
             ]
             0


### PR DESCRIPTION
Do not reuse the `Address` inside the lower-level `OutputScript` type, but use the embedded `Hash160`.