### PR TITLE
nit: export isDataCarrier in Network.Haskoin.Script

### DIFF
--- a/haskoin-core/src/Network/Haskoin/Script.hs
+++ b/haskoin-core/src/Network/Haskoin/Script.hs
@@ -29,6 +29,7 @@ module Network.Haskoin.Script
 , isPayPKHash
 , isPayMulSig
 , isPayScriptHash
+, isDataCarrier
 , p2shAddr
 , sortMulSig
 

--- a/haskoin-core/src/Network/Haskoin/Script/Parser.hs
+++ b/haskoin-core/src/Network/Haskoin/Script/Parser.hs
@@ -26,11 +26,11 @@ module Network.Haskoin.Script.Parser
 , isPayPKHash
 , isPayMulSig
 , isPayScriptHash
+, isDataCarrier
 , isSpendPK
 , isSpendPKHash
 , isSpendMulSig
 , isScriptHashInput
-, isDataCarrier
 ) where
 
 import           Control.Applicative            ((<|>))

--- a/haskoin-core/src/Network/Haskoin/Transaction/Types.hs
+++ b/haskoin-core/src/Network/Haskoin/Transaction/Types.hs
@@ -80,7 +80,7 @@ data Tx = Tx
     , txIn       :: ![TxIn]
       -- | List of transaction outputs
     , txOut      :: ![TxOut]
-      -- | The block number of timestamp at which this transaction is locked
+      -- | The block number or timestamp at which this transaction is locked
     , txLockTime :: !Word32
     } deriving (Eq)
 


### PR DESCRIPTION
The check on whether the type of a `ScriptOutput` is a `DataCarrier` was missing from the exports in `Script.hs`