### PR TITLE
Adding testnet3 configuration

### DIFF
--- a/haskoin-wallet/config/config.yml
+++ b/haskoin-wallet/config/config.yml
@@ -20,6 +20,9 @@ database:
     testnet5:
         database: hw-wallet.sqlite3
         poolsize: 1
+    testnet3:
+        database: hw-wallet.sqlite3
+        poolsize: 1
     prodnet:
         database: hw-wallet.sqlite3
         poolsize: 1
@@ -31,6 +34,11 @@ bitcoin-full-nodes:
           port: 18555
         - host: bitcoin-testnet.bloqseeds.net
           port: 18555
+    testnet3:
+        - host: testnet-seed.bitcoin.jonasschnelli.ch
+          port: 18333
+        - host: seed.tbtc.petertodd.org
+          port: 18333
     prodnet:
         - host: seed.mainnet.b-pay.net
           port: 8333


### PR DESCRIPTION
Running hw using testnet doesn't work currently. I added testnet3 confiugration to config.yml. Is this actually the way to go? 

tilmann$ stack exec hw -- -t start
hw: DB config settings for testnet3 not found
CallStack (from HasCallStack):
  error, called at src/Network/Haskoin/Wallet/Server.hs:218:14 in haskoin-wallet-0.4.3-BbXtrCLDaLjCTNiaMs4Fql:Network.Haskoin.Wallet.Server