### PR TITLE
Relax upper bounds and move from monad-control to unliftso

### DIFF
--- a/haskoin-core/haskoin-core.cabal
+++ b/haskoin-core/haskoin-core.cabal
@@ -72,32 +72,32 @@ library
                          Network.Haskoin.Test.Transaction
                          Network.Haskoin.Test.Block
                          Paths_haskoin_core
-    build-depends:       aeson >= 1.2 && < 1.3
+    build-depends:       aeson >= 1.2 && < 1.4
                        , base >= 4.8 && < 5
                        , byteable >= 0.1 && < 0.2
                        , bytestring >= 0.10 && < 0.11
                        , base16-bytestring >= 0.1 && < 0.2
                        , cereal >= 0.5 && < 0.6
-                       , conduit >= 1.2 && < 1.3
+                       , conduit >= 1.2 && < 1.4
                        , containers >= 0.5 && < 0.6
-                       , cryptonite >= 0.24 && < 0.25
+                       , cryptonite >= 0.24 && < 0.26
                        , deepseq >= 1.4 && < 1.5
-                       , either >= 4.5 && < 4.6
+                       , either >= 4.5 && < 5.1
                        , hashable >= 1.2 && < 1.3
                        , mtl >= 2.2 && < 2.3
                        , memory >= 0.14 && < 0.15
                        , murmur3 >= 1.0&& < 1.1
-                       , network >= 2.6&& < 2.7
+                       , network >= 2.6&& < 2.8
                        , pbkdf >= 1.1 && < 1.2
-                       , QuickCheck >= 2.10 && < 2.11
+                       , QuickCheck >= 2.10 && < 2.12
                        , split >= 0.2 && < 0.3
                        , string-conversions >= 0.4 && < 0.5
                        , text >= 0.11 && < 1.3
-                       , time >= 1.8 && < 1.9
+                       , time >= 1.8 && < 1.10
                        , unordered-containers >= 0.2 && < 0.3
                        , vector >= 0.12 && < 0.13
                        , secp256k1 >= 0.5 && < 0.6
-                       , entropy >= 0.3 && < 0.4
+                       , entropy >= 0.3 && < 0.5
     default-language:    Haskell2010
 
 test-suite haskoin-core-test
@@ -126,7 +126,7 @@ test-suite haskoin-core-test
                          Network.Haskoin.Json.Tests
                          Network.Haskoin.Cereal.Tests
     build-depends:       base >= 4.8 && < 5
-                       , aeson >= 1.2 && < 1.3
+                       , aeson >= 1.2 && < 1.4
                        , haskoin-core
                        , bytestring >= 0.10 && < 0.11
                        , cereal >= 0.5 && < 0.6
@@ -134,7 +134,7 @@ test-suite haskoin-core-test
                        , mtl >= 2.2 && < 2.3
                        , split >= 0.2 && < 0.3
                        , HUnit >= 1.6 && < 1.7
-                       , QuickCheck >= 2.10 && < 2.11
+                       , QuickCheck >= 2.10 && < 2.12
                        , test-framework >= 0.8 && < 0.9
                        , test-framework-quickcheck2 >= 0.3 && < 0.4
                        , test-framework-hunit >= 0.3 && < 0.4
@@ -155,7 +155,7 @@ test-suite haskoin-core-regtest
     build-depends:       base >= 4.8 && < 5
                        , haskoin-core
                        , HUnit >= 1.6 && < 1.7
-                       , QuickCheck >= 2.10 && < 2.11
+                       , QuickCheck >= 2.10 && < 2.12
                        , mtl >= 2.2 && < 2.3
                        , test-framework >= 0.8 && < 0.9
                        , test-framework-quickcheck2 >= 0.3 && < 0.4

--- a/haskoin-node/haskoin-node.cabal
+++ b/haskoin-node/haskoin-node.cabal
@@ -49,38 +49,37 @@ library
                 RecordWildCards
                 DeriveDataTypeable
 
-    build-depends: aeson                    >= 1.2          && < 1.3
-                 , async                    >= 2.0          && < 2.2
+    build-depends: aeson                    >= 1.2          && < 1.4
+                 , async                    >= 2.0          && < 2.3
                  , base                     >= 4.8          && < 5
                  , bytestring               >= 0.10         && < 0.11
                  , concurrent-extra         >= 0.7          && < 0.8
                  , cereal                   >= 0.5          && < 0.6
-                 , conduit                  >= 1.2          && < 1.3
-                 , conduit-extra            >= 1.2          && < 1.3
+                 , conduit                  >= 1.3          && < 1.4
+                 , conduit-extra            >= 1.2          && < 1.4
                  , containers               >= 0.5          && < 0.6
                  , data-default             >= 0.5          && < 0.8
                  , deepseq                  >= 1.4          && < 1.5
-                 , either                   >= 4.5          && < 4.6
-                 , esqueleto                >= 2.4          && < 2.6
-                 , exceptions               >= 0.8          && < 0.9
+                 , either                   >= 4.5          && < 5.1
+                 , esqueleto                >= 2.4          && < 2.7
+                 , exceptions               >= 0.8          && < 0.11
                  , haskoin-core             >= 0.3          && < 0.5
                  , largeword                >= 1.2.4        && < 1.3
-                 , lifted-async             >= 0.2          && < 0.10
-                 , lifted-base              >= 0.2          && < 0.3
-                 , monad-control            >= 1.0          && < 1.1
                  , monad-logger             >= 0.3          && < 0.4
                  , mtl                      >= 2.2          && < 2.3
-                 , network                  >= 2.4          && < 2.7
-                 , persistent               >= 2.7          && < 2.8
+                 , network                  >= 2.4          && < 2.8
+                 , persistent               >= 2.7          && < 2.9
                  , persistent-template      >= 2.5          && < 2.6
                  , resource-pool            >= 0.2          && < 0.3
                  , random                   >= 1.0          && < 1.2
                  , stm                      >= 2.4          && < 2.5
                  , stm-chans                >= 3.0          && < 3.1
-                 , stm-conduit              >= 2.5          && < 3.1
+                 , stm-conduit              >= 2.5          && < 4.1
                  , string-conversions       >= 0.4          && < 0.5
                  , text                     >= 0.11         && < 1.3
-                 , time                     >= 1.8          && < 1.9
+                 , time                     >= 1.8          && < 1.10
+                 , unliftio                 >= 0.2          && < 0.3
+                 , unliftio-core            >= 0.1          && < 0.2
 
     ghc-options: -Wall
 
@@ -97,13 +96,13 @@ test-suite test-haskoin-node
                  , haskoin-core
                  , haskoin-node
                  , HUnit                          >= 1.6        && < 1.7
-                 , QuickCheck                     >= 2.10       && < 2.11
+                 , QuickCheck                     >= 2.10       && < 2.12
                  , monad-logger                   >= 0.3        && < 0.4
                  , mtl                            >= 2.2        && < 2.3
-                 , persistent                     >= 2.7        && < 2.8
-                 , persistent-sqlite              >= 2.6        && < 2.7
-                 , resourcet                      >= 1.1        && < 1.2
-                 , test-framework                 >= 0.8        && < 0.9
+                 , persistent                     >= 2.7        && < 2.9
+                 , persistent-sqlite              >= 2.6        && < 2.9
+                 , resourcet                      >= 1.2        && < 1.3
+                 , test-framework                 >= 0.8        && < 1.2
                  , test-framework-quickcheck2     >= 0.3        && < 0.4
                  , test-framework-hunit           >= 0.3        && < 0.4
 

--- a/haskoin-wallet/haskoin-wallet.cabal
+++ b/haskoin-wallet/haskoin-wallet.cabal
@@ -60,45 +60,45 @@ library
                 RecordWildCards
                 GeneralizedNewtypeDeriving
 
-    build-depends: aeson                         >= 1.2       && < 1.3
+    build-depends: aeson                         >= 1.2       && < 1.4
                  , aeson-pretty                  >= 0.7       && < 0.9
+                 , async                         >= 2.0       && < 2.3
                  , base                          >= 4.8       && < 5
                  , base64-bytestring             >= 1.0.0.1
                  , bytestring                    >= 0.10      && < 0.11
                  , cereal                        >= 0.5       && < 0.6
                  , containers                    >= 0.5       && < 0.6
-                 , conduit                       >= 1.2       && < 1.3
+                 , conduit                       >= 1.3       && < 1.4
                  , deepseq                       >= 1.4       && < 1.5
                  , data-default                  >= 0.5       && < 0.8
                  , directory                     >= 1.2       && < 1.4
                  , daemons                       >= 0.2       && < 0.3
-                 , entropy                       >= 0.3.7     && < 0.4
-                 , exceptions                    >= 0.6       && < 0.9
-                 , esqueleto                     >= 2.4       && < 2.6
+                 , entropy                       >= 0.3.7     && < 0.5
+                 , exceptions                    >= 0.6       && < 0.11
+                 , esqueleto                     >= 2.4       && < 2.7
                  , file-embed                    >= 0.0       && < 0.1
                  , filepath                      >= 1.4       && < 1.5
                  , haskeline
                  , haskoin-core                  >= 0.3       && < 0.5
                  , haskoin-node                  >= 0.3       && < 0.5
-                 , lifted-async                  >= 0.2       && < 0.10
-                 , lifted-base                   >= 0.2       && < 0.3
                  , monad-logger                  >= 0.3.13    && < 0.4
-                 , monad-control                 >= 1.0       && < 1.1
                  , mtl                           >= 2.1       && < 2.3
-                 , persistent                    >= 2.7       && < 2.8
+                 , persistent                    >= 2.7       && < 2.9
                  , persistent-template           >= 2.1       && < 2.6
-                 , persistent-sqlite             >= 2.2       && < 2.7
-                 , resourcet                     >= 1.1       && < 1.2
+                 , persistent-sqlite             >= 2.2       && < 2.9
+                 , resourcet                     >= 1.2       && < 1.3
                  , semigroups
                  , split                         >= 0.2       && < 0.3
                  , stm                           >= 2.4       && < 2.5
                  , stm-chans                     >= 3.0       && < 3.1
-                 , stm-conduit                   >= 2.6       && < 3.1
+                 , stm-conduit                   >= 2.6       && < 4.1
                  , string-conversions            >= 0.4       && < 0.5
                  , text                          >= 0.11      && < 1.3
-                 , time                          >= 1.8       && < 1.9
+                 , time                          >= 1.8       && < 1.10
                  , transformers-base             >= 0.4       && < 0.5
                  , unix                          >= 2.6       && < 2.8
+                 , unliftio                      >= 0.2       && < 0.3
+                 , unliftio-core                 >= 0.1       && < 0.2
                  , unordered-containers          >= 0.2       && < 0.3
                  , uri-encode                    >= 1.5.0.5
                  , yaml                          >= 0.8       && < 0.9
@@ -125,12 +125,12 @@ test-suite test-haskoin-wallet
 
     other-modules: Network.Haskoin.Wallet.Arbitrary
                  , Network.Haskoin.Wallet.Tests
-                 , Network.Haskoin.Wallet.Units 
+                 , Network.Haskoin.Wallet.Units
 
     extensions: RecordWildCards
                 OverloadedStrings
 
-    build-depends: aeson                         >= 1.2       && < 1.3
+    build-depends: aeson                         >= 1.2       && < 1.4
                  , base                          >= 4.8       && < 5
                  , bytestring                    >= 0.10      && < 0.11
                  , containers                    >= 0.5       && < 0.6
@@ -140,13 +140,13 @@ test-suite test-haskoin-wallet
                  , haskoin-wallet
                  , monad-logger                  >= 0.3       && < 0.4
                  , mtl                           >= 2.1       && < 2.3
-                 , persistent                    >= 2.7       && < 2.8
-                 , persistent-sqlite             >= 2.2       && < 2.7
-                 , resourcet                     >= 1.1       && < 1.2
+                 , persistent                    >= 2.7       && < 2.9
+                 , persistent-sqlite             >= 2.2       && < 2.9
+                 , resourcet                     >= 1.2       && < 1.3
                  , text                          >= 0.11      && < 1.3
                  , unordered-containers          >= 0.2       && < 0.3
                  , HUnit                         >= 1.6       && < 1.7
-                 , QuickCheck                    >= 2.10      && < 2.11
+                 , QuickCheck                    >= 2.10      && < 2.12
                  , stm                           >= 2.4       && < 2.5
                  , stm-chans                     >= 3.0       && < 3.1
                  , string-conversions            >= 0.4       && < 0.5
@@ -172,13 +172,13 @@ executable example-inproc-wallet-server
                  -with-rtsopts=-N4
 
     build-depends:     base                          >= 4.8       && < 5
-                     , aeson                         >= 1.2       && < 1.3
+                     , aeson                         >= 1.2       && < 1.4
                      , aeson-pretty                  >= 0.7       && < 0.9
                      , haskoin-node                  >= 0.3       && < 0.5
                      , haskoin-wallet
                      , monad-logger                  >= 0.3       && < 0.4
-                     , persistent-sqlite             >= 2.2       && < 2.7
-                     , resourcet                     >= 1.1       && < 1.2
+                     , persistent-sqlite             >= 2.2       && < 2.9
+                     , resourcet                     >= 1.2       && < 1.3
                      , unordered-containers          >= 0.2       && < 0.3
                      , string-conversions            >= 0.4       && < 0.5
                      , zeromq4-haskell               >= 0.7       && < 0.8

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Accounts.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Accounts.hs
@@ -122,7 +122,7 @@ rootToAccKeys xKey pubs =
     is = nub $ map xPubChild pubs
 
 -- | Fetch all accounts
-accounts :: (MonadIO m, MonadThrow m, MonadResource m)
+accounts :: (MonadIO m, MonadResource m)
          => ListRequest -> SqlPersistT m ([Account], Word32)
 accounts ListRequest{..} = do
     cntRes <- select $ from $ \acc ->
@@ -229,7 +229,7 @@ newAccount NewAccount{..} = do
         -- The account already exists
         Nothing -> throwM $ WalletException "Account already exists"
 
-renameAccount :: (MonadIO m, MonadThrow m, MonadResource m)
+renameAccount :: (MonadIO m, MonadResource m)
               => Entity Account
               -> AccountName
               -> SqlPersistT m Account
@@ -312,12 +312,12 @@ getAddress accE@(Entity ai _) addrType index = do
 
 -- | All addresses in the wallet, including hidden gap addresses. This is useful
 -- for building a bloom filter.
-addressesAll :: (MonadIO m, MonadThrow m, MonadResource m)
+addressesAll :: (MonadIO m, MonadResource m)
              => SqlPersistT m [WalletAddr]
 addressesAll = fmap (map entityVal) $ select $ from return
 
 -- | All addresses in one account excluding hidden gap.
-addresses :: (MonadIO m, MonadThrow m, MonadResource m)
+addresses :: (MonadIO m, MonadResource m)
           => Entity Account             -- ^ Account Entity
           -> AddressType                -- ^ Address Type
           -> SqlPersistT m [WalletAddr] -- ^ Addresses
@@ -405,7 +405,7 @@ unusedAddresses (Entity ai acc) addrType ListRequest{..} = do
             | otherwise   = min lim' (cnt - off cnt - gap)
     order = if listReverse then desc else asc
 
-lookupByPubKey :: (MonadIO m, MonadThrow m)
+lookupByPubKey :: (MonadIO m)
                => Entity Account         -- ^ Account Entity
                -> PubKeyC                -- ^ Pubkey of interest
                -> AddressType            -- ^ Address type

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Accounts.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Accounts.hs
@@ -43,7 +43,6 @@ module Network.Haskoin.Wallet.Accounts
 import           Control.Applicative             ((<|>))
 import           Control.Exception               (throw)
 import           Control.Monad                   (unless, void, when)
-import           Control.Monad.Base              (MonadBase)
 import           Control.Monad.Catch             (MonadThrow, throwM)
 import           Control.Monad.Trans             (MonadIO, liftIO)
 import           Control.Monad.Trans.Resource    (MonadResource)
@@ -123,7 +122,7 @@ rootToAccKeys xKey pubs =
     is = nub $ map xPubChild pubs
 
 -- | Fetch all accounts
-accounts :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+accounts :: (MonadIO m, MonadThrow m, MonadResource m)
          => ListRequest -> SqlPersistT m ([Account], Word32)
 accounts ListRequest{..} = do
     cntRes <- select $ from $ \acc ->
@@ -140,7 +139,7 @@ accounts ListRequest{..} = do
 
     return (res, cnt)
 
-initGap :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+initGap :: (MonadIO m, MonadThrow m, MonadResource m)
         => Entity Account -> SqlPersistT m ()
 initGap accE = do
     void $ createAddrs accE AddressExternal 20
@@ -163,7 +162,7 @@ mnemonicToPrvKey pass ms = case mnemonicToSeed pass ms of
 
 -- |Create a new account using the given mnemonic or keys. If no mnemonic,
 -- master key or public keys are provided, a new mnemonic will be generated.
-newAccount :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+newAccount :: (MonadIO m, MonadThrow m, MonadResource m)
            => NewAccount
            -> SqlPersistT m (Entity Account, Maybe Mnemonic)
 newAccount NewAccount{..} = do
@@ -230,7 +229,7 @@ newAccount NewAccount{..} = do
         -- The account already exists
         Nothing -> throwM $ WalletException "Account already exists"
 
-renameAccount :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+renameAccount :: (MonadIO m, MonadThrow m, MonadResource m)
               => Entity Account
               -> AccountName
               -> SqlPersistT m Account
@@ -240,7 +239,7 @@ renameAccount (Entity ai acc) name = do
 
 -- | Add new thirdparty keys to a multisignature account. This function can
 -- fail if the multisignature account already has all required keys.
-addAccountKeys :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+addAccountKeys :: (MonadIO m, MonadThrow m, MonadResource m)
                => Entity Account        -- ^ Account Entity
                -> [XPubKey]             -- ^ Thirdparty public keys to add
                -> SqlPersistT m Account -- ^ Account information
@@ -313,12 +312,12 @@ getAddress accE@(Entity ai _) addrType index = do
 
 -- | All addresses in the wallet, including hidden gap addresses. This is useful
 -- for building a bloom filter.
-addressesAll :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+addressesAll :: (MonadIO m, MonadThrow m, MonadResource m)
              => SqlPersistT m [WalletAddr]
 addressesAll = fmap (map entityVal) $ select $ from return
 
 -- | All addresses in one account excluding hidden gap.
-addresses :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+addresses :: (MonadIO m, MonadThrow m, MonadResource m)
           => Entity Account             -- ^ Account Entity
           -> AddressType                -- ^ Address Type
           -> SqlPersistT m [WalletAddr] -- ^ Addresses
@@ -461,7 +460,7 @@ addressPrvKey accE@(Entity ai acc) masterM index addrType = do
 -- addresses in an account, disregarding visible and hidden address gaps. You
 -- should use the function `setAccountGap` if you want to control the gap of an
 -- account instead.
-createAddrs :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+createAddrs :: (MonadIO m, MonadThrow m, MonadResource m)
             => Entity Account
             -> AddressType
             -> Word32
@@ -518,7 +517,7 @@ createAddrs (Entity ai acc) addrType n
                 ]
 
 -- | Generate all the addresses up to certain index.
-generateAddrs :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+generateAddrs :: (MonadIO m, MonadThrow m, MonadResource m)
               => Entity Account
               -> AddressType
               -> KeyIndex
@@ -534,7 +533,7 @@ generateAddrs accE addrType genIndex = do
 
 -- | Use an address and make sure we have enough gap addresses after it.
 -- Returns the new addresses that have been created.
-useAddress :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+useAddress :: (MonadIO m, MonadThrow m, MonadResource m)
            => WalletAddr -> SqlPersistT m [WalletAddr]
 useAddress WalletAddr{..} = do
     res <- select $ from $ \x -> do
@@ -558,7 +557,7 @@ useAddress WalletAddr{..} = do
 -- | Set the address gap of an account to a new value. This will create new
 -- internal and external addresses as required. The gap can only be increased,
 -- not decreased in size.
-setAccountGap :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+setAccountGap :: (MonadIO m, MonadThrow m, MonadResource m)
               => Entity Account -- ^ Account Entity
               -> Word32         -- ^ New gap value
               -> SqlPersistT m (Entity Account)
@@ -595,7 +594,7 @@ firstAddrTime = do
 
 -- | Add the given addresses to the bloom filter. If the number of elements
 -- becomes too large, a new bloom filter is computed from scratch.
-incrementFilter :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+incrementFilter :: (MonadIO m, MonadThrow m, MonadResource m)
                 => [WalletAddr]
                 -> SqlPersistT m ()
 incrementFilter addrs = do
@@ -606,7 +605,7 @@ incrementFilter addrs = do
         else setBloomFilter (addToFilter bloom addrs) newElems
 
 -- | Generate a new bloom filter from the data in the database
-computeNewFilter :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+computeNewFilter :: (MonadIO m, MonadThrow m, MonadResource m)
                  => SqlPersistT m ()
 computeNewFilter = do
     (_, _, fpRate) <- getBloomFilter

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
@@ -42,7 +42,7 @@ module Network.Haskoin.Wallet.Client.Commands
 )
 where
 
-import           Control.Concurrent.Async.Lifted          (async, wait)
+import           Control.Concurrent.Async                (async, wait)
 import           Control.Monad
 import qualified Control.Monad.Reader                     as R
 import           Control.Monad.Trans                      (liftIO)
@@ -666,14 +666,14 @@ sendZmq req = do
     when (configVerbose cfg) $ liftIO $
         B8.hPutStrLn stderr $ "Outgoing JSON: " `mappend` msg
     -- TODO: If I do this in the same thread I have to ^C twice to exit
-    a <- async $ liftIO $ withContext $ \ctx ->
+    a <- liftIO $ async $ withContext $ \ctx ->
         withSocket ctx Req $ \sock -> do
             setLinger (restrict (0 :: Int)) sock
             setupAuth cfg sock
             connect sock (configConnect cfg)
             send sock [] (cs $ encode req)
             eitherDecode . cs <$> receive sock
-    wait a
+    liftIO $ wait a
 
 setupAuth :: (SocketType t)
           => Config

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Client/Commands.hs
@@ -643,7 +643,7 @@ parseResponse resE = case resE of
     Left err                   -> error err
 
 handleResponse
-    :: (FromJSON a, ToJSON a)
+    :: ToJSON a
     => Either String (WalletResponse a)
     -> (a -> Handler ())
     -> Handler ()
@@ -657,7 +657,7 @@ handleResponse resE handle = case parseResponse resE of
         OutputYAML   -> liftIO . formatStr $ cs $ YAML.encode a
         OutputNormal -> handle a
 
-sendZmq :: (FromJSON a, ToJSON a)
+sendZmq :: FromJSON a
         => WalletRequest
         -> Handler (Either String (WalletResponse a))
 sendZmq req = do
@@ -675,8 +675,7 @@ sendZmq req = do
             eitherDecode . cs <$> receive sock
     liftIO $ wait a
 
-setupAuth :: (SocketType t)
-          => Config
+setupAuth :: Config
           -> Socket t
           -> IO ()
 setupAuth cfg sock = do

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Database.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Database.hs
@@ -1,14 +1,14 @@
 module Network.Haskoin.Wallet.Database where
 
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Logger (MonadLoggerIO)
-import Control.Monad.Trans.Control (MonadBaseControl)
 
 import Database.Persist.Sql (ConnectionPool)
 import Database.Persist.Sqlite (SqliteConf(..), createSqlitePool)
 
 type DatabaseConfType = SqliteConf
 
-getDatabasePool :: (MonadLoggerIO m, MonadBaseControl IO m)
+getDatabasePool :: (MonadLoggerIO m, MonadUnliftIO m)
                 => DatabaseConfType -> m ConnectionPool
 getDatabasePool conf = createSqlitePool (sqlDatabase conf) (sqlPoolSize conf)
 

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Server.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Server.hs
@@ -5,29 +5,24 @@ module Network.Haskoin.Wallet.Server
 , runSPVServerWithContext
 ) where
 
-import           Control.Concurrent.Async.Lifted       (async, link,
-                                                        waitAnyCancel)
 import           Control.Concurrent.STM                (atomically, retry)
 import           Control.Concurrent.STM.TBMChan        (TBMChan, newTBMChan,
                                                         readTBMChan)
 import           Control.DeepSeq                       (NFData (..))
-import           Control.Exception.Lifted              (ErrorCall (..),
-                                                        SomeException (..),
-                                                        catches)
-import qualified Control.Exception.Lifted              as E (Handler (..))
+import           Control.Exception                     (ErrorCall (..),
+                                                        SomeException(..))
 import           Control.Monad                         (forM_, forever, unless,
                                                         void, when)
-import           Control.Monad.Base                    (MonadBase)
 import           Control.Monad.Catch                   (MonadThrow)
 import           Control.Monad.Fix                     (fix)
+import           Control.Monad.IO.Unlift               (MonadUnliftIO,
+                                                        withRunInIO)
 import           Control.Monad.Logger                  (MonadLoggerIO,
                                                         filterLogger, logDebug,
                                                         logError, logInfo,
                                                         logWarn,
                                                         runStdoutLoggingT)
 import           Control.Monad.Trans                   (lift, liftIO)
-import           Control.Monad.Trans.Control           (MonadBaseControl,
-                                                        liftBaseOpDiscard)
 import           Control.Monad.Trans.Resource          (MonadResource,
                                                         runResourceT)
 import           Data.Aeson                            (Value, decode, encode)
@@ -71,13 +66,26 @@ import           System.Posix.Daemon                   (Redirection (ToFile),
                                                         runDetached)
 import           System.ZMQ4                           (Context, KeyFormat (..),
                                                         Pub (..), Rep (..),
-                                                        Socket, bind, receive,
+                                                        Socket, SocketType,
+                                                        bind, receive,
                                                         receiveMulti, restrict,
                                                         send, sendMulti,
                                                         setCurveSecretKey,
                                                         setCurveServer,
                                                         setLinger, withContext,
                                                         withSocket, z85Decode)
+import           UnliftIO.Exception                    (catches)
+import qualified UnliftIO.Exception               as E (Handler (..))
+import           UnliftIO.Async                        (async, link,
+                                                        waitAnyCancel)
+
+withSocketLifted
+    :: (MonadUnliftIO m, SocketType a)
+    => Context
+    -> a
+    -> (Socket a -> m b)
+    -> m b
+withSocketLifted ctx a go = withRunInIO $ \run -> withSocket ctx a $ run . go
 
 data EventSession = EventSession
     { eventBatchSize :: !Int
@@ -104,8 +112,7 @@ runSPVServer cfg = maybeDetach cfg $ -- start the server process
 --  the "inproc" ZeroMQ transport, where a shared context is
 --  required.
 runSPVServerWithContext :: ( MonadLoggerIO m
-                           , MonadBaseControl IO m
-                           , MonadBase IO m
+                           , MonadUnliftIO m
                            , MonadThrow m
                            , MonadResource m
                            )
@@ -210,7 +217,7 @@ runSPVServerWithContext cfg ctx = do
                 atomicallyNodeT $ sendBloomFilter bloom elems
         $(logDebug) "Exiting tx-import thread"
 
-initDatabase :: (MonadBaseControl IO m, MonadLoggerIO m)
+initDatabase :: (MonadUnliftIO m, MonadLoggerIO m)
              => Config -> m ConnectionPool
 initDatabase cfg = do
     -- Create a database pool
@@ -226,7 +233,7 @@ initDatabase cfg = do
     return pool
 
 merkleSync
-    :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m, MonadResource m)
+    :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m, MonadResource m)
     => ConnectionPool
     -> Word32
     -> TBMChan Notif
@@ -356,14 +363,13 @@ maybeDetach cfg action =
 -- TODO: Support concurrent requests using DEALER socket when we can do
 -- concurrent MySQL requests.
 runWalletNotif :: ( MonadLoggerIO m
-                , MonadBaseControl IO m
-                , MonadBase IO m
+                , MonadUnliftIO m
                 , MonadThrow m
                 , MonadResource m
                 )
                => Context -> HandlerSession -> m ()
 runWalletNotif ctx session =
-    liftBaseOpDiscard (withSocket ctx Pub) $ \sock -> do
+    withSocketLifted ctx Pub $ \sock -> do
         liftIO $ setLinger (restrict (0 :: Int)) sock
         setupCrypto ctx sock session
         liftIO $ bind sock $ configBindNotif $ handlerConfig session
@@ -378,14 +384,13 @@ runWalletNotif ctx session =
                 in liftIO $ sendMulti sock $ typ :| [pay]
 
 runWalletCmd :: ( MonadLoggerIO m
-                , MonadBaseControl IO m
-                , MonadBase IO m
+                , MonadUnliftIO m
                 , MonadThrow m
                 , MonadResource m
                 )
              => Context -> HandlerSession -> m ()
 runWalletCmd ctx session = do
-    liftBaseOpDiscard (withSocket ctx Rep) $ \sock -> do
+    withSocketLifted ctx Rep $ \sock -> do
         liftIO $ setLinger (restrict (0 :: Int)) sock
         setupCrypto ctx sock session
         liftIO $ bind sock $ configBind $ handlerConfig session
@@ -412,7 +417,7 @@ runWalletCmd ctx session = do
             return $ ResponseError $ pack $ show exc
         ]
 
-setupCrypto :: (MonadLoggerIO m, MonadBaseControl IO m)
+setupCrypto :: (MonadLoggerIO m, MonadUnliftIO m)
             => Context -> Socket a -> HandlerSession -> m ()
 setupCrypto ctx' sock session = do
     when (isJust serverKeyM) $ liftIO $ do
@@ -428,13 +433,12 @@ setupCrypto ctx' sock session = do
     clientKeyPubM = configClientKeyPub cfg
 
 runZapAuth :: ( MonadLoggerIO m
-              , MonadBaseControl IO m
-              , MonadBase IO m
+              , MonadUnliftIO m
               )
            => Context -> ByteString -> m ()
 runZapAuth ctx k = do
     $(logDebug) $ "Starting ØMQ authentication thread"
-    liftBaseOpDiscard (withSocket ctx Rep) $ \zap -> do
+    withSocketLifted ctx Rep $ \zap -> do
         liftIO $ setLinger (restrict (0 :: Int)) zap
         liftIO $ bind zap "inproc://zeromq.zap.01"
         forever $ do
@@ -463,8 +467,7 @@ runZapAuth ctx k = do
 
 
 dispatchRequest :: ( MonadLoggerIO m
-                   , MonadBaseControl IO m
-                   , MonadBase IO m
+                   , MonadUnliftIO m
                    , MonadThrow m
                    , MonadResource m
                    )

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Server.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Server.hs
@@ -364,8 +364,6 @@ maybeDetach cfg action =
 -- concurrent MySQL requests.
 runWalletNotif :: ( MonadLoggerIO m
                 , MonadUnliftIO m
-                , MonadThrow m
-                , MonadResource m
                 )
                => Context -> HandlerSession -> m ()
 runWalletNotif ctx session =

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Server/Handler.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Server/Handler.hs
@@ -52,7 +52,7 @@ data HandlerSession = HandlerSession
     , handlerNotifChan :: !(TBMChan Notif)
     }
 
-runHandler :: Monad m => Handler m a -> HandlerSession -> m a
+runHandler :: Handler m a -> HandlerSession -> m a
 runHandler = runReaderT
 
 runDB :: MonadUnliftIO m => SqlPersistT m a -> Handler m a
@@ -93,7 +93,6 @@ accountReq name = do
 
 accountsReq :: ( MonadLoggerIO m
                , MonadUnliftIO m
-               , MonadThrow m
                , MonadResource m
                )
              => ListRequest
@@ -511,8 +510,9 @@ offlineTxReq accountName txid = do
         getOfflineTxData ai txid
     return $ Just $ toJSON dat
 
-signOfflineTxReq :: ( MonadLoggerIO m, MonadUnliftIO m
-                    , MonadThrow m, MonadResource m
+signOfflineTxReq :: ( MonadLoggerIO m
+                    , MonadUnliftIO m
+                    , MonadThrow m
                     )
                  => AccountName
                  -> Maybe XPrvKey

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Server/Handler.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Server/Handler.hs
@@ -9,13 +9,12 @@ import           Control.Concurrent.STM.TBMChan     (TBMChan)
 import           Control.Exception                  (SomeException (..),
                                                      tryJust)
 import           Control.Monad                      (liftM, forM, unless, when)
-import           Control.Monad.Base                 (MonadBase)
 import           Control.Monad.Catch                (MonadThrow, throwM)
+import           Control.Monad.IO.Unlift            (MonadUnliftIO)
 import           Control.Monad.Logger               (MonadLoggerIO, logError,
                                                      logInfo)
 import           Control.Monad.Reader               (ReaderT, asks, runReaderT)
 import           Control.Monad.Trans                (MonadIO, lift, liftIO)
-import           Control.Monad.Trans.Control        (MonadBaseControl)
 import           Control.Monad.Trans.Resource       (MonadResource)
 import           Data.Aeson                         (Value (..), toJSON)
 import qualified Data.Map.Strict                    as M (elems, fromList,
@@ -56,10 +55,10 @@ data HandlerSession = HandlerSession
 runHandler :: Monad m => Handler m a -> HandlerSession -> m a
 runHandler = runReaderT
 
-runDB :: MonadBaseControl IO m => SqlPersistT m a -> Handler m a
+runDB :: MonadUnliftIO m => SqlPersistT m a -> Handler m a
 runDB action = asks handlerPool >>= lift . runDBPool action
 
-runDBPool :: MonadBaseControl IO m => SqlPersistT m a -> ConnectionPool -> m a
+runDBPool :: MonadUnliftIO m => SqlPersistT m a -> ConnectionPool -> m a
 runDBPool = runSqlPool
 
 tryDBPool :: MonadLoggerIO m => ConnectionPool -> SqlPersistM a -> m (Maybe a)
@@ -82,7 +81,7 @@ runNode action = do
 
 {- Server Handlers -}
 
-accountReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+accountReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
            => AccountName -> Handler m (Maybe Value)
 accountReq name = do
     $(logInfo) $ format $ unlines
@@ -93,8 +92,7 @@ accountReq name = do
     return $ Just $ toJSON $ toJsonAccount Nothing acc
 
 accountsReq :: ( MonadLoggerIO m
-               , MonadBaseControl IO m
-               , MonadBase IO m
+               , MonadUnliftIO m
                , MonadThrow m
                , MonadResource m
                )
@@ -111,7 +109,7 @@ accountsReq lq@ListRequest{..} = do
     return $ Just $ toJSON $ ListResult (map (toJsonAccount Nothing) accs) cnt
 
 newAccountReq
-    :: (MonadResource m, MonadThrow m, MonadLoggerIO m, MonadBaseControl IO m)
+    :: (MonadResource m, MonadThrow m, MonadLoggerIO m, MonadUnliftIO m)
     => NewAccount -> Handler m (Maybe Value)
 newAccountReq newAcc@NewAccount{..} = do
     $(logInfo) $ format $ unlines
@@ -125,7 +123,7 @@ newAccountReq newAcc@NewAccount{..} = do
     return $ Just $ toJSON $ toJsonAccount mnemonicM newAcc'
 
 renameAccountReq
-    :: (MonadResource m, MonadThrow m, MonadLoggerIO m, MonadBaseControl IO m)
+    :: (MonadResource m, MonadThrow m, MonadLoggerIO m, MonadUnliftIO m)
     => AccountName -> AccountName -> Handler m (Maybe Value)
 renameAccountReq oldName newName = do
     $(logInfo) $ format $ unlines
@@ -139,7 +137,7 @@ renameAccountReq oldName newName = do
     return $ Just $ toJSON $ toJsonAccount Nothing newAcc
 
 addPubKeysReq
-    :: (MonadResource m, MonadThrow m, MonadLoggerIO m, MonadBaseControl IO m)
+    :: (MonadResource m, MonadThrow m, MonadLoggerIO m, MonadUnliftIO m)
     => AccountName -> [XPubKey] -> Handler m (Maybe Value)
 addPubKeysReq name keys = do
     $(logInfo) $ format $ unlines
@@ -155,8 +153,7 @@ addPubKeysReq name keys = do
     return $ Just $ toJSON $ toJsonAccount Nothing newAcc
 
 setAccountGapReq :: ( MonadLoggerIO m
-                    , MonadBaseControl IO m
-                    , MonadBase IO m
+                    , MonadUnliftIO m
                     , MonadThrow m
                     , MonadResource m
                     )
@@ -176,7 +173,7 @@ setAccountGapReq name gap = do
     whenOnline updateNodeFilter
     return $ Just $ toJSON $ toJsonAccount Nothing newAcc
 
-addrsReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+addrsReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
          => AccountName
          -> AddressType
          -> Word32
@@ -215,7 +212,7 @@ addrsReq name addrType minConf offline listReq = do
         in  M.intersectionWith (,) (M.fromList $ map f addrs) (M.fromList bals)
 
 unusedAddrsReq
-    :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+    :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
     => AccountName -> AddressType -> ListRequest -> Handler m (Maybe Value)
 unusedAddrsReq name addrType lq@ListRequest{..} = do
     $(logInfo) $ format $ unlines
@@ -233,7 +230,7 @@ unusedAddrsReq name addrType lq@ListRequest{..} = do
 
     return $ Just $ toJSON $ ListResult (map (`toJsonAddr` Nothing) addrs) cnt
 
-addressReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+addressReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
            => AccountName -> KeyIndex -> AddressType
            -> Word32 -> Bool
            -> Handler m (Maybe Value)
@@ -255,7 +252,7 @@ addressReq name i addrType minConf offline = do
     return $ Just $ toJSON $ toJsonAddr addr balM
 
 -- TODO: How can we generalize this? Perhaps as part of wallet searching?
-pubKeyIndexReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+pubKeyIndexReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
                => AccountName
                -> PubKeyC
                -> AddressType
@@ -273,7 +270,7 @@ pubKeyIndexReq name key addrType = do
     -- TODO: We don't return the balance for now. Maybe add it? Or not?
     return $ Just $ toJSON $ map (`toJsonAddr` Nothing) addrLst
 
-setAddrLabelReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+setAddrLabelReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
                 => AccountName
                 -> KeyIndex
                 -> AddressType
@@ -294,9 +291,8 @@ setAddrLabelReq name i addrType label = do
     return $ Just $ toJSON $ toJsonAddr newAddr Nothing
 
 generateAddrsReq :: ( MonadLoggerIO m
-                    , MonadBaseControl IO m
+                    , MonadUnliftIO m
                     , MonadThrow m
-                    , MonadBase IO m
                     , MonadResource m
                     )
                  => AccountName
@@ -320,7 +316,7 @@ generateAddrsReq name i addrType = do
     return $ Just $ toJSON cnt
 
 -- This is a generic function (see specifics below)
-getTxs :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+getTxs :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
        => AccountName
        -> ListRequest
        -> String
@@ -345,19 +341,19 @@ getTxs name lq@ListRequest{..} cmd f = do
   where
     g bb = toJsonTx name (Just bb)
 
-txsReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+txsReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
        => AccountName -> ListRequest -> Handler m (Maybe Value)
 txsReq name lq = getTxs name lq "Txs" (txs Nothing)
 
-pendingTxsReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+pendingTxsReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
               => AccountName -> ListRequest -> Handler m (Maybe Value)
 pendingTxsReq name lq = getTxs name lq "PendingTxs" (txs (Just TxPending))
 
-deadTxsReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+deadTxsReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
          => AccountName -> ListRequest -> Handler m (Maybe Value)
 deadTxsReq name lq = getTxs name lq "DeadTxs" (txs (Just TxDead))
 
-addrTxsReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+addrTxsReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
            => AccountName -> KeyIndex -> AddressType -> ListRequest
            -> Handler m (Maybe Value)
 addrTxsReq name index addrType lq@ListRequest{..} = do
@@ -382,7 +378,7 @@ addrTxsReq name index addrType lq@ListRequest{..} = do
   where
     f bb = toJsonTx name (Just bb)
 
-createTxReq :: ( MonadLoggerIO m, MonadBaseControl IO m, MonadBase IO m
+createTxReq :: ( MonadLoggerIO m, MonadUnliftIO m
                , MonadThrow m, MonadResource m
                )
             => AccountName
@@ -416,7 +412,7 @@ createTxReq name (CreateTx rs fee minconf rcptFee sign masterM) = do
             runNode $ broadcastTxs [walletTxHash txRes]
     return $ Just $ toJSON $ toJsonTx name (Just bb) txRes
 
-importTxReq :: ( MonadLoggerIO m, MonadBaseControl IO m, MonadBase IO m
+importTxReq :: ( MonadLoggerIO m, MonadUnliftIO m
                , MonadThrow m, MonadResource m
                )
             => AccountName -> Tx -> Handler m (Maybe Value)
@@ -445,7 +441,7 @@ importTxReq name tx = do
             runNode $ broadcastTxs [walletTxHash txRes]
     return $ Just $ toJSON $ toJsonTx name (Just bb) txRes
 
-signTxReq :: ( MonadLoggerIO m, MonadBaseControl IO m, MonadBase IO m
+signTxReq :: ( MonadLoggerIO m, MonadUnliftIO m
              , MonadThrow m, MonadResource m
              )
           => AccountName -> SignTx -> Handler m (Maybe Value)
@@ -474,7 +470,7 @@ signTxReq name (SignTx txid masterM) = do
             runNode $ broadcastTxs [walletTxHash txRes]
     return $ Just $ toJSON $ toJsonTx name (Just bb) txRes
 
-txReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+txReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
       => AccountName -> TxHash -> Handler m (Maybe Value)
 txReq name txid = do
     $(logInfo) $ format $ unlines
@@ -490,7 +486,7 @@ txReq name txid = do
     return $ Just $ toJSON $ toJsonTx name (Just bb) res
 
 -- TODO: This should be limited to a single account
-deleteTxReq :: (MonadLoggerIO m, MonadThrow m, MonadBaseControl IO m)
+deleteTxReq :: (MonadLoggerIO m, MonadThrow m, MonadUnliftIO m)
             => TxHash -> Handler m (Maybe Value)
 deleteTxReq txid = do
     $(logInfo) $ format $ unlines
@@ -500,8 +496,8 @@ deleteTxReq txid = do
     runDB $ deleteTx txid
     return Nothing
 
-offlineTxReq :: ( MonadLoggerIO m, MonadBaseControl IO m
-                , MonadBase IO m, MonadThrow m, MonadResource m
+offlineTxReq :: ( MonadLoggerIO m, MonadUnliftIO m
+                , MonadThrow m, MonadResource m
                 )
              => AccountName -> TxHash -> Handler m (Maybe Value)
 offlineTxReq accountName txid = do
@@ -515,8 +511,8 @@ offlineTxReq accountName txid = do
         getOfflineTxData ai txid
     return $ Just $ toJSON dat
 
-signOfflineTxReq :: ( MonadLoggerIO m, MonadBaseControl IO m
-                    , MonadBase IO m, MonadThrow m, MonadResource m
+signOfflineTxReq :: ( MonadLoggerIO m, MonadUnliftIO m
+                    , MonadThrow m, MonadResource m
                     )
                  => AccountName
                  -> Maybe XPrvKey
@@ -535,7 +531,7 @@ signOfflineTxReq accountName masterM tx signData = do
         toDat CoinSignData{..} = (coinSignScriptOutput, coinSignOutPoint)
     return $ Just $ toJSON $ TxCompleteRes signedTx complete
 
-balanceReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+balanceReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
            => AccountName -> Word32 -> Bool
            -> Handler m (Maybe Value)
 balanceReq name minconf offline = do
@@ -550,7 +546,7 @@ balanceReq name minconf offline = do
         accountBalance ai minconf offline
     return $ Just $ toJSON bal
 
-nodeActionReq :: (MonadLoggerIO m, MonadBaseControl IO m, MonadThrow m)
+nodeActionReq :: (MonadLoggerIO m, MonadUnliftIO m, MonadThrow m)
               => NodeAction -> Handler m (Maybe Value)
 nodeActionReq action = case action of
     NodeActionRescan tM -> do
@@ -575,7 +571,7 @@ nodeActionReq action = case action of
     err = throwM $ WalletException
         "No keys have been generated in the wallet"
 
-syncReq :: (MonadThrow m, MonadLoggerIO m, MonadBaseControl IO m)
+syncReq :: (MonadThrow m, MonadLoggerIO m, MonadUnliftIO m)
         => AccountName
         -> Either BlockHeight BlockHash
         -> ListRequest
@@ -609,7 +605,7 @@ syncReq acc blockE lq@ListRequest{..} = runDB $ do
         Left  e -> show e
         Right b -> cs $ blockHashToHex b
 
-blockInfoReq :: (MonadThrow m, MonadLoggerIO m, MonadBaseControl IO m)
+blockInfoReq :: (MonadThrow m, MonadLoggerIO m, MonadUnliftIO m)
              => [BlockHash] -> Handler m (Maybe Value)
 blockInfoReq headerLst = do
     $(logInfo) $ format "Received BlockInfo request"
@@ -632,7 +628,7 @@ whenOnline handler = do
     when (mode == SPVOnline) handler
 
 updateNodeFilter
-    :: (MonadBaseControl IO m, MonadLoggerIO m, MonadThrow m)
+    :: (MonadUnliftIO m, MonadLoggerIO m, MonadThrow m)
     => Handler m ()
 updateNodeFilter = do
     $(logInfo) $ format "Sending a new bloom filter"

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Transaction.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Transaction.hs
@@ -197,7 +197,7 @@ addrTxs (Entity ai _) (Entity addrI WalletAddr{..}) ListRequest{..} = do
           , walletTxOutValue = input
           }
 
-accTxsFromBlock :: (MonadIO m, MonadThrow m)
+accTxsFromBlock :: MonadIO m
                 => AccountId
                 -> BlockHeight
                 -> Word32 -- ^ Block count (0 for all)
@@ -1130,7 +1130,7 @@ signAccountTx (Entity ai acc) notifChanM masterM txid = do
     importTx' signedTx notifChanM ai inCoins
 
 getOfflineTxData
-    :: (MonadIO m, MonadThrow m, MonadResource m)
+    :: (MonadIO m, MonadResource m)
     => AccountId
     -> TxHash
     -> SqlPersistT m (OfflineTxData, [InCoinData])
@@ -1183,7 +1183,7 @@ signOfflineTx acc masterM tx coinSignData
 -- number of confirmations. Coinbase coins can only be spent after 100
 -- confirmations.
 spendableCoins
-    :: (MonadIO m, MonadThrow m, MonadResource m)
+    :: (MonadIO m, MonadResource m)
     => AccountId                   -- ^ Account key
     -> Word32                      -- ^ Minimum confirmations
     -> (    SqlExpr (Entity WalletCoin)

--- a/haskoin-wallet/src/Network/Haskoin/Wallet/Transaction.hs
+++ b/haskoin-wallet/src/Network/Haskoin/Wallet/Transaction.hs
@@ -42,7 +42,6 @@ import           Control.Concurrent.STM          (atomically)
 import           Control.Concurrent.STM.TBMChan  (TBMChan, writeTBMChan)
 import           Control.Exception               (throw, throwIO)
 import           Control.Monad                   (forM, forM_, unless, when)
-import           Control.Monad.Base              (MonadBase)
 import           Control.Monad.Catch             (MonadThrow, throwM)
 import           Control.Monad.Trans             (MonadIO, liftIO)
 import           Control.Monad.Trans.Resource    (MonadResource)
@@ -258,7 +257,7 @@ getPendingTxs i =
 -- spent, then the transaction will be imported as a network transaction.
 -- Otherwise, the transaction will be imported into the local account as an
 -- offline transaction.
-importTx :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+importTx :: (MonadIO m, MonadThrow m, MonadResource m)
          => Tx               -- ^ Transaction to import
          -> Maybe (TBMChan Notif)
          -> AccountId        -- ^ Account ID
@@ -267,7 +266,7 @@ importTx :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
 importTx tx notifChanM ai =
     importTx' tx notifChanM ai =<< getInCoins tx (Just ai)
 
-importTx' :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+importTx' :: (MonadIO m, MonadThrow m, MonadResource m)
           => Tx                   -- ^ Transaction to import
           -> Maybe (TBMChan Notif)
           -> AccountId            -- ^ Account ID
@@ -358,7 +357,7 @@ mergeNoSigHashTxs ai tx inCoins = do
 -- have no idea if they are valid or not. Transactions are broadcast from the
 -- transaction creation function and only if the transaction is complete.
 importOfflineTx
-    :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+    :: (MonadIO m, MonadThrow m, MonadResource m)
     => Tx
     -> Maybe (TBMChan Notif)
     -> AccountId
@@ -408,7 +407,7 @@ importOfflineTx tx notifChanM ai inCoins spendingTxs = do
 --
 -- This function returns the network confidence of the imported transaction.
 importNetTx
-    :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+    :: (MonadIO m, MonadThrow m, MonadResource m)
     => Tx -- Network transaction to import
     -> Maybe (TBMChan Notif)
     -> SqlPersistT m ([WalletTx], [WalletAddr])
@@ -1001,7 +1000,7 @@ reviveTx notifChanM tx = do
 
 -- | Create a transaction sending some coins to a list of recipient addresses.
 createWalletTx
-    :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+    :: (MonadIO m, MonadThrow m, MonadResource m)
         => Entity Account        -- ^ Account Entity
         -> Maybe (TBMChan Notif) -- ^ Notification channel
         -> Maybe XPrvKey         -- ^ Key if not provided by account
@@ -1040,7 +1039,7 @@ toCoinSignData (InCoinData (Entity _ c) t x) =
 -- the unsigned transaction together with the input coins that have been
 -- selected or spending.
 buildUnsignedTx
-    :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+    :: (MonadIO m, MonadThrow m, MonadResource m)
     => Entity Account
     -> [(Address, Word64)]
     -> Word64
@@ -1119,7 +1118,7 @@ buildUnsignedTx accE@(Entity ai acc) origDests origFee minConf rcptFee = do
             _ -> liftIO . throwIO $ WalletException
                 "No unused addresses available"
 
-signAccountTx :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+signAccountTx :: (MonadIO m, MonadThrow m, MonadResource m)
               => Entity Account
               -> Maybe (TBMChan Notif)
               -> Maybe XPrvKey
@@ -1131,7 +1130,7 @@ signAccountTx (Entity ai acc) notifChanM masterM txid = do
     importTx' signedTx notifChanM ai inCoins
 
 getOfflineTxData
-    :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+    :: (MonadIO m, MonadThrow m, MonadResource m)
     => AccountId
     -> TxHash
     -> SqlPersistT m (OfflineTxData, [InCoinData])
@@ -1184,7 +1183,7 @@ signOfflineTx acc masterM tx coinSignData
 -- number of confirmations. Coinbase coins can only be spent after 100
 -- confirmations.
 spendableCoins
-    :: (MonadIO m, MonadThrow m, MonadBase IO m, MonadResource m)
+    :: (MonadIO m, MonadThrow m, MonadResource m)
     => AccountId                   -- ^ Account key
     -> Word32                      -- ^ Minimum confirmations
     -> (    SqlExpr (Entity WalletCoin)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.1
+resolver: lts-11.7
 flags: {}
 packages:
 - haskoin-core
@@ -6,7 +6,8 @@ packages:
 - haskoin-wallet
 extra-deps:
 - daemons-0.2.1
-- pbkdf-1.1.1.1
 - murmur3-1.0.3
+- pbkdf-1.1.1.1
 - secp256k1-0.5.2
-- concurrent-extra-0.7.0.10
+- git: git@github.com:bitemyapp/esqueleto
+  commit: 6a86ee32e5b869a877151f74064572225e1a0398


### PR DESCRIPTION
[*DON'T MERGE YET: this PR depends on an unreleased version of esqueleto. So, consider this PR on hold until a new version is esqueleto is released.  You can use `stack build` to pull esqueleto from GitHub and build with lts-11.7.*]

This PR updates outdated upper bounds on dependencies.

`conduit-1.3` and `resourcet-1.2` dropped support for `monad-control` and require `unliftio`. So, this PR moves the code base from using `MonadBaseControl IO m` to `MonadUnliftIO m` for lifting control functions into transformers. Most of the changes are straight forward.

Along the way, this PR also removes redundant constraints.