### PR TITLE
Upgrading haskoin-core to GHC 8.4.3

### DIFF
--- a/haskoin-core/haskoin-core.cabal
+++ b/haskoin-core/haskoin-core.cabal
@@ -72,24 +72,23 @@ library
                          Network.Haskoin.Test.Transaction
                          Network.Haskoin.Test.Block
                          Paths_haskoin_core
-    build-depends:       aeson >= 1.2 && < 1.3
+    build-depends:       aeson >= 1.2 && < 1.4
                        , base >= 4.8 && < 5
                        , byteable >= 0.1 && < 0.2
                        , bytestring >= 0.10 && < 0.11
                        , base16-bytestring >= 0.1 && < 0.2
                        , cereal >= 0.5 && < 0.6
-                       , conduit >= 1.2 && < 1.3
+                       , conduit >= 1.2 && < 1.4
                        , containers >= 0.5 && < 0.6
-                       , cryptonite >= 0.24 && < 0.25
+                       , cryptonite >= 0.24 && < 0.26
                        , deepseq >= 1.4 && < 1.5
-                       , either >= 4.5 && < 4.6
                        , hashable >= 1.2 && < 1.3
                        , mtl >= 2.2 && < 2.3
                        , memory >= 0.14 && < 0.15
                        , murmur3 >= 1.0&& < 1.1
                        , network >= 2.6&& < 2.7
                        , pbkdf >= 1.1 && < 1.2
-                       , QuickCheck >= 2.10 && < 2.11
+                       , QuickCheck >= 2.10 && < 2.12
                        , split >= 0.2 && < 0.3
                        , string-conversions >= 0.4 && < 0.5
                        , text >= 0.11 && < 1.3
@@ -97,7 +96,7 @@ library
                        , unordered-containers >= 0.2 && < 0.3
                        , vector >= 0.12 && < 0.13
                        , secp256k1 >= 0.5 && < 0.6
-                       , entropy >= 0.3 && < 0.4
+                       , entropy >= 0.3 && < 0.5
     default-language:    Haskell2010
 
 test-suite haskoin-core-test
@@ -126,7 +125,7 @@ test-suite haskoin-core-test
                          Network.Haskoin.Json.Tests
                          Network.Haskoin.Cereal.Tests
     build-depends:       base >= 4.8 && < 5
-                       , aeson >= 1.2 && < 1.3
+                       , aeson >= 1.2 && < 1.4
                        , haskoin-core
                        , bytestring >= 0.10 && < 0.11
                        , cereal >= 0.5 && < 0.6
@@ -134,7 +133,7 @@ test-suite haskoin-core-test
                        , mtl >= 2.2 && < 2.3
                        , split >= 0.2 && < 0.3
                        , HUnit >= 1.6 && < 1.7
-                       , QuickCheck >= 2.10 && < 2.11
+                       , QuickCheck >= 2.10 && < 2.12
                        , test-framework >= 0.8 && < 0.9
                        , test-framework-quickcheck2 >= 0.3 && < 0.4
                        , test-framework-hunit >= 0.3 && < 0.4
@@ -155,7 +154,7 @@ test-suite haskoin-core-regtest
     build-depends:       base >= 4.8 && < 5
                        , haskoin-core
                        , HUnit >= 1.6 && < 1.7
-                       , QuickCheck >= 2.10 && < 2.11
+                       , QuickCheck >= 2.10 && < 2.12
                        , mtl >= 2.2 && < 2.3
                        , test-framework >= 0.8 && < 0.9
                        , test-framework-quickcheck2 >= 0.3 && < 0.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.1
+resolver: lts-12.2
 flags: {}
 packages:
 - haskoin-core


### PR DESCRIPTION
I also have a patch for `haskoin-wallet` and `haskoin-node`, but `esqueleto` hasn't fully upgraded to GHC 8.4.3 yet, so I'm gonna wait on that.