### PR TITLE
Minor clean ups

### DIFF
--- a/src/Network/Haskoin/Block/Common.hs
+++ b/src/Network/Haskoin/Block/Common.hs
@@ -73,7 +73,7 @@ instance Serialize Block where
         return $ Block header txs
     put (Block h txs) = do
         put h
-        put $ VarInt $ fromIntegral $ length txs
+        putVarInt $ length txs
         forM_ txs put
 
 -- | Block header hash. To be serialized reversed for display purposes.
@@ -200,7 +200,7 @@ instance Serialize GetBlocks where
 putGetBlockMsg :: Word32 -> BlockLocator -> BlockHash -> Put
 putGetBlockMsg v xs h = do
     putWord32le v
-    put $ VarInt $ fromIntegral $ length xs
+    putVarInt $ length xs
     forM_ xs put
     put h
 
@@ -248,7 +248,7 @@ instance Serialize Headers where
         action = liftM2 (,) get get
 
     put (Headers xs) = do
-        put $ VarInt $ fromIntegral $ length xs
+        putVarInt $ length xs
         forM_ xs $ \(a,b) -> put a >> put b
 
 -- | Decode the compact number used in the difficulty target of a block.

--- a/src/Network/Haskoin/Block/Merkle.hs
+++ b/src/Network/Haskoin/Block/Merkle.hs
@@ -88,10 +88,10 @@ instance Serialize MerkleBlock where
     put (MerkleBlock h ntx hashes flags) = do
         put h
         putWord32le ntx
-        put $ VarInt $ fromIntegral $ length hashes
+        putVarInt $ length hashes
         forM_ hashes put
         let ws = encodeMerkleFlags flags
-        put $ VarInt $ fromIntegral $ length ws
+        putVarInt $ length ws
         forM_ ws putWord8
 
 -- | Unpack Merkle flags into 'FlagBits' structure.

--- a/src/Network/Haskoin/Network/Bloom.hs
+++ b/src/Network/Haskoin/Network/Bloom.hs
@@ -106,7 +106,7 @@ instance Serialize BloomFilter where
         readDat (VarInt len) = replicateM (fromIntegral len) getWord8
 
     put (BloomFilter dat hashFuncs tweak flags) = do
-        put $ VarInt $ fromIntegral $ S.length dat
+        putVarInt $ S.length dat
         forM_ (F.toList dat) putWord8
         putWord32le hashFuncs
         putWord32le tweak
@@ -132,7 +132,7 @@ instance Serialize FilterAdd where
         return $ FilterAdd dat
 
     put (FilterAdd bs) = do
-        put $ VarInt $ fromIntegral $ BS.length bs
+        putVarInt $ BS.length bs
         putByteString bs
 
 

--- a/src/Network/Haskoin/Network/Common.hs
+++ b/src/Network/Haskoin/Network/Common.hs
@@ -38,6 +38,7 @@ module Network.Haskoin.Network.Common
     , nodeXThin
     , commandToString
     , stringToCommand
+    , putVarInt
     ) where
 
 import           Control.Monad               (forM_, liftM2, replicateM, unless)
@@ -74,7 +75,7 @@ instance Serialize Addr where
         action             = liftM2 (,) getWord32le S.get
 
     put (Addr xs) = do
-        put $ VarInt $ fromIntegral $ length xs
+        putVarInt $ length xs
         forM_ xs $ \(a,b) -> putWord32le a >> put b
 
 -- | Data type describing signed messages that can be sent between bitcoin
@@ -111,7 +112,7 @@ instance Serialize GetData where
         repList (VarInt c) = replicateM (fromIntegral c) S.get
 
     put (GetData xs) = do
-        put $ VarInt $ fromIntegral $ length xs
+        putVarInt $ length xs
         forM_ xs put
 
 -- | 'Inv' messages are used by nodes to advertise their knowledge of new
@@ -130,7 +131,7 @@ instance Serialize Inv where
         repList (VarInt c) = replicateM (fromIntegral c) S.get
 
     put (Inv xs) = do
-        put $ VarInt $ fromIntegral $ length xs
+        putVarInt $ length xs
         forM_ xs put
 
 -- | Data type identifying the type of an inventory vector. SegWit types are
@@ -248,7 +249,7 @@ instance Serialize NotFound where
         repList (VarInt c) = replicateM (fromIntegral c) S.get
 
     put (NotFound xs) = do
-        put $ VarInt $ fromIntegral $ length xs
+        putVarInt $ length xs
         forM_ xs put
 
 -- | A 'Ping' message is sent to bitcoin peers to check if a connection is still
@@ -373,6 +374,9 @@ instance Serialize VarInt where
             putWord8 0xff
             putWord64le x
 
+putVarInt :: Integral a => a -> Put
+putVarInt = put . VarInt . fromIntegral
+
 -- | Data type for serialization of variable-length strings.
 newtype VarString = VarString { getVarString :: ByteString }
     deriving (Eq, Show, Read)
@@ -384,7 +388,7 @@ instance Serialize VarString where
         readBS (VarInt len) = getByteString (fromIntegral len)
 
     put (VarString bs) = do
-        put $ VarInt $ fromIntegral $ B.length bs
+        putVarInt $ B.length bs
         putByteString bs
 
 -- | When a bitcoin node creates an outgoing connection to another node,

--- a/src/Network/Haskoin/Script/SigHash.hs
+++ b/src/Network/Haskoin/Script/SigHash.hs
@@ -277,7 +277,7 @@ txSigHashForkId net tx out v i sh =
         | otherwise = zeros
     putScript s = do
         let encodedScript = encode s
-        put $ VarInt $ fromIntegral $ BS.length encodedScript
+        putVarInt $ BS.length encodedScript
         putByteString encodedScript
     zeros :: Hash256
     zeros = "0000000000000000000000000000000000000000000000000000000000000000"

--- a/src/Network/Haskoin/Transaction/Common.hs
+++ b/src/Network/Haskoin/Transaction/Common.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-|
 Module      : Network.Haskoin.Transaction.Common
 Copyright   : No rights reserved
@@ -129,9 +129,9 @@ instance Serialize Tx where
 
 putInOut :: Tx -> Put
 putInOut tx = do
-    put $ VarInt $ fromIntegral $ length (txIn tx)
+    putVarInt $ length (txIn tx)
     forM_ (txIn tx) put
-    put $ VarInt $ fromIntegral $ length (txOut tx)
+    putVarInt $ length (txOut tx)
     forM_ (txOut tx) put
 
 -- | Non-SegWit transaction serializer.
@@ -197,10 +197,10 @@ putWitnessData :: WitnessData -> Put
 putWitnessData = mapM_ putWitnessStack
   where
     putWitnessStack ws = do
-        put $ VarInt $ fromIntegral $ length ws
+        putVarInt $ length ws
         mapM_ putWitnessStackItem ws
     putWitnessStackItem bs = do
-        put $ VarInt $ fromIntegral $ B.length bs
+        putVarInt $ B.length bs
         putByteString bs
 
 instance FromJSON Tx where
@@ -229,7 +229,7 @@ instance Serialize TxIn where
 
     put (TxIn o s q) = do
         put o
-        put $ VarInt $ fromIntegral $ B.length s
+        putVarInt $ B.length s
         putByteString s
         putWord32le q
 
@@ -250,7 +250,7 @@ instance Serialize TxOut where
 
     put (TxOut o s) = do
         putWord64le o
-        put $ VarInt $ fromIntegral $ B.length s
+        putVarInt $ B.length s
         putByteString s
 
 -- | The 'OutPoint' refers to a transaction output being spent.


### PR DESCRIPTION
In working on PSBT, I found some minor refactorings that made things cleaner. `Fingerprint`s are used in the PSBT format, hence the type alias.