### PR TITLE
Expose transaction signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ cabal.project.local~
 .ghc.environment.*
 haskoin-core.cabal
 TAGS
+tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.9.1
+### Added
+- Adds a function to produce a structured signature over a transaction
+
 ## 0.9.0
 ### Changed
 - Address conversion to string now defined for all inputs.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: haskoin-core
-version: 0.9.0
+version: 0.9.1
 synopsis: Bitcoin & Bitcoin Cash library for Haskell
 description: 'Haskoin Core is a complete Bitcoin and Bitcoin Cash library of functions and data types for Haskell developers.'
 category: Bitcoin, Finance, Network

--- a/src/Network/Haskoin/Transaction/Builder.hs
+++ b/src/Network/Haskoin/Transaction/Builder.hs
@@ -46,14 +46,19 @@ import           Control.Arrow                      (first)
 import           Control.Monad                      (foldM, mzero, unless, when)
 import           Control.Monad.Identity             (runIdentity)
 import           Crypto.Secp256k1
-import           Data.Aeson                         (FromJSON, ToJSON, Value (Object), object, parseJSON, toJSON, (.:),
+import           Data.Aeson                         (FromJSON, ToJSON,
+                                                     Value (Object), object,
+                                                     parseJSON, toJSON, (.:),
                                                      (.:?), (.=))
 import qualified Data.ByteString                    as B
-import           Data.Conduit                       (ConduitT, Void, await, runConduit, (.|))
+import           Data.Conduit                       (ConduitT, Void, await,
+                                                     runConduit, (.|))
 import           Data.Conduit.List                  (sourceList)
 import           Data.Hashable
 import           Data.List                          (find, nub)
-import           Data.Maybe                         (catMaybes, fromJust, fromMaybe, isJust, mapMaybe, maybeToList)
+import           Data.Maybe                         (catMaybes, fromJust,
+                                                     fromMaybe, isJust,
+                                                     mapMaybe, maybeToList)
 import           Data.Serialize                     (encode)
 import           Data.String.Conversions            (cs)
 import           Data.Text                          (Text)

--- a/src/Network/Haskoin/Transaction/Builder.hs
+++ b/src/Network/Haskoin/Transaction/Builder.hs
@@ -46,19 +46,14 @@ import           Control.Arrow                      (first)
 import           Control.Monad                      (foldM, mzero, unless, when)
 import           Control.Monad.Identity             (runIdentity)
 import           Crypto.Secp256k1
-import           Data.Aeson                         (FromJSON, ToJSON,
-                                                     Value (Object), object,
-                                                     parseJSON, toJSON, (.:),
+import           Data.Aeson                         (FromJSON, ToJSON, Value (Object), object, parseJSON, toJSON, (.:),
                                                      (.:?), (.=))
 import qualified Data.ByteString                    as B
-import           Data.Conduit                       (ConduitT, Void, await,
-                                                     runConduit, (.|))
+import           Data.Conduit                       (ConduitT, Void, await, runConduit, (.|))
 import           Data.Conduit.List                  (sourceList)
 import           Data.Hashable
 import           Data.List                          (find, nub)
-import           Data.Maybe                         (catMaybes, fromJust,
-                                                     fromMaybe, isJust,
-                                                     mapMaybe, maybeToList)
+import           Data.Maybe                         (catMaybes, fromJust, fromMaybe, isJust, mapMaybe, maybeToList)
 import           Data.Serialize                     (encode)
 import           Data.String.Conversions            (cs)
 import           Data.Text                          (Text)
@@ -276,7 +271,7 @@ data SigInput = SigInput
     , sigInputValue  :: !Word64       -- ^ output script value
     , sigInputOP     :: !OutPoint     -- ^ outpoint to spend
     , sigInputSH     :: !SigHash      -- ^ signature type
-    , sigInputRedeem :: !(Maybe RedeemScript) -- ^ sedeem script
+    , sigInputRedeem :: !(Maybe RedeemScript) -- ^ redeem script
     } deriving (Eq, Show, Read, Generic, Hashable)
 
 instance ToJSON SigInput where


### PR DESCRIPTION
This PR adds a function which computes a `TxSignature` over a transaction in case detached signatures are needed for a transaction construction workflow.  