### PR TITLE
Added bloomRelevantUpdate implementation for bloom filter

### DIFF
--- a/test/Network/Haskoin/NetworkSpec.hs
+++ b/test/Network/Haskoin/NetworkSpec.hs
@@ -11,8 +11,10 @@ import           Network.Haskoin.Keys
 import           Network.Haskoin.Network
 import           Network.Haskoin.Test
 import           Network.Haskoin.Util
+import           Network.Haskoin.Transaction.Common
 import           Test.Hspec
-import           Test.HUnit                (Assertion, assertBool)
+import           Test.HUnit                (Assertion, assertBool,
+                                            assertEqual)
 import           Test.QuickCheck
 
 spec :: Spec
@@ -22,6 +24,9 @@ spec = do
         it "bloom filter vector 1" bloomFilter1
         it "bloom filter vector 2" bloomFilter2
         it "bloom filter vector 3" bloomFilter3
+    describe "relevant bloom filter update" $ do
+        it "Relevant Update" relevantOutputUpdated
+        it "Irrelevant Update" irrelevantOutputNotUpdated
     describe "serialization of protocol types" $ do
         it "encodes and decodes varint" $
             property $ forAll arbitraryVarInt cerealID
@@ -107,3 +112,76 @@ cerealID x = S.decode (S.encode x) == Right x
 
 testPutGet :: Eq a => Get a -> Putter a -> a -> Bool
 testPutGet g p a = runGet g (runPut (p a)) == Right a
+
+relevantOutputUpdated :: Assertion
+relevantOutputUpdated = assertBool "Bloom filter output updated" $
+    any (bloomContains bf2) spendTxInput
+    where
+        bf0 = bloomCreate 10 0.000001 0 BloomUpdateAll
+        relevantOutputHash = fromJust $ decodeHex"03f47604ea2736334151081e13265b4fe38e6fa8"
+        bf1 = bloomInsert bf0 relevantOutputHash
+        bf2 = fromJust $ bloomRelevantUpdate bf1 relevantTx
+        spendTxInput = (encode .prevOutput) <$> txIn spendRelevantTx 
+
+irrelevantOutputNotUpdated :: Assertion
+irrelevantOutputNotUpdated = assertEqual "Bloom filter not updated" Nothing bf2 
+    where
+        bf0 = bloomCreate 10 0.000001 0 BloomUpdateAll
+        relevantOutputHash = fromJust $ decodeHex"03f47604ea2736334151081e13265b4fe38e6fa8"
+        bf1 = bloomInsert bf0 relevantOutputHash
+        bf2 = bloomRelevantUpdate bf1 unrelatedTx
+        spendTxInput = (encode .prevOutput) <$> txIn spendRelevantTx 
+
+-- Random transaction (57dc904f32ad4daab7b321dd469e8791ad09df784cdd273a73985150a4f225e9)
+relevantTx :: Tx
+relevantTx = Tx
+        { txVersion = 1
+        , txIn = [ TxIn
+            { prevOutput = OutPoint "35fe9017b7e3af592920b56fa06ac02faf0c52cdb19dcb416129ac71c95d060e" 1
+            , scriptInput = fromJust $ decodeHex "473044022032fc8eef299b7e94b9a986a6aa2dcb9733ab804bef80df995e443b9c1f8c604202203335df7a2e2b4789451cdb4b2b05a786a81c51519eb6a567fd6fe8cd7b2d33fe014104272502dc63a512dad1473cb82a71be9baf4f4303abd1ff6028fc8a78e1f3aec1218907119dec14f07354850758ff0948e88a904fa411c4df7d5444414ec64ad6"
+            , txInSequence = 4294967295
+            } ]
+        , txOut =
+            [ TxOut { outValue = 100000000, scriptOutput = fromJust $ decodeHex "76a91403f47604ea2736334151081e13265b4fe38e6fa888ac" }
+            , TxOut { outValue = 107980000, scriptOutput = fromJust $ decodeHex "76a91481cc186a2f4a69f633ed4bf10ef4a78be13effdd88ac" }
+            ]
+        , txWitness = []
+        , txLockTime = 0
+        }
+
+-- Transaction that spends above (fd6e3b693b844aa431fad46765c1aa019a6b13aebfa9dae916b3ffa43283a300)
+spendRelevantTx :: Tx
+spendRelevantTx = Tx
+        { txVersion = 1
+        , txIn = [ TxIn
+            { prevOutput = OutPoint "57dc904f32ad4daab7b321dd469e8791ad09df784cdd273a73985150a4f225e9" 0
+            , scriptInput = fromJust $ decodeHex "483045022100ecc334821e4e94cc2fdc841d5ad147d5bb942b993ba81460cc446e0410afa811022015fcbc542b734dbb61a05ec06012095096de5839c50808fe56f2b315e877c20d012103fb64e5792fa586172339b776b7017d3d529358cb73be6406a1fc994228d14f88"
+            , txInSequence = 4294967295
+            }, TxIn
+            { prevOutput = OutPoint "cfee6a8d6e68e8fd16df6fff010afffcd19d7e075aa7b707dd1bae6adc420042" 0
+            , scriptInput = fromJust $ decodeHex "47304402200e6bb95fa606f254d17089d83c4ceeb19c5d1699b4faddcd4f1f1568286e6b650220087fb8439f31e1b30e47710d095422405f601d6151f2f93e125e1a08a6e29ad4012103b49252e8fc6d5b49c8d14ee71fab45591df4a126a6c453c724f3d356e38f0cee"
+            , txInSequence = 4294967295
+            } ]
+        , txOut =
+            [ TxOut { outValue = 3851100, scriptOutput = fromJust $ decodeHex "76a914a297cae82a9a3b932bf023ae274fe2585295c9ca88ac" }
+            , TxOut { outValue = 111000000, scriptOutput = fromJust $ decodeHex "76a9148f952c38600a61385974acc30a64f74407f9801488ac" }
+            ]
+        , txWitness = []
+        , txLockTime = 0
+        }
+
+-- This random transaction is unrelated to the others
+unrelatedTx :: Tx
+unrelatedTx = Tx
+        { txVersion = 1
+        , txIn = [ TxIn
+            { prevOutput = OutPoint "3ec3a71431c68e5d978a5fb4a0a1081d8bee8384d8aa4c06b1fbaf9413e2214f" 20
+            , scriptInput = fromJust $ decodeHex "483045022100ec9c202c9d3140b973aca9d7f21a82138aa4cfa43fddc5419098ac5e26a6f152022010848fd688f290ae010fb5cb493410caa03145fc12445900ec1ad2bde33aecd9012102c7445e72d723f99a0064526c28269d07f47c8fd81531a94a8d3bf5ebd5e23ef1"
+            , txInSequence = 4294967295
+            }]
+        , txOut =
+            [ TxOut { outValue = 12600000, scriptOutput = fromJust $ decodeHex "76a9148fef3b7051de8cc44e966159e7ea37f4520187e888ac" }
+            ]
+        , txWitness = []
+        , txLockTime = 0
+        }


### PR DESCRIPTION
This adds functionality to update a bloom filter based on the outputs from a tx. If the scriptPubKey of any output is relevant (i.e., any of its data elements are contained in the bloom filter) then an outpoint (comprising the txid and vout) is inserted into the bloom filter. This avoids round-tripping as a result of missing relevant txs (e.g. a tx that spends a previous output).

Tests are based on the `bloom_test.cpp` from Bitcoin-core but with different transactions as the sigs used in those are high-S which cause `decodeStrictSig` to fail.