### PR TITLE
lowercase input before bech32 encoding

### DIFF
--- a/src/Network/Haskoin/Address/Bech32.hs
+++ b/src/Network/Haskoin/Address/Bech32.hs
@@ -131,7 +131,7 @@ maxBech32Length = 90
 bech32Encode :: HRP -> [Word5] -> Maybe Bech32
 bech32Encode hrp dat = do
     guard $ checkHRP hrp
-    let dat' = dat ++ bech32CreateChecksum hrp dat
+    let dat' = dat ++ bech32CreateChecksum (T.toLower hrp) dat
         rest = map (charset !) dat'
         result = T.concat [T.toLower hrp, T.pack "1", T.pack rest]
     guard $ T.length result <= maxBech32Length

--- a/test/Network/Haskoin/Address/Bech32Spec.hs
+++ b/test/Network/Haskoin/Address/Bech32Spec.hs
@@ -28,6 +28,8 @@ spec = do
         it "should be a valid address" $ forM_ validAddresses testValidAddress
         it "should be an invalid address" $
             forM_ invalidAddresses testInvalidAddress
+        it "should be same for the input data in different case" $
+            all (== Just "test12hrzfj") (map bech32EncodeDefault hrpCaseVariants)
     describe "more encoding/decoding cases" $ do
         it "length > 90" $
             assert $
@@ -48,6 +50,8 @@ spec = do
             Just "hrp1g9xj8m" `shouldBe`
             bech32Encode "HRP" []
 
+bech32EncodeDefault :: HRP -> Maybe Bech32 
+bech32EncodeDefault x = bech32Encode x []
 
 testValidChecksum :: Bech32 -> Assertion
 testValidChecksum checksum = case bech32Decode checksum of
@@ -140,4 +144,18 @@ invalidAddresses =
     , "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du"
     , "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv"
     , "bc1gmk9yu"
+    ]
+
+hrpCaseVariants :: [Text]
+hrpCaseVariants = 
+    [ "TEST"
+    , "TESt"
+    , "TEsT"
+    , "TeST"
+    , "tEST"
+    , "TEst"
+    , "tESt"
+    , "teST"
+    , "TeSt"
+    , "tESt"
     ]

--- a/test/Network/Haskoin/Address/Bech32Spec.hs
+++ b/test/Network/Haskoin/Address/Bech32Spec.hs
@@ -29,7 +29,7 @@ spec = do
         it "should be an invalid address" $
             forM_ invalidAddresses testInvalidAddress
         it "should be same for the input in different case" $
-            all (== Just "test12hrzfj") (map (flip bech32Encode []) hrpCaseVariants)
+            (all (== Just "test12hrzfj") . map (flip bech32Encode [])) hrpCaseVariants
     describe "more encoding/decoding cases" $ do
         it "length > 90" $
             assert $

--- a/test/Network/Haskoin/Address/Bech32Spec.hs
+++ b/test/Network/Haskoin/Address/Bech32Spec.hs
@@ -144,16 +144,13 @@ invalidAddresses =
     , "bc1gmk9yu"
     ]
 
-hrpCaseVariants :: [Text]
-hrpCaseVariants = 
-    [ "TEST"
-    , "TESt"
-    , "TEsT"
-    , "TeST"
-    , "tEST"
-    , "TEst"
-    , "tESt"
-    , "teST"
-    , "TeSt"
-    , "tESt"
-    ]
+hrpCaseVariants:: [Text]
+hrpCaseVariants = map T.pack hrpTestPermutations
+
+hrpTestPermutations :: [String]
+hrpTestPermutations = do
+    a <- ['t', 'T']
+    b <- ['e', 'E']
+    c <- ['s', 'S']
+    d <- ['t', 'T']
+    return [a, b, c, d]

--- a/test/Network/Haskoin/Address/Bech32Spec.hs
+++ b/test/Network/Haskoin/Address/Bech32Spec.hs
@@ -28,8 +28,8 @@ spec = do
         it "should be a valid address" $ forM_ validAddresses testValidAddress
         it "should be an invalid address" $
             forM_ invalidAddresses testInvalidAddress
-        it "should be same for the input data in different case" $
-            all (== Just "test12hrzfj") (map bech32EncodeDefault hrpCaseVariants)
+        it "should be same for the input in different case" $
+            all (== Just "test12hrzfj") (map (flip bech32Encode []) hrpCaseVariants)
     describe "more encoding/decoding cases" $ do
         it "length > 90" $
             assert $
@@ -49,9 +49,6 @@ spec = do
         it "hrp lowercased" $
             Just "hrp1g9xj8m" `shouldBe`
             bech32Encode "HRP" []
-
-bech32EncodeDefault :: HRP -> Maybe Bech32 
-bech32EncodeDefault x = bech32Encode x []
 
 testValidChecksum :: Bech32 -> Assertion
 testValidChecksum checksum = case bech32Decode checksum of

--- a/test/Network/Haskoin/Address/Bech32Spec.hs
+++ b/test/Network/Haskoin/Address/Bech32Spec.hs
@@ -29,7 +29,7 @@ spec = do
         it "should be an invalid address" $
             forM_ invalidAddresses testInvalidAddress
         it "should be same for the input in different case" $
-            (all (== Just "test12hrzfj") . map (flip bech32Encode [])) hrpCaseVariants
+            all (== Just "test12hrzfj") . map (flip bech32Encode []) $ hrpCaseVariants
     describe "more encoding/decoding cases" $ do
         it "length > 90" $
             assert $

--- a/test/Network/Haskoin/Address/Bech32Spec.hs
+++ b/test/Network/Haskoin/Address/Bech32Spec.hs
@@ -50,6 +50,7 @@ spec = do
             Just "hrp1g9xj8m" `shouldBe`
             bech32Encode "HRP" []
 
+
 testValidChecksum :: Bech32 -> Assertion
 testValidChecksum checksum = case bech32Decode checksum of
     Nothing                      -> assertFailure (show checksum)


### PR DESCRIPTION
fixes https://github.com/haskoin/haskoin-core/issues/375

Quick shortcut for testing:

    $ stack test --test-arguments "--match=bech32"