### PR TITLE
Adds support for base16-bytestring >=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.17.1
+## Changed
+- Use the C-preprocessor to handle versions of `base16-bytestring` including 1.0
+  (with a breaking API change)
+
 ## 0.17.0
 ### Added
 - Support for Bitcoin Cash November 2020 hard fork.

--- a/haskoin-core.cabal
+++ b/haskoin-core.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 181e7ec454b3259ee0885c9cc758b5f23e592c6d353720e57cdc74186bc03e96
+-- hash: bbfc660e68e7e88b4c9b54474050fe894d3b43aac965df758b81ce1c68fbe72c
 
 name:           haskoin-core
-version:        0.17.0
+version:        0.17.1
 synopsis:       Bitcoin & Bitcoin Cash library for Haskell
 description:    Please see the README on GitHub at <https://github.com/haskoin/haskoin-core#readme>
 category:       Bitcoin, Finance, Network
@@ -156,7 +156,7 @@ test-suite spec
     , deepseq >=1.4.4.0
     , entropy >=0.4.1.5
     , hashable >=1.3.0.0
-    , haskoin-core ==0.17.0
+    , haskoin-core ==0.17.1
     , hspec >=2.7.1
     , lens >=4.18.1
     , lens-aeson >=1.1

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: haskoin-core
-version: &version 0.17.0
+version: &version 0.17.1
 synopsis: Bitcoin & Bitcoin Cash library for Haskell
 description: Please see the README on GitHub at <https://github.com/haskoin/haskoin-core#readme>
 category: Bitcoin, Finance, Network

--- a/src/Haskoin/Util.hs
+++ b/src/Haskoin/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-|
 Module      : Haskoin.Util
@@ -84,9 +85,13 @@ encodeHex = E.decodeUtf8 . BL.toStrict . toLazyByteString . byteStringHex
 
 -- | Decode string of human-readable hex characters.
 decodeHex :: Text -> Maybe ByteString
+# if MIN_VERSION_base16_bytestring(1,0,0)
+decodeHex = eitherToMaybe . B16.decode . E.encodeUtf8
+# else
 decodeHex text =
     let (x, b) = B16.decode (E.encodeUtf8 text)
     in guard (b == BS.empty) >> return x
+# endif
 
 -- | Obtain 'Int' bits from beginning of 'ByteString'. Resulting 'ByteString'
 -- will be smallest required to hold that many bits, padded with zeroes to the


### PR DESCRIPTION
`base16-bytestring` recently changed the signature of the decoding function for version 1.0.  This change makes `haskoin-core` compatible with versions up to and including 1.0.