### PR TITLE
Change representation for fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.21.0
+### Fixed
+- Make fingerprint serialization agree everywhere
+
 ## 0.20.5
 ### Added
 - Support Bech32m address format for Taproot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## 0.21.0
-### Fixed
-- Make fingerprint serialization agree everywhere
+### Changed
+- Use a newtype for Fingerprint, which uses an 8 digit hex string for IsString,
+  Read, & Show.  This fixes inconsistent (de)serialization across the package.
 
 ## 0.20.5
 ### Added

--- a/haskoin-core.cabal
+++ b/haskoin-core.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.5.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 83e95434961483bbb306908fbc61269ebec705003a8994ca0a8a04d1e3f7de50
+-- hash: 4b340a6dfe197ae20194205ecebc4358218dfb13d1451ff7606ed6290a4ba10e
 
 name:           haskoin-core
 version:        0.20.5
@@ -86,7 +86,7 @@ library
       Haskoin.Util.Arbitrary.Transaction
       Haskoin.Util.Arbitrary.Util
   other-modules:
-      Paths_haskoin_core
+      Haskoin.Keys.Extended.Internal
   hs-source-dirs:
       src
   build-depends:

--- a/package.yaml
+++ b/package.yaml
@@ -50,6 +50,11 @@ dependencies:
   - vector >= 0.12.1.2
 library:
   source-dirs: src
+  other-modules:
+    Haskoin.Keys.Extended.Internal
+  when:
+    - condition: false
+      other-modules: Paths_haskoin_core
 tests:
   spec:
     main: Spec.hs

--- a/src/Haskoin/Keys/Extended/Internal.hs
+++ b/src/Haskoin/Keys/Extended/Internal.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications           #-}
+
+module Haskoin.Keys.Extended.Internal (
+    Fingerprint (..)
+) where
+
+import           Control.DeepSeq   (NFData)
+import           Data.Binary       (Binary (..))
+import           Data.Bytes.Get    (getWord32be)
+import           Data.Bytes.Put    (putWord32be)
+import           Data.Bytes.Serial (Serial (..))
+import           Data.Either       (fromRight)
+import           Data.Hashable     (Hashable)
+import           Data.Maybe        (fromMaybe)
+import           Data.Serialize    (Serialize (..))
+import qualified Data.Serialize    as S
+import           Data.String       (IsString (..))
+import qualified Data.Text         as Text
+import           Data.Typeable     (Typeable)
+import           Data.Word         (Word32)
+import           GHC.Generics      (Generic)
+import           Haskoin.Util      (decodeHex, encodeHex)
+import           Text.Read         (readPrec)
+
+-- | Fingerprint of parent
+newtype Fingerprint = Fingerprint { unFingerprint :: Word32 }
+    deriving (Eq, Ord, Hashable, Typeable, Generic, NFData)
+
+instance Show Fingerprint where
+    show = show . Text.unpack . encodeHex . S.encode
+
+instance Read Fingerprint where
+    readPrec =
+        readPrec
+            >>= maybe (fail "Fingerprint: invalid hex") pure . decodeHex
+            >>= either (fail . ("Fingerprint: " <>)) pure . S.decode
+
+instance IsString Fingerprint where
+    fromString = fromRight decodeError
+        . S.decode
+        . fromMaybe hexError
+        . decodeHex
+        . Text.pack
+     where
+       decodeError  = error "Fingerprint literal: Unable to decode"
+       hexError = error "Fingerprint literal: Invalid hex"
+
+instance Serial Fingerprint where
+    serialize = putWord32be . unFingerprint
+    deserialize = Fingerprint <$> getWord32be
+
+instance Binary Fingerprint where
+    put = serialize
+    get = deserialize
+
+instance Serialize Fingerprint where
+    put = serialize
+    get = deserialize

--- a/src/Haskoin/Transaction/Partial.hs
+++ b/src/Haskoin/Transaction/Partial.hs
@@ -679,7 +679,7 @@ instance Serialize PSBTHDPath where
         PSBTHDPath <$>
             S.isolate
                 (fromIntegral valueSize)
-                ((,) <$> S.getWord32be <*> getKeyIndexList numIndices)
+                ((,) <$> S.get <*> getKeyIndexList numIndices)
       where
         getKeyIndexList n = replicateM n S.getWord32le
 
@@ -687,7 +687,7 @@ instance Serialize PSBTHDPath where
         putVarInt (B.length bs)
         S.putByteString bs
       where
-        bs = S.runPut $ S.putWord32be fp >> mapM_ S.putWord32le kis
+        bs = S.runPut $ S.put fp >> mapM_ S.putWord32le kis
 
 putPubKeyMap :: Enum t => (a -> Put) -> t -> HashMap PubKeyI a -> Put
 putPubKeyMap f t =

--- a/src/Haskoin/Transaction/Partial.hs
+++ b/src/Haskoin/Transaction/Partial.hs
@@ -679,7 +679,7 @@ instance Serialize PSBTHDPath where
         PSBTHDPath <$>
             S.isolate
                 (fromIntegral valueSize)
-                ((,) <$> S.getWord32le <*> getKeyIndexList numIndices)
+                ((,) <$> S.getWord32be <*> getKeyIndexList numIndices)
       where
         getKeyIndexList n = replicateM n S.getWord32le
 
@@ -687,7 +687,7 @@ instance Serialize PSBTHDPath where
         putVarInt (B.length bs)
         S.putByteString bs
       where
-        bs = S.runPut $ S.putWord32le fp >> mapM_ S.putWord32le kis
+        bs = S.runPut $ S.putWord32be fp >> mapM_ S.putWord32le kis
 
 putPubKeyMap :: Enum t => (a -> Put) -> t -> HashMap PubKeyI a -> Put
 putPubKeyMap f t =

--- a/src/Haskoin/Util/Arbitrary/Keys.hs
+++ b/src/Haskoin/Util/Arbitrary/Keys.hs
@@ -8,12 +8,14 @@ Portability : POSIX
 -}
 module Haskoin.Util.Arbitrary.Keys where
 
-import           Data.Bits             (clearBit)
-import           Data.List             (foldl')
-import           Data.Word             (Word32)
+import           Data.Bits                      (clearBit)
+import           Data.Coerce                    (coerce)
+import           Data.List                      (foldl')
+import           Data.Word                      (Word32)
 import           Haskoin.Crypto
 import           Haskoin.Keys.Common
 import           Haskoin.Keys.Extended
+import           Haskoin.Keys.Extended.Internal (Fingerprint (..))
 import           Haskoin.Util.Arbitrary.Crypto
 import           Test.QuickCheck
 
@@ -27,11 +29,14 @@ arbitraryKeyPair = do
     k <- arbitrarySecKeyI
     return (k, derivePubKeyI k)
 
+arbitraryFingerprint :: Gen Fingerprint
+arbitraryFingerprint = Fingerprint <$> arbitrary
+
 -- | Arbitrary extended private key.
 arbitraryXPrvKey :: Gen XPrvKey
 arbitraryXPrvKey =
     XPrvKey <$> arbitrary
-            <*> arbitrary
+            <*> arbitraryFingerprint
             <*> arbitrary
             <*> arbitraryHash256
             <*> arbitrary

--- a/test/Haskoin/Transaction/PartialSpec.hs
+++ b/test/Haskoin/Transaction/PartialSpec.hs
@@ -106,10 +106,8 @@ vec4Test = do
 vec5Test :: Assertion
 vec5Test = do
     psbt <- decodeHexPSBTM "Cannot parse validVec5" validVec5Hex
-    assertEqual "1 input" 1 (length $ inputs psbt)
-    assertEqual "1 output" 1 (length $ outputs psbt)
+    assertEqual "Correctly decode PSBT" expectedPsbt psbt
     let input = head $ inputs psbt
-    assertEqual "input not final script sig" Nothing (finalScriptSig input)
 
     let rdmScript = fromJust $ inputRedeemScript input
     assertBool "p2wsh" $ (isPayWitnessScriptHash <$> decodeOutput rdmScript) == Right True
@@ -121,6 +119,74 @@ vec5Test = do
   where
     expectedOut2 = fromRight (error "could not decode expected output")
                 . decodeOutputBS . fromJust $ decodeHex "a9146345200f68d189e1adc0df1c4d16ea8f14c0dbeb87"
+    -- From the bitcoind decodepsbt rpc call
+    expectedPsbt = PartiallySignedTransaction
+        { unsignedTransaction = Tx { txVersion = 2
+                                   , txIn = [ TxIn { prevOutput =
+                                                         OutPoint { outPointHash = "39bc5c3b33d66ce3d7852a7942331e3ec10f8ba50f225fc41fb5dfa523239a27"
+                                                                  , outPointIndex = 0
+                                                                  }
+                                                   , scriptInput = ""
+                                                   , txInSequence = 4294967295
+                                                   }
+                                            ]
+                                   , txOut = [ TxOut { outValue = 199908000
+                                                     , scriptOutput = (fromJust . decodeHex) "76a914ffe9c0061097cc3b636f2cb0460fa4fc427d2b4588ac"
+                                                     }
+                                             ]
+                                   , txWitness = mempty
+                                   , txLockTime = 0
+                                   }
+        , globalUnknown = mempty
+        , inputs = [ Input { nonWitnessUtxo = Nothing
+                           , witnessUtxo = Just (TxOut { outValue = 199909013
+                                                       , scriptOutput = (fromJust . decodeHex) "a9146345200f68d189e1adc0df1c4d16ea8f14c0dbeb87"
+                                                       }
+                                                )
+                           , partialSigs = fromList [(PubKeyI { pubKeyPoint = "03b1341ccba7683b6af4f1238cd6e97e7167d569fac47f1e48d47541844355bd46"
+                                                              , pubKeyCompressed = True
+                                                              }
+                                                     , (fromJust . decodeHex) "304302200424b58effaaa694e1559ea5c93bbfd4a89064224055cdf070b6771469442d07021f5c8eb0fea6516d60b8acb33ad64ede60e8785bfb3aa94b99bdf86151db9a9a01"
+                                                     )
+                                                    ]
+                           , sigHashType = Nothing
+                           , inputRedeemScript =
+                                 Just
+                                    . fromRight (error "vec5Test: Could not decode redeem script")
+                                    . decode
+                                    . fromJust
+                                    $ decodeHex "0020771fd18ad459666dd49f3d564e3dbc42f4c84774e360ada16816a8ed488d5681"
+                           , inputWitnessScript =
+                                 Just
+                                    . fromRight (error "vec5Test: Could not decode witness script")
+                                    . decode
+                                    . fromJust
+                                    $ decodeHex "522103b1341ccba7683b6af4f1238cd6e97e7167d569fac47f1e48d47541844355bd462103de55d1e1dac805e3f8a58c1fbf9b94c02f3dbaafe127fefca4995f26f82083bd52ae"
+                           , inputHDKeypaths = fromList [ ( PubKeyI { pubKeyPoint = "03b1341ccba7683b6af4f1238cd6e97e7167d569fac47f1e48d47541844355bd46"
+                                                                    , pubKeyCompressed = True
+                                                                    }
+                                                          , (3030825575,[hardIndex 0,hardIndex 0,hardIndex 4])
+                                                          )
+                                                        , ( PubKeyI { pubKeyPoint = "03de55d1e1dac805e3f8a58c1fbf9b94c02f3dbaafe127fefca4995f26f82083bd"
+                                                                    , pubKeyCompressed = True
+                                                                    }
+                                                          , (3030825575,[hardIndex 0, hardIndex 0, hardIndex 5])
+                                                          )
+                                                        ]
+                           , finalScriptSig = Nothing
+                           , finalScriptWitness = Nothing
+                           , inputUnknown = mempty
+                           }
+                   ]
+        , outputs = [ Output { outputRedeemScript = Nothing
+                             , outputWitnessScript = Nothing
+                             , outputHDKeypaths = mempty
+                             , outputUnknown = mempty
+                             }
+                    ]
+        }
+    hardIndex = (+ 2^31)
+
 
 vec6Test :: Assertion
 vec6Test = do
@@ -136,6 +202,7 @@ vec6Test = do
     expectedUnknowns = UnknownMap $ singleton
         (Key 0x0f (fromJust $ decodeHex "010203040506070809"))
         (fromJust $ decodeHex "0102030405060708090a0b0c0d0e0f")
+
 
 expectedOut :: ScriptOutput
 expectedOut = fromRight (error "could not decode expected output")

--- a/test/Haskoin/Transaction/PartialSpec.hs
+++ b/test/Haskoin/Transaction/PartialSpec.hs
@@ -106,6 +106,7 @@ vec4Test = do
 vec5Test :: Assertion
 vec5Test = do
     psbt <- decodeHexPSBTM "Cannot parse validVec5" validVec5Hex
+    print psbt
     assertEqual "Correctly decode PSBT" expectedPsbt psbt
     let input = head $ inputs psbt
 
@@ -165,12 +166,12 @@ vec5Test = do
                            , inputHDKeypaths = fromList [ ( PubKeyI { pubKeyPoint = "03b1341ccba7683b6af4f1238cd6e97e7167d569fac47f1e48d47541844355bd46"
                                                                     , pubKeyCompressed = True
                                                                     }
-                                                          , (3030825575,[hardIndex 0,hardIndex 0,hardIndex 4])
+                                                          , ("b4a6ba67",[hardIndex 0,hardIndex 0,hardIndex 4])
                                                           )
                                                         , ( PubKeyI { pubKeyPoint = "03de55d1e1dac805e3f8a58c1fbf9b94c02f3dbaafe127fefca4995f26f82083bd"
                                                                     , pubKeyCompressed = True
                                                                     }
-                                                          , (3030825575,[hardIndex 0, hardIndex 0, hardIndex 5])
+                                                          , ("b4a6ba67",[hardIndex 0, hardIndex 0, hardIndex 5])
                                                           )
                                                         ]
                            , finalScriptSig = Nothing
@@ -187,7 +188,6 @@ vec5Test = do
         }
     hardIndex = (+ 2^31)
 
-
 vec6Test :: Assertion
 vec6Test = do
     psbt <- decodeHexPSBTM "Cannot parse validVec6" validVec6Hex
@@ -202,7 +202,6 @@ vec6Test = do
     expectedUnknowns = UnknownMap $ singleton
         (Key 0x0f (fromJust $ decodeHex "010203040506070809"))
         (fromJust $ decodeHex "0102030405060708090a0b0c0d0e0f")
-
 
 expectedOut :: ScriptOutput
 expectedOut = fromRight (error "could not decode expected output")


### PR DESCRIPTION
This changes how we represent fingerprints to `newtype Fingerprint = Fingerprint { unFingerprint :: Word32 }`.  This has a few benefits.  First, `Fingerprint` has `Serialize` etc. instances and downstream structures use these instances, so there is no risk of the encoding drifting from one place to another.  (The binary encodings for fingerprints in the extended keys section disagreed with that from the psbt section.)   Second, I added IsString/Read/Show instances that treat `Fingerprint` as having an 8-digit hex string representation instead of a decimal number.