### PR TITLE
Adds taproot support (no signing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Signing support for PSBTs
 - Helper function for merging PSBTs
 - More PSBT tests
+- Partial support for taproot
 
 ## 0.20.5
 ### Added

--- a/data/bip341.json
+++ b/data/bip341.json
@@ -1,0 +1,452 @@
+{
+    "version": 1,
+    "scriptPubKey": [
+        {
+            "given": {
+                "internalPubkey": "d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d",
+                "scriptTree": null
+            },
+            "intermediary": {
+                "merkleRoot": null,
+                "tweak": "b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70",
+                "tweakedPubkey": "53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343"
+            },
+            "expected": {
+                "scriptPubKey": "512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343",
+                "bip350Address": "bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5"
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27",
+                "scriptTree": {
+                    "id": 0,
+                    "script": "20d85a959b0290bf19bb89ed43c916be835475d013da4b362117393e25a48229b8ac",
+                    "leafVersion": 192
+                }
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21"
+                ],
+                "merkleRoot": "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+                "tweak": "cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001",
+                "tweakedPubkey": "147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3"
+            },
+            "expected": {
+                "scriptPubKey": "5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3",
+                "bip350Address": "bc1pz37fc4cn9ah8anwm4xqqhvxygjf9rjf2resrw8h8w4tmvcs0863sa2e586",
+                "scriptPathControlBlocks": [
+                    "c1187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820",
+                "scriptTree": {
+                    "id": 0,
+                    "script": "20b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007ac",
+                    "leafVersion": 192
+                }
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b"
+                ],
+                "merkleRoot": "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+                "tweak": "6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30",
+                "tweakedPubkey": "e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e"
+            },
+            "expected": {
+                "scriptPubKey": "5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e",
+                "bip350Address": "bc1punvppl2stp38f7kwv2u2spltjuvuaayuqsthe34hd2dyy5w4g58qqfuag5",
+                "scriptPathControlBlocks": [
+                    "c093478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "20387671353e273264c495656e27e39ba899ea8fee3bb69fb2a680e22093447d48ac",
+                        "leafVersion": 192
+                    },
+                    {
+                        "id": 1,
+                        "script": "06424950333431",
+                        "leafVersion": 250
+                    }
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7",
+                    "f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a"
+                ],
+                "merkleRoot": "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+                "tweak": "9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9",
+                "tweakedPubkey": "712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5"
+            },
+            "expected": {
+                "scriptPubKey": "5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5",
+                "bip350Address": "bc1pwyjywgrd0ffr3tx8laflh6228dj98xkjj8rum0zfpd6h0e930h6saqxrrm",
+                "scriptPathControlBlocks": [
+                    "c0ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a",
+                    "faee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf37865928ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "2044b178d64c32c4a05cc4f4d1407268f764c940d20ce97abfd44db5c3592b72fdac",
+                        "leafVersion": 192
+                    },
+                    {
+                        "id": 1,
+                        "script": "07546170726f6f74",
+                        "leafVersion": 192
+                    }
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "64512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89",
+                    "2cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb"
+                ],
+                "merkleRoot": "ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc",
+                "tweak": "639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e",
+                "tweakedPubkey": "77e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220"
+            },
+            "expected": {
+                "scriptPubKey": "512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220",
+                "bip350Address": "bc1pwl3s54fzmk0cjnpl3w9af39je7pv5ldg504x5guk2hpecpg2kgsqaqstjq",
+                "scriptPathControlBlocks": [
+                    "c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd82cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb",
+                    "c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd864512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "2072ea6adcf1d371dea8fba1035a09f3d24ed5a059799bae114084130ee5898e69ac",
+                        "leafVersion": 192
+                    },
+                    [
+                        {
+                            "id": 1,
+                            "script": "202352d137f2f3ab38d1eaa976758873377fa5ebb817372c71e2c542313d4abda8ac",
+                            "leafVersion": 192
+                        },
+                        {
+                            "id": 2,
+                            "script": "207337c0dd4253cb86f2c43a2351aadd82cccb12a172cd120452b9bb8324f2186aac",
+                            "leafVersion": 192
+                        }
+                    ]
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+                    "ba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c",
+                    "9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf6"
+                ],
+                "merkleRoot": "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+                "tweak": "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+                "tweakedPubkey": "91b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605"
+            },
+            "expected": {
+                "scriptPubKey": "512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+                "bip350Address": "bc1pjxmy65eywgafs5tsunw95ruycpqcqnev6ynxp7jaasylcgtcxczs6n332e",
+                "scriptPathControlBlocks": [
+                    "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fffe578e9ea769027e4f5a3de40732f75a88a6353a09d767ddeb66accef85e553",
+                    "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf62645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+                    "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "2071981521ad9fc9036687364118fb6ccd2035b96a423c59c5430e98310a11abe2ac",
+                        "leafVersion": 192
+                    },
+                    [
+                        {
+                            "id": 1,
+                            "script": "20d5094d2dbe9b76e2c245a2b89b6006888952e2faa6a149ae318d69e520617748ac",
+                            "leafVersion": 192
+                        },
+                        {
+                            "id": 2,
+                            "script": "20c440b462ad48c7a77f94cd4532d8f2119dcebbd7c9764557e62726419b08ad4cac",
+                            "leafVersion": 192
+                        }
+                    ]
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
+                    "737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711",
+                    "d7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7"
+                ],
+                "merkleRoot": "2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def",
+                "tweak": "6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9",
+                "tweakedPubkey": "75169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831"
+            },
+            "expected": {
+                "scriptPubKey": "512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831",
+                "bip350Address": "bc1pw5tf7sqp4f50zka7629jrr036znzew70zxyvvej3zrpf8jg8hqcssyuewe",
+                "scriptPathControlBlocks": [
+                    "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d3cd369a528b326bc9d2133cbd2ac21451acb31681a410434672c8e34fe757e91",
+                    "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312dd7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
+                    "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d"
+                ]
+            }
+        }
+    ],
+    "keyPathSpending": [
+        {
+            "given": {
+                "rawUnsignedTx": "02000000097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a418420000000000fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0065cd1d",
+                "utxosSpent": [
+                    {
+                        "scriptPubKey": "512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343",
+                        "amountSats": 420000000
+                    },
+                    {
+                        "scriptPubKey": "5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3",
+                        "amountSats": 462000000
+                    },
+                    {
+                        "scriptPubKey": "76a914751e76e8199196d454941c45d1b3a323f1433bd688ac",
+                        "amountSats": 294000000
+                    },
+                    {
+                        "scriptPubKey": "5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e",
+                        "amountSats": 504000000
+                    },
+                    {
+                        "scriptPubKey": "512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+                        "amountSats": 630000000
+                    },
+                    {
+                        "scriptPubKey": "00147dd65592d0ab2fe0d0257d571abf032cd9db93dc",
+                        "amountSats": 378000000
+                    },
+                    {
+                        "scriptPubKey": "512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831",
+                        "amountSats": 672000000
+                    },
+                    {
+                        "scriptPubKey": "5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5",
+                        "amountSats": 546000000
+                    },
+                    {
+                        "scriptPubKey": "512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220",
+                        "amountSats": 588000000
+                    }
+                ]
+            },
+            "intermediary": {
+                "hashAmounts": "58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde6",
+                "hashOutputs": "a2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc5",
+                "hashPrevouts": "e3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f",
+                "hashScriptPubkeys": "23ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e21",
+                "hashSequences": "18959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e"
+            },
+            "inputSpending": [
+                {
+                    "given": {
+                        "txinIndex": 0,
+                        "internalPrivkey": "6b973d88838f27366ed61c9ad6367663045cb456e28335c109e30717ae0c6baa",
+                        "merkleRoot": null,
+                        "hashType": 3
+                    },
+                    "intermediary": {
+                        "internalPubkey": "d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d",
+                        "tweak": "b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70",
+                        "tweakedPrivkey": "2405b971772ad26915c8dcdf10f238753a9b837e5f8e6a86fd7c0cce5b7296d9",
+                        "sigMsg": "0003020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0000000000d0418f0e9a36245b9a50ec87f8bf5be5bcae434337b87139c3a5b1f56e33cba0",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "2514a6272f85cfa0f45eb907fcb0d121b808ed37c6ea160a5a9046ed5526d555"
+                    },
+                    "expected": {
+                        "witness": [
+                            "ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c03"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 1,
+                        "internalPrivkey": "1e4da49f6aaf4e5cd175fe08a32bb5cb4863d963921255f33d3bc31e1343907f",
+                        "merkleRoot": "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+                        "hashType": 131
+                    },
+                    "intermediary": {
+                        "internalPubkey": "187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27",
+                        "tweak": "cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001",
+                        "tweakedPrivkey": "ea260c3b10e60f6de018455cd0278f2f5b7e454be1999572789e6a9565d26080",
+                        "sigMsg": "0083020000000065cd1d00d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd9900000000808f891b00000000225120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3ffffffffffcef8fb4ca7efc5433f591ecfc57391811ce1e186a3793024def5c884cba51d",
+                        "precomputedUsed": [],
+                        "sigHash": "325a644af47e8a5a2591cda0ab0723978537318f10e6a63d4eed783b96a71a4d"
+                    },
+                    "expected": {
+                        "witness": [
+                            "052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 3,
+                        "internalPrivkey": "d3c7af07da2d54f7a7735d3d0fc4f0a73164db638b2f2f7c43f711f6d4aa7e64",
+                        "merkleRoot": "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+                        "hashType": 1
+                    },
+                    "intermediary": {
+                        "internalPubkey": "93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820",
+                        "tweak": "6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30",
+                        "tweakedPrivkey": "97323385e57015b75b0339a549c56a948eb961555973f0951f555ae6039ef00d",
+                        "sigMsg": "0001020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50003000000",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashOutputs",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "bf013ea93474aa67815b1b6cc441d23b64fa310911d991e713cd34c7f5d46669"
+                    },
+                    "expected": {
+                        "witness": [
+                            "ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a01"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 4,
+                        "internalPrivkey": "f36bb07a11e469ce941d16b63b11b9b9120a84d9d87cff2c84a8d4affb438f4e",
+                        "merkleRoot": "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+                        "hashType": 0
+                    },
+                    "intermediary": {
+                        "internalPubkey": "e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f",
+                        "tweak": "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+                        "tweakedPrivkey": "a8e7aa924f0d58854185a490e6c41f6efb7b675c0f3331b7f14b549400b4d501",
+                        "sigMsg": "0000020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50004000000",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashOutputs",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "4f900a0bae3f1446fd48490c2958b5a023228f01661cda3496a11da502a7f7ef"
+                    },
+                    "expected": {
+                        "witness": [
+                            "b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 6,
+                        "internalPrivkey": "415cfe9c15d9cea27d8104d5517c06e9de48e2f986b695e4f5ffebf230e725d8",
+                        "merkleRoot": "2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def",
+                        "hashType": 2
+                    },
+                    "intermediary": {
+                        "internalPubkey": "55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d",
+                        "tweak": "6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9",
+                        "tweakedPrivkey": "241c14f2639d0d7139282aa6abde28dd8a067baa9d633e4e7230287ec2d02901",
+                        "sigMsg": "0002020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0006000000",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "15f25c298eb5cdc7eb1d638dd2d45c97c4c59dcaec6679cfc16ad84f30876b85"
+                    },
+                    "expected": {
+                        "witness": [
+                            "a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee002"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 7,
+                        "internalPrivkey": "c7b0e81f0a9a0b0499e112279d718cca98e79a12e2f137c72ae5b213aad0d103",
+                        "merkleRoot": "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+                        "hashType": 130
+                    },
+                    "intermediary": {
+                        "internalPubkey": "ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592",
+                        "tweak": "9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9",
+                        "tweakedPrivkey": "65b6000cd2bfa6b7cf736767a8955760e62b6649058cbc970b7c0871d786346b",
+                        "sigMsg": "0082020000000065cd1d00e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf00000000804c8b2000000000225120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5ffffffff",
+                        "precomputedUsed": [],
+                        "sigHash": "cd292de50313804dabe4685e83f923d2969577191a3e1d2882220dca88cbeb10"
+                    },
+                    "expected": {
+                        "witness": [
+                            "ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c482"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 8,
+                        "internalPrivkey": "77863416be0d0665e517e1c375fd6f75839544eca553675ef7fdf4949518ebaa",
+                        "merkleRoot": "ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc",
+                        "hashType": 129
+                    },
+                    "intermediary": {
+                        "internalPubkey": "f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8",
+                        "tweak": "639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e",
+                        "tweakedPrivkey": "ec18ce6af99f43815db543f47b8af5ff5df3b2cb7315c955aa4a86e8143d2bf5",
+                        "sigMsg": "0081020000000065cd1da2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc500a778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af101000000002b0c230000000022512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220ffffffff",
+                        "precomputedUsed": [
+                            "hashOutputs"
+                        ],
+                        "sigHash": "cccb739eca6c13a8a89e6e5cd317ffe55669bbda23f2fd37b0f18755e008edd2"
+                    },
+                    "expected": {
+                        "witness": [
+                            "bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd981"
+                        ]
+                    }
+                }
+            ],
+            "auxiliary": {
+                "fulledSignedTx": "020000000001097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a41842000000006b4830450221008f3b8f8f0537c420654d2283673a761b7ee2ea3c130753103e08ce79201cf32a022079e7ab904a1980ef1c5890b648c8783f4d10103dd62f740d13daa79e298d50c201210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0141ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c030141052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83000141ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a010140b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f0247304402202b795e4de72646d76eab3f0ab27dfa30b810e856ff3a46c9a702df53bb0d8cc302203ccc4d822edab5f35caddb10af1be93583526ccfbade4b4ead350781e2f8adcd012102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f90141a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee0020141ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c4820141bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd9810065cd1d"
+            }
+        }
+    ]
+}

--- a/haskoin-core.cabal
+++ b/haskoin-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ec2010d735f2cc98f82ef204ad36efd8e1077e2f9cf9c67871c1e868c025a11f
+-- hash: 03edd130a89789be22754a6b6bbe6524bac85c7afd49f622d76994be6189a765
 
 name:           haskoin-core
 version:        0.21.0
@@ -21,6 +21,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
+    data/bip341.json
     data/complex_psbt.json
     data/forkid_script_tests.json
     data/forkid_sighash.json
@@ -75,6 +76,7 @@ library
       Haskoin.Transaction.Genesis
       Haskoin.Transaction.Partial
       Haskoin.Transaction.Segwit
+      Haskoin.Transaction.Taproot
       Haskoin.Util
       Haskoin.Util.Arbitrary
       Haskoin.Util.Arbitrary.Address
@@ -139,6 +141,7 @@ test-suite spec
       Haskoin.NetworkSpec
       Haskoin.ScriptSpec
       Haskoin.Transaction.PartialSpec
+      Haskoin.Transaction.TaprootSpec
       Haskoin.TransactionSpec
       Haskoin.UtilSpec
       Paths_haskoin_core

--- a/src/Haskoin/Crypto/Hash.hs
+++ b/src/Haskoin/Crypto/Hash.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
 
 {- |
 Module      : Haskoin.Crypto.Hash
@@ -29,14 +30,18 @@ module Haskoin.Crypto.Hash (
     hmac256,
     split512,
     join512,
+    initTaggedHash,
 ) where
 
 import Control.DeepSeq
 import Crypto.Hash (
+    Context,
     RIPEMD160 (..),
     SHA1 (..),
     SHA256 (..),
     SHA512 (..),
+    hashInit,
+    hashUpdates,
     hashWith,
  )
 import Crypto.MAC.HMAC (HMAC, hmac)
@@ -242,3 +247,17 @@ join512 (a, b) =
     Hash512
         . BSS.toShort
         $ BSS.fromShort (getHash256 a) `BS.append` BSS.fromShort (getHash256 b)
+
+{- | Initialize tagged hash specified in BIP340
+
+@since 0.21.0
+-}
+initTaggedHash ::
+    -- | Hash tag
+    ByteString ->
+    Context SHA256
+initTaggedHash tag =
+    (`hashUpdates` [hashedTag, hashedTag]) $
+        hashInit @SHA256
+  where
+    hashedTag = hashWith SHA256 tag

--- a/src/Haskoin/Transaction.hs
+++ b/src/Haskoin/Transaction.hs
@@ -12,6 +12,7 @@ module Haskoin.Transaction (
     module Common,
     module Builder,
     module Segwit,
+    module Taproot,
     module Partial,
 ) where
 
@@ -19,3 +20,4 @@ import Haskoin.Transaction.Builder as Builder
 import Haskoin.Transaction.Common as Common
 import Haskoin.Transaction.Partial as Partial
 import Haskoin.Transaction.Segwit as Segwit
+import Haskoin.Transaction.Taproot as Taproot

--- a/src/Haskoin/Transaction/Taproot.hs
+++ b/src/Haskoin/Transaction/Taproot.hs
@@ -1,0 +1,310 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+{- |
+Module      : Haskoin.Transaction.Taproot
+Copyright   : No rights reserved
+License     : MIT
+Maintainer  : jprupp@protonmail.ch
+Stability   : experimental
+Portability : POSIX
+
+This module provides support for reperesenting full taproot outputs and parsing
+taproot witnesses.  For reference see BIPS 340, 341, and 342.
+-}
+module Haskoin.Transaction.Taproot (
+    XOnlyPubKey (..),
+    TapLeafVersion,
+    MAST (..),
+    mastCommitment,
+    getMerkleProofs,
+    TaprootOutput (..),
+    taprootOutputKey,
+    taprootScriptOutput,
+    TaprootWitness (..),
+    ScriptPathData (..),
+    viewTaprootWitness,
+    encodeTaprootWitness,
+    verifyScriptPathData,
+) where
+
+import Control.Applicative (many)
+import Control.Monad ((<=<))
+import Crypto.Hash (
+    Digest,
+    SHA256,
+    digestFromByteString,
+    hashFinalize,
+    hashUpdate,
+    hashUpdates,
+ )
+import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), withText)
+import Data.Binary (Binary (..))
+import Data.Bits ((.&.), (.|.))
+import Data.Bool (bool)
+import qualified Data.ByteArray as BA
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Bytes.Get (getBytes, runGetS)
+import Data.Bytes.Put (putByteString, runPutS)
+import Data.Bytes.Serial (Serial (..), deserialize, serialize)
+import Data.Bytes.VarInt (VarInt (VarInt))
+import Data.Foldable (foldl')
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Serialize (Serialize, get, getByteString, getWord8, put)
+import Data.Word (Word8)
+import Haskoin.Crypto (PubKey, initTaggedHash, tweak, tweakAddPubKey)
+import Haskoin.Keys.Common (PubKeyI (PubKeyI), pubKeyPoint)
+import Haskoin.Script.Common (Script)
+import Haskoin.Script.Standard (ScriptOutput (PayWitness))
+import Haskoin.Transaction.Common (WitnessStack)
+import Haskoin.Util (decodeHex, eitherToMaybe, encodeHex)
+
+{- | An x-only pubkey corresponds to the keys @(x,y)@ and @(x, -y)@.  The
+equality test only checks the x-coordinate.  An x-only pubkey serializes to 32
+bytes.
+
+@since 0.21.0
+-}
+newtype XOnlyPubKey = XOnlyPubKey {xOnlyPubKey :: PubKey}
+    deriving (Show)
+
+instance Eq XOnlyPubKey where
+    k1 == k2 = runPutS (serialize k1) == runPutS (serialize k2)
+
+instance Serial XOnlyPubKey where
+    serialize (XOnlyPubKey pk) =
+        putByteString
+            . BS.drop 1
+            . runPutS
+            . serialize
+            $ PubKeyI pk True
+    deserialize =
+        either fail (pure . XOnlyPubKey . pubKeyPoint)
+            . runGetS deserialize
+            . BS.cons 0x02
+            =<< getBytes 32
+
+instance Serialize XOnlyPubKey where
+    put = serialize
+    get = deserialize
+
+instance Binary XOnlyPubKey where
+    put = serialize
+    get = deserialize
+
+-- | Hex encoding
+instance FromJSON XOnlyPubKey where
+    parseJSON =
+        withText "XOnlyPubKey" $
+            either fail pure
+                . (runGetS deserialize <=< maybe (Left "Unable to decode hex") Right . decodeHex)
+
+-- | Hex encoding
+instance ToJSON XOnlyPubKey where
+    toJSON = toJSON . encodeHex . runPutS . serialize
+
+-- | @since 0.21.0
+type TapLeafVersion = Word8
+
+{- | Merklized Abstract Syntax Tree.  This type can represent trees where only a
+subset of the leaves are known.  Note that the tree is invariant under swapping
+branches at an internal node.
+
+@since 0.21.0
+-}
+data MAST
+    = MASTBranch MAST MAST
+    | MASTLeaf TapLeafVersion Script
+    | MASTCommitment (Digest SHA256)
+    deriving (Show)
+
+{- | Get the inclusion proofs for the leaves in the tree.  The proof is ordered
+leaf-to-root.
+
+@since 0.21.0
+-}
+getMerkleProofs :: MAST -> [(TapLeafVersion, Script, [Digest SHA256])]
+getMerkleProofs = getProofs mempty
+  where
+    getProofs proof = \case
+        MASTBranch branchL branchR ->
+            (updateProof proof (mastCommitment branchR) <$> getMerkleProofs branchL)
+                <> (updateProof proof (mastCommitment branchL) <$> getMerkleProofs branchR)
+        MASTLeaf v s -> [(v, s, proof)]
+        MASTCommitment{} -> mempty
+    updateProof proofInit branchCommitment (v, s, proofTail) =
+        (v, s, reverse $ proofInit <> (branchCommitment : proofTail))
+
+{- | Calculate the root hash for this tree.
+
+@since 0.21.0
+-}
+mastCommitment :: MAST -> Digest SHA256
+mastCommitment = \case
+    MASTBranch leftBranch rightBranch ->
+        hashBranch (mastCommitment leftBranch) (mastCommitment rightBranch)
+    MASTLeaf leafVersion leafScript -> leafHash leafVersion leafScript
+    MASTCommitment theCommitment -> theCommitment
+
+hashBranch :: Digest SHA256 -> Digest SHA256 -> Digest SHA256
+hashBranch hashA hashB =
+    hashFinalize $
+        hashUpdates
+            (initTaggedHash "TapBranch")
+            [ min hashA hashB
+            , max hashA hashB
+            ]
+
+leafHash :: TapLeafVersion -> Script -> Digest SHA256
+leafHash leafVersion leafScript =
+    hashFinalize
+        . hashUpdate (initTaggedHash "TapLeaf")
+        . runPutS
+        $ do
+            serialize leafVersion
+            serialize $ VarInt (BS.length scriptBytes)
+            putByteString scriptBytes
+  where
+    scriptBytes = runPutS $ serialize leafScript
+
+{- | Representation of a full taproot output.
+
+@since 0.21.0
+-}
+data TaprootOutput = TaprootOutput
+    { taprootInternalKey :: PubKey
+    , taprootMAST :: Maybe MAST
+    }
+    deriving (Show)
+
+-- | @since 0.21.0
+taprootOutputKey :: TaprootOutput -> PubKey
+taprootOutputKey TaprootOutput{taprootInternalKey, taprootMAST} =
+    fromMaybe keyFail $ tweak commitment >>= tweakAddPubKey taprootInternalKey
+  where
+    commitment = taprootCommitment taprootInternalKey $ mastCommitment <$> taprootMAST
+    keyFail = error "haskoin-core taprootOutputKey: key derivation failed"
+
+taprootCommitment :: PubKey -> Maybe (Digest SHA256) -> ByteString
+taprootCommitment internalKey merkleRoot =
+    BA.convert . hashFinalize
+        . maybe id (flip hashUpdate) merkleRoot
+        . (`hashUpdate` keyBytes)
+        $ initTaggedHash "TapTweak"
+  where
+    keyBytes = runPutS . serialize $ XOnlyPubKey internalKey
+
+{- | Generate the output script for a taproot output
+
+@since 0.21.0
+-}
+taprootScriptOutput :: TaprootOutput -> ScriptOutput
+taprootScriptOutput = PayWitness 0x01 . runPutS . serialize . XOnlyPubKey . taprootOutputKey
+
+{- | Comprehension of taproot witness data
+
+@since 0.21.0
+-}
+data TaprootWitness
+    = -- | Signature
+      KeyPathSpend ByteString
+    | ScriptPathSpend ScriptPathData
+    deriving (Eq, Show)
+
+-- | @since 0.21.0
+data ScriptPathData = ScriptPathData
+    { scriptPathAnnex :: Maybe ByteString
+    , scriptPathStack :: [ByteString]
+    , scriptPathScript :: Script
+    , scriptPathExternalIsOdd :: Bool
+    , -- | This value is masked by 0xFE
+      scriptPathLeafVersion :: Word8
+    , scriptPathInternalKey :: PubKey
+    , scriptPathControl :: [ByteString]
+    }
+    deriving (Eq, Show)
+
+{- | Try to interpret a 'WitnessStack' as taproot witness data.
+
+@since 0.21.0
+-}
+viewTaprootWitness :: WitnessStack -> Maybe TaprootWitness
+viewTaprootWitness witnessStack = case reverse witnessStack of
+    [sig] -> Just $ KeyPathSpend sig
+    annexA : remainingStack
+        | 0x50 : _ <- BS.unpack annexA ->
+            parseSpendPathData (Just annexA) remainingStack
+    remainingStack -> parseSpendPathData Nothing remainingStack
+  where
+    parseSpendPathData scriptPathAnnex = \case
+        scriptBytes : controlBytes : scriptPathStack -> do
+            scriptPathScript <- eitherToMaybe $ runGetS deserialize scriptBytes
+            (v, scriptPathInternalKey, scriptPathControl) <- deconstructControl controlBytes
+            pure . ScriptPathSpend $
+                ScriptPathData
+                    { scriptPathAnnex
+                    , scriptPathStack
+                    , scriptPathScript
+                    , scriptPathExternalIsOdd = odd v
+                    , scriptPathLeafVersion = v .&. 0xFE
+                    , scriptPathInternalKey
+                    , scriptPathControl
+                    }
+        _ -> Nothing
+    deconstructControl = eitherToMaybe . runGetS deserializeControl
+    deserializeControl = do
+        v <- getWord8
+        k <- xOnlyPubKey <$> deserialize
+        proof <- many $ getByteString 32
+        pure (v, k, proof)
+
+{- | Transform the high-level representation of taproot witness data into a witness stack
+
+@since 0.21.0
+-}
+encodeTaprootWitness :: TaprootWitness -> WitnessStack
+encodeTaprootWitness = \case
+    KeyPathSpend signature -> pure signature
+    ScriptPathSpend scriptPathData ->
+        scriptPathStack scriptPathData
+            <> [ runPutS . serialize $ scriptPathScript scriptPathData
+               , mconcat
+                    [ BS.pack [scriptPathLeafVersion scriptPathData .|. parity scriptPathData]
+                    , runPutS . serialize . XOnlyPubKey $ scriptPathInternalKey scriptPathData
+                    , mconcat $ scriptPathControl scriptPathData
+                    ]
+               , fromMaybe mempty $ scriptPathAnnex scriptPathData
+               ]
+  where
+    parity = bool 0 1 . scriptPathExternalIsOdd
+
+{- | Verify that the script path spend is valid, except for script execution.
+
+@since 0.21.0
+-}
+verifyScriptPathData ::
+    -- | Output key
+    PubKey ->
+    ScriptPathData ->
+    Bool
+verifyScriptPathData outputKey scriptPathData = fromMaybe False $ do
+    tweak commitment >>= fmap onComputedKey . tweakAddPubKey (scriptPathInternalKey scriptPathData)
+  where
+    onComputedKey computedKey =
+        XOnlyPubKey outputKey == XOnlyPubKey computedKey
+            && expectedParity == keyParity computedKey
+    commitment = taprootCommitment (scriptPathInternalKey scriptPathData) (Just merkleRoot)
+    merkleRoot =
+        foldl' hashBranch theLeafHash
+            . mapMaybe (digestFromByteString @SHA256)
+            $ scriptPathControl scriptPathData
+    theLeafHash = (leafHash <$> (.&. 0xFE) . scriptPathLeafVersion <*> scriptPathScript) scriptPathData
+    expectedParity = bool 0 1 $ scriptPathExternalIsOdd scriptPathData
+
+keyParity :: PubKey -> Word8
+keyParity key = case BS.unpack . runPutS . serialize $ PubKeyI key True of
+    0x02 : _ -> 0x00
+    _ -> 0x01

--- a/test/Haskoin/Transaction/TaprootSpec.hs
+++ b/test/Haskoin/Transaction/TaprootSpec.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Haskoin.Transaction.TaprootSpec (spec) where
+
+import Control.Applicative ((<|>))
+import Control.Monad (zipWithM, (<=<))
+import Data.Aeson (FromJSON (parseJSON), withObject, (.:), (.:?))
+import Data.Aeson.Types (Parser)
+import qualified Data.ByteArray as BA
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Bytes.Get (runGetS)
+import Data.Bytes.Put (runPutS)
+import Data.Bytes.Serial (deserialize, serialize)
+import Data.Text (Text)
+import Data.Word (Word8)
+import Haskoin (
+    MAST (..),
+    PubKey,
+    PubKeyI (PubKeyI),
+    ScriptOutput,
+    ScriptPathData (..),
+    TaprootOutput (TaprootOutput),
+    TaprootWitness (ScriptPathSpend),
+    XOnlyPubKey (..),
+    addrToText,
+    btc,
+    decodeHex,
+    encodeTaprootWitness,
+    getMerkleProofs,
+    mastCommitment,
+    outputAddress,
+    taprootInternalKey,
+    taprootMAST,
+    taprootOutputKey,
+    taprootScriptOutput,
+    verifyScriptPathData,
+ )
+import Haskoin.UtilSpec (readTestFile)
+import Test.HUnit (assertBool, (@?=))
+import Test.Hspec (Spec, describe, it, runIO)
+
+spec :: Spec
+spec = do
+    TestVector{testScriptPubKey} <- runIO $ readTestFile "bip341.json"
+    describe "Taproot" $ do
+        it "should calculate the correct hashes" $ mapM_ testHashes testScriptPubKey
+        it "should build the correct output key" $ mapM_ testOutputKey testScriptPubKey
+        it "should build the correct script output" $ mapM_ testScriptOutput testScriptPubKey
+        it "should calculate the correct control blocks" $ mapM_ testControlBlocks testScriptPubKey
+        it "should arrive at the correct address" $ mapM_ testAddress testScriptPubKey
+
+testHashes :: TestScriptPubKey -> IO ()
+testHashes testData =
+    mapM_ checkMASTDetails $ (taprootMAST . tspkGiven) testData
+  where
+    checkMASTDetails theMAST = do
+        -- Leaf hashes
+        (Just . getLeafHashes) theMAST @?= (spkiLeafHashes . tspkIntermediary) testData
+        -- Merkle root
+        (Just . BA.convert . mastCommitment) theMAST @?= (spkiMerkleRoot . tspkIntermediary) testData
+
+    getLeafHashes = \case
+        MASTBranch branchL branchR -> getLeafHashes branchL <> getLeafHashes branchR
+        leaf@MASTLeaf{} -> [BA.convert $ mastCommitment leaf]
+        MASTCommitment{} -> mempty -- The test vectors have complete trees
+
+testOutputKey :: TestScriptPubKey -> IO ()
+testOutputKey testData = do
+    XOnlyPubKey (taprootOutputKey theOutput) @?= theOutputKey
+  where
+    theOutput = tspkGiven testData
+    theOutputKey = XOnlyPubKey . spkiTweakedPubKey $ tspkIntermediary testData
+
+testScriptOutput :: TestScriptPubKey -> IO ()
+testScriptOutput testData =
+    taprootScriptOutput (tspkGiven testData) @?= (spkeScriptPubKey . tspkExpected) testData
+
+testControlBlocks :: TestScriptPubKey -> IO ()
+testControlBlocks testData = do
+    mapM_ onExamples exampleControlBlocks
+    mapM_ checkVerification scriptPathSpends
+  where
+    theOutput = tspkGiven testData
+    theOutputKey = taprootOutputKey theOutput
+    exampleControlBlocks = spkeControlBlocks $ tspkExpected testData
+    calculatedControlBlocks =
+        (!! 1) . encodeTaprootWitness . ScriptPathSpend <$> scriptPathSpends
+    scriptPathSpends =
+        fmap mkScriptPathSpend
+            . maybe mempty getMerkleProofs
+            $ taprootMAST theOutput
+    mkScriptPathSpend (scriptPathLeafVersion, scriptPathScript, proof) =
+        ScriptPathData
+            { scriptPathAnnex = Nothing
+            , scriptPathStack = mempty
+            , scriptPathScript
+            , scriptPathExternalIsOdd = odd $ keyParity theOutputKey
+            , scriptPathLeafVersion
+            , scriptPathInternalKey = taprootInternalKey theOutput
+            , scriptPathControl = BA.convert <$> proof
+            }
+    onExamples = zipWithM (@?=) calculatedControlBlocks
+    checkVerification = assertBool "Script verifies" . verifyScriptPathData theOutputKey
+
+keyParity :: PubKey -> Word8
+keyParity key = case BS.unpack . runPutS . serialize $ PubKeyI key True of
+    0x02 : _ -> 0x00
+    _ -> 0x01
+
+testAddress :: TestScriptPubKey -> IO ()
+testAddress testData = computedAddress @?= (Just . spkeAddress . tspkExpected) testData
+  where
+    computedAddress = (addrToText btc <=< outputAddress) . taprootScriptOutput $ tspkGiven testData
+
+newtype SpkGiven = SpkGiven {unSpkGiven :: TaprootOutput}
+
+instance FromJSON SpkGiven where
+    parseJSON = withObject "SpkGiven" $ \obj ->
+        fmap SpkGiven $
+            TaprootOutput
+                <$> (xOnlyPubKey <$> obj .: "internalPubkey")
+                <*> (obj .:? "scriptTree" >>= traverse parseScriptTree)
+      where
+        parseScriptTree v =
+            parseScriptLeaf v
+                <|> parseScriptBranch v
+                <|> fail "Unable to parse scriptTree"
+        parseScriptLeaf = withObject "ScriptTree leaf" $ \obj ->
+            MASTLeaf
+                <$> obj .: "leafVersion"
+                <*> (obj .: "script" >>= hexScript)
+        parseScriptBranch v =
+            parseJSON v >>= \case
+                [v1, v2] -> MASTBranch <$> parseScriptTree v1 <*> parseScriptTree v2
+                _ -> fail "ScriptTree branch"
+        hexScript = either fail pure . runGetS deserialize <=< jsonHex
+
+data SpkIntermediary = SpkIntermediary
+    { spkiLeafHashes :: Maybe [ByteString]
+    , spkiMerkleRoot :: Maybe ByteString
+    , spkiTweakedPubKey :: PubKey
+    }
+
+instance FromJSON SpkIntermediary where
+    parseJSON = withObject "SpkIntermediary" $ \obj ->
+        SpkIntermediary
+            <$> (obj .:? "leafHashes" >>= (traverse . traverse) jsonHex)
+            <*> (obj .: "merkleRoot" >>= traverse jsonHex)
+            <*> (xOnlyPubKey <$> obj .: "tweakedPubkey")
+
+data SpkExpected = SpkExpected
+    { spkeScriptPubKey :: ScriptOutput
+    , spkeControlBlocks :: Maybe [ByteString]
+    , spkeAddress :: Text
+    }
+
+instance FromJSON SpkExpected where
+    parseJSON = withObject "SpkExpected" $ \obj ->
+        SpkExpected
+            <$> obj .: "scriptPubKey"
+            <*> (obj .:? "scriptPathControlBlocks" >>= (traverse . traverse) jsonHex)
+            <*> obj .: "bip350Address"
+
+data TestScriptPubKey = TestScriptPubKey
+    { tspkGiven :: TaprootOutput
+    , tspkIntermediary :: SpkIntermediary
+    , tspkExpected :: SpkExpected
+    }
+
+instance FromJSON TestScriptPubKey where
+    parseJSON = withObject "TestScriptPubKey" $ \obj ->
+        TestScriptPubKey
+            <$> (unSpkGiven <$> obj .: "given")
+            <*> obj .: "intermediary"
+            <*> obj .: "expected"
+
+newtype TestVector = TestVector
+    { testScriptPubKey :: [TestScriptPubKey]
+    }
+
+instance FromJSON TestVector where
+    parseJSON = withObject "TestVector" $ \obj ->
+        TestVector <$> obj .: "scriptPubKey"
+
+jsonHex :: Text -> Parser ByteString
+jsonHex = maybe (fail "Unable to decode hex") pure . decodeHex


### PR DESCRIPTION
## Overview 

* Express taproot output structure
* Derive external key
* Parse taproot witness data

I am looking for a better solution for x-only pubkeys if anyone has suggestions.

I took the test vectors from https://github.com/bitcoin/bips/blob/995f45211d1baac4ac34685cf09d804eb8edd078/bip-0341/wallet-test-vectors.json