### PR TITLE
Utilities for testing Marshal and MarshalJSON classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2023-08-31
+
+### Changed
+
+- New dependency on data-default
+- Renamed some arbitrary (test) functions for clarity
+- Reworked the identity testing tool to include Marshal and MarshalJSON classes
+
 ## [1.0.2] - 2023-08-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.0.3] - 2023-08-31
+## [1.0.3] - 2023-09-02
 
 ### Changed
 

--- a/haskoin-core.cabal
+++ b/haskoin-core.cabal
@@ -118,6 +118,7 @@ library
     , conduit >=1.3.1.2
     , containers >=0.6.2.1
     , cryptonite >=0.26
+    , data-default >=0.7.1.1
     , deepseq >=1.4.4.0
     , entropy >=0.4.1.5
     , hashable >=1.3.0.0
@@ -175,6 +176,7 @@ test-suite spec
     , conduit >=1.3.1.2
     , containers >=0.6.2.1
     , cryptonite >=0.26
+    , data-default >=0.7.1.1
     , deepseq >=1.4.4.0
     , entropy >=0.4.1.5
     , hashable >=1.3.0.0

--- a/haskoin-core.cabal
+++ b/haskoin-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           haskoin-core
-version:        1.0.2
+version:        1.0.3
 synopsis:       Bitcoin & Bitcoin Cash library for Haskell
 description:    Please see the README on GitHub at <https://github.com/haskoin/haskoin-core#readme>
 category:       Bitcoin, Finance, Network

--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,7 @@ dependencies:
   - containers >= 0.6.2.1
   - cryptonite >= 0.26
   - deepseq >= 1.4.4.0
+  - data-default >= 0.7.1.1
   - entropy >= 0.4.1.5
   - hashable >= 1.3.0.0
   - hspec >= 2.7.1

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: haskoin-core
-version: 1.0.2
+version: 1.0.3
 synopsis: Bitcoin & Bitcoin Cash library for Haskell
 description: Please see the README on GitHub at <https://github.com/haskoin/haskoin-core#readme>
 category: Bitcoin, Finance, Network

--- a/src/Haskoin/Util/Arbitrary/Keys.hs
+++ b/src/Haskoin/Util/Arbitrary/Keys.hs
@@ -24,6 +24,10 @@ import Test.QuickCheck
 arbitraryPrivateKey :: Gen PrivateKey
 arbitraryPrivateKey = wrapSecKey <$> arbitrary <*> arbitrary
 
+-- | Arbitrary public key, either compressed or not.
+arbitraryPublicKey :: Ctx -> Gen PublicKey
+arbitraryPublicKey ctx = snd <$> arbitraryKeyPair ctx
+
 -- | Arbitrary keypair, both either compressed or not.
 arbitraryKeyPair :: Ctx -> Gen (PrivateKey, PublicKey)
 arbitraryKeyPair ctx = do
@@ -43,9 +47,13 @@ arbitraryXPrvKey =
     <*> arbitraryHash256
     <*> arbitrary
 
+-- | Arbitrary extended public key.
+arbitraryXPubKey :: Ctx -> Gen XPubKey
+arbitraryXPubKey ctx = snd <$> arbitraryXKeyPair ctx
+
 -- | Arbitrary extended public key with its corresponding private key.
-arbitraryXPubKey :: Ctx -> Gen (XPrvKey, XPubKey)
-arbitraryXPubKey ctx = (\k -> (k, deriveXPubKey ctx k)) <$> arbitraryXPrvKey
+arbitraryXKeyPair :: Ctx -> Gen (XPrvKey, XPubKey)
+arbitraryXKeyPair ctx = (\k -> (k, deriveXPubKey ctx k)) <$> arbitraryXPrvKey
 
 {- Custom derivations -}
 

--- a/test/Haskoin/AddressSpec.hs
+++ b/test/Haskoin/AddressSpec.hs
@@ -5,6 +5,7 @@ module Haskoin.AddressSpec (spec) where
 
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as B
+import Data.Default (def)
 import Data.Maybe (fromJust, isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -19,19 +20,17 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
-serialVals :: [SerialBox]
-serialVals = [SerialBox arbitraryAddressAll]
-
-readVals :: [ReadBox]
-readVals = [ReadBox arbitraryAddressAll]
-
-netVals :: [NetBox]
-netVals =
-  [NetBox (marshalValue, marshalEncoding, unmarshalValue, arbitraryNetAddress)]
+identityTests :: IdentityTests
+identityTests =
+  def
+    { readTests = [ReadBox arbitraryAddressAll],
+      serialTests = [SerialBox arbitraryAddressAll],
+      marshalJsonTests = [MarshalJsonBox arbitraryNetAddress]
+    }
 
 spec :: Spec
 spec = prepareContext $ \ctx -> do
-  testIdentity serialVals readVals [] netVals
+  testIdentity identityTests
   describe "Address properties" $ do
     prop "encodes and decodes base58 bytestring" $
       forAll arbitraryBS $ \bs ->

--- a/test/Haskoin/BlockSpec.hs
+++ b/test/Haskoin/BlockSpec.hs
@@ -9,6 +9,7 @@ where
 
 import Control.Monad
 import Control.Monad.State.Strict
+import Data.Default (def)
 import Data.Either (fromRight)
 import Data.Maybe (fromJust)
 import Data.String (fromString)
@@ -28,36 +29,36 @@ import Test.Hspec.QuickCheck
 import Test.QuickCheck
 import Text.Printf (printf)
 
-serialVals :: Ctx -> [SerialBox]
-serialVals ctx =
-  [ SerialBox (flip arbitraryBlock ctx =<< arbitraryNetwork),
-    SerialBox arbitraryBlockHash,
-    SerialBox arbitraryBlockHeader,
-    SerialBox arbitraryGetBlocks,
-    SerialBox arbitraryGetHeaders,
-    SerialBox arbitraryHeaders,
-    SerialBox arbitraryMerkleBlock,
-    SerialBox arbitraryBlockNode
-  ]
-
-readVals :: Ctx -> [ReadBox]
-readVals ctx =
-  [ ReadBox (flip arbitraryBlock ctx =<< arbitraryNetwork),
-    ReadBox arbitraryBlockHash,
-    ReadBox arbitraryBlockHeader,
-    ReadBox arbitraryGetBlocks,
-    ReadBox arbitraryGetHeaders,
-    ReadBox arbitraryHeaders,
-    ReadBox arbitraryMerkleBlock,
-    ReadBox arbitraryBlockNode
-  ]
-
-jsonVals :: Ctx -> [JsonBox]
-jsonVals ctx =
-  [ JsonBox (flip arbitraryBlock ctx =<< arbitraryNetwork),
-    JsonBox arbitraryBlockHash,
-    JsonBox arbitraryBlockHeader
-  ]
+identityTests :: Ctx -> IdentityTests
+identityTests ctx =
+  def
+    { readTests =
+        [ ReadBox (flip arbitraryBlock ctx =<< arbitraryNetwork),
+          ReadBox arbitraryBlockHash,
+          ReadBox arbitraryBlockHeader,
+          ReadBox arbitraryGetBlocks,
+          ReadBox arbitraryGetHeaders,
+          ReadBox arbitraryHeaders,
+          ReadBox arbitraryMerkleBlock,
+          ReadBox arbitraryBlockNode,
+          ReadBox arbitraryHeaderMemory
+        ],
+      jsonTests =
+        [ JsonBox (flip arbitraryBlock ctx =<< arbitraryNetwork),
+          JsonBox arbitraryBlockHash,
+          JsonBox arbitraryBlockHeader
+        ],
+      serialTests =
+        [ SerialBox (flip arbitraryBlock ctx =<< arbitraryNetwork),
+          SerialBox arbitraryBlockHash,
+          SerialBox arbitraryBlockHeader,
+          SerialBox arbitraryGetBlocks,
+          SerialBox arbitraryGetHeaders,
+          SerialBox arbitraryHeaders,
+          SerialBox arbitraryMerkleBlock,
+          SerialBox arbitraryBlockNode
+        ]
+    }
 
 myTime :: Timestamp
 myTime = 1499083075
@@ -74,7 +75,7 @@ chain net bh i = do
 
 spec :: Spec
 spec = prepareContext $ \ctx -> do
-  testIdentity (serialVals ctx) (readVals ctx) (jsonVals ctx) []
+  testIdentity $ identityTests ctx
   describe "blockchain headers" $ do
     it "gets best block on bchRegTest" $
       let net = bchRegTest

--- a/test/Haskoin/Crypto/HashSpec.hs
+++ b/test/Haskoin/Crypto/HashSpec.hs
@@ -14,6 +14,7 @@ import Data.ByteString.Short qualified as Short
 import Data.Bytes.Get
 import Data.Bytes.Put
 import Data.Bytes.Serial
+import Data.Default (def)
 import Data.Maybe (fromJust)
 import Data.String (fromString)
 import Data.String.Conversions
@@ -28,27 +29,27 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
-serialVals :: [SerialBox]
-serialVals =
-  [ SerialBox arbitraryBS,
-    SerialBox arbitraryHash160,
-    SerialBox arbitraryHash256,
-    SerialBox arbitraryHash512
-  ]
-
-readVals :: [ReadBox]
-readVals =
-  [ ReadBox arbitraryBS,
-    ReadBox arbitraryBSS,
-    ReadBox arbitraryHash160,
-    ReadBox arbitraryHash256,
-    ReadBox arbitraryHash512
-  ]
+identityTests :: IdentityTests
+identityTests =
+  def
+    { readTests =
+        [ ReadBox arbitraryHash160,
+          ReadBox arbitraryHash256,
+          ReadBox arbitraryHash512,
+          ReadBox arbitraryCheckSum32
+        ],
+      serialTests =
+        [ SerialBox arbitraryHash160,
+          SerialBox arbitraryHash256,
+          SerialBox arbitraryHash512,
+          SerialBox arbitraryCheckSum32
+        ]
+    }
 
 spec :: Spec
 spec =
   describe "Hash" $ do
-    testIdentity serialVals readVals [] []
+    testIdentity identityTests
     describe "Property Tests" $ do
       prop "join512( split512(h) ) == h" $
         forAll arbitraryHash256 $

--- a/test/Haskoin/NetworkSpec.hs
+++ b/test/Haskoin/NetworkSpec.hs
@@ -7,6 +7,7 @@ module Haskoin.NetworkSpec (spec) where
 import Data.Bytes.Get
 import Data.Bytes.Put
 import Data.Bytes.Serial
+import Data.Default (def)
 import Data.Maybe (fromJust)
 import Data.Text (Text)
 import Data.Word (Word32)
@@ -22,34 +23,37 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
-serialVals :: [SerialBox]
-serialVals =
-  [ SerialBox arbitraryVarInt,
-    SerialBox arbitraryVarString,
-    SerialBox arbitraryNetworkAddress,
-    SerialBox arbitraryInvType,
-    SerialBox arbitraryInvVector,
-    SerialBox arbitraryInv1,
-    SerialBox arbitraryVersion,
-    SerialBox arbitraryAddr1,
-    SerialBox arbitraryAlert,
-    SerialBox arbitraryReject,
-    SerialBox arbitraryRejectCode,
-    SerialBox arbitraryGetData,
-    SerialBox arbitraryNotFound,
-    SerialBox arbitraryPing,
-    SerialBox arbitraryPong,
-    SerialBox arbitraryMessageCommand,
-    SerialBox arbitraryMessageHeader,
-    SerialBox arbitraryBloomFlags,
-    SerialBox arbitraryBloomFilter,
-    SerialBox arbitraryFilterLoad,
-    SerialBox arbitraryFilterAdd
-  ]
+identityTests :: IdentityTests
+identityTests =
+  def
+    { serialTests =
+        [ SerialBox arbitraryVarInt,
+          SerialBox arbitraryVarString,
+          SerialBox arbitraryNetworkAddress,
+          SerialBox arbitraryInvType,
+          SerialBox arbitraryInvVector,
+          SerialBox arbitraryInv1,
+          SerialBox arbitraryVersion,
+          SerialBox arbitraryAddr1,
+          SerialBox arbitraryAlert,
+          SerialBox arbitraryReject,
+          SerialBox arbitraryRejectCode,
+          SerialBox arbitraryGetData,
+          SerialBox arbitraryNotFound,
+          SerialBox arbitraryPing,
+          SerialBox arbitraryPong,
+          SerialBox arbitraryMessageCommand,
+          SerialBox arbitraryMessageHeader,
+          SerialBox arbitraryBloomFlags,
+          SerialBox arbitraryBloomFilter,
+          SerialBox arbitraryFilterLoad,
+          SerialBox arbitraryFilterAdd
+        ]
+    }
 
 spec :: Spec
 spec = prepareContext $ \ctx -> do
-  testIdentity serialVals [] [] []
+  testIdentity identityTests
   describe "Custom identity tests" $ do
     prop "Data.Serialize Encoding for type Message" $
       forAll arbitraryNetwork $ \net ->

--- a/test/Haskoin/TransactionSpec.hs
+++ b/test/Haskoin/TransactionSpec.hs
@@ -12,6 +12,7 @@ import Data.ByteString qualified as B
 import Data.Bytes.Get
 import Data.Bytes.Put
 import Data.Bytes.Serial
+import Data.Default (def)
 import Data.Either
 import Data.Maybe
 import Data.String (fromString)
@@ -31,39 +32,38 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
-serialVals :: Ctx -> [SerialBox]
-serialVals ctx =
-  [ SerialBox $ flip arbitraryTx ctx =<< arbitraryNetwork,
-    SerialBox $ flip arbitraryWitnessTx ctx =<< arbitraryNetwork,
-    SerialBox $ flip arbitraryLegacyTx ctx =<< arbitraryNetwork,
-    SerialBox $ flip arbitraryTxIn ctx =<< arbitraryNetwork,
-    SerialBox $ flip arbitraryTxOut ctx =<< arbitraryNetwork,
-    SerialBox arbitraryOutPoint
-  ]
-
-readVals :: Ctx -> [ReadBox]
-readVals ctx =
-  [ ReadBox arbitraryTxHash,
-    ReadBox $ flip arbitraryTx ctx =<< arbitraryNetwork,
-    ReadBox $ flip arbitraryTxIn ctx =<< arbitraryNetwork,
-    ReadBox $ flip arbitraryTxOut ctx =<< arbitraryNetwork,
-    ReadBox arbitraryOutPoint
-  ]
-
-jsonVals :: Ctx -> [JsonBox]
-jsonVals ctx =
-  [ JsonBox arbitraryTxHash,
-    JsonBox $ flip arbitraryTx ctx =<< arbitraryNetwork,
-    JsonBox $ flip arbitraryWitnessTx ctx =<< arbitraryNetwork,
-    JsonBox $ flip arbitraryLegacyTx ctx =<< arbitraryNetwork,
-    JsonBox $ flip arbitraryTxIn ctx =<< arbitraryNetwork,
-    JsonBox $ flip arbitraryTxOut ctx =<< arbitraryNetwork,
-    JsonBox arbitraryOutPoint
-  ]
+identityTests :: Ctx -> IdentityTests
+identityTests ctx =
+  def
+    { readTests =
+        [ ReadBox arbitraryTxHash,
+          ReadBox $ flip arbitraryTx ctx =<< arbitraryNetwork,
+          ReadBox $ flip arbitraryTxIn ctx =<< arbitraryNetwork,
+          ReadBox $ flip arbitraryTxOut ctx =<< arbitraryNetwork,
+          ReadBox arbitraryOutPoint
+        ],
+      jsonTests =
+        [ JsonBox arbitraryTxHash,
+          JsonBox $ flip arbitraryTx ctx =<< arbitraryNetwork,
+          JsonBox $ flip arbitraryWitnessTx ctx =<< arbitraryNetwork,
+          JsonBox $ flip arbitraryLegacyTx ctx =<< arbitraryNetwork,
+          JsonBox $ flip arbitraryTxIn ctx =<< arbitraryNetwork,
+          JsonBox $ flip arbitraryTxOut ctx =<< arbitraryNetwork,
+          JsonBox arbitraryOutPoint
+        ],
+      serialTests =
+        [ SerialBox $ flip arbitraryTx ctx =<< arbitraryNetwork,
+          SerialBox $ flip arbitraryWitnessTx ctx =<< arbitraryNetwork,
+          SerialBox $ flip arbitraryLegacyTx ctx =<< arbitraryNetwork,
+          SerialBox $ flip arbitraryTxIn ctx =<< arbitraryNetwork,
+          SerialBox $ flip arbitraryTxOut ctx =<< arbitraryNetwork,
+          SerialBox arbitraryOutPoint
+        ]
+    }
 
 spec :: Spec
 spec = prepareContext $ \ctx -> do
-  testIdentity (serialVals ctx) (readVals ctx) (jsonVals ctx) []
+  testIdentity $ identityTests ctx
   describe "Transaction properties" $ do
     prop "decode and encode txid" $
       forAll arbitraryTxHash $

--- a/test/Haskoin/UtilSpec.hs
+++ b/test/Haskoin/UtilSpec.hs
@@ -7,6 +7,7 @@ import Data.Aeson.Encoding (encodingToLazyByteString)
 import Data.Aeson.Types (Parser, parse)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as B
+import Data.Default (def)
 import Data.Either (fromLeft, fromRight, isLeft, isRight)
 import Data.Foldable (toList)
 import Data.List (permutations)
@@ -21,9 +22,18 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck (forAll)
 
+identityTests :: IdentityTests
+identityTests =
+  def
+    { readTests =
+        [ ReadBox arbitraryNetwork
+        ]
+    }
+
 spec :: Spec
 spec =
   describe "utility functions" $ do
+    testIdentity identityTests
     prop "bsToInteger . integerToBS" getPutInteger
     prop "decodeHex . encodeHex" $ forAll arbitraryBS fromToHex
     prop "compare updateIndex with Data.Sequence" testUpdateIndex


### PR DESCRIPTION
* New dependency on data-default
* Renamed some arbitrary (test) functions for clarity
* Reworked the identity testing tool to include `Marshal` and `MarshalJSON` classes
* Version bump to 1.0.3

This pull request breaks backwards compatibility on the testing framework (Haskoin.Util.Arbitrary).