### PR TITLE
Add functions toMnemonicIndices and indicesToSeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2023-10-08
+
+### Changed
+
+- Add functions toMnemonicIndices and indicesToSeed
+
 ## [1.0.3] - 2023-09-02
 
 ### Changed

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: haskoin-core
-version: 1.0.3
+version: 1.0.4
 synopsis: Bitcoin & Bitcoin Cash library for Haskell
 description: Please see the README on GitHub at <https://github.com/haskoin/haskoin-core#readme>
 category: Bitcoin, Finance, Network

--- a/test/Haskoin/Crypto/Keys/MnemonicSpec.hs
+++ b/test/Haskoin/Crypto/Keys/MnemonicSpec.hs
@@ -26,6 +26,7 @@ spec =
     it "entropy to mnemonic sentence" toMnemonicTest
     it "mnemonic sentence to entropy" fromMnemonicTest
     it "mnemonic sentence to seed" mnemonicToSeedTest
+    it "mnemonic indices to seed" indicesToSeedTest
     it "mnemonic sentence with invalid checksum" fromMnemonicInvalidTest
     it "empty mnemonic sentence is invalid" $ sequence_ [emptyMnemonicTest]
     it "generate 12 words" $ property toMnemonic128
@@ -88,6 +89,15 @@ emptyMnemonicTest =
     case fromMnemonic "" of
       Right _ -> False
       Left err -> "fromMnemonic: empty mnemonic" `isPrefixOf` err
+
+indicesToSeedTest :: Assertion
+indicesToSeedTest =
+  assertEqual "" (seeds !! 1) $
+    encodeHex $
+      fromRight (error "Could not decode mnemonic seed from indices") $
+        indicesToSeed
+          "TREZOR"
+          [1019, 2015, 1790, 2039, 1983, 1533, 2031, 1919, 1019, 2015, 1790, 2040]
 
 ents :: [Text]
 ents =


### PR DESCRIPTION
This change makes is easier to work with mnemonics as a list of indices rather than words.
The index (first word = 0) in the word list is used.