### PR TITLE
Build under ghc 9.8

### DIFF
--- a/src/Haskoin.hs
+++ b/src/Haskoin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 -- |
 -- Module      : Haskoin
 -- Description : Bitcoin (BTC/BCH) Libraries for Haskell

--- a/src/Haskoin/Block.hs
+++ b/src/Haskoin/Block.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 -- |
 -- Module      : Haskoin.Block
 -- Copyright   : No rights reserved

--- a/src/Haskoin/Crypto.hs
+++ b/src/Haskoin/Crypto.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 -- |
 -- Module      : Haskoin.Crypto
 -- Copyright   : No rights reserved

--- a/src/Haskoin/Crypto/Keys.hs
+++ b/src/Haskoin/Crypto/Keys.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 -- |
 -- Module      : Haskoin.Keys
 -- Copyright   : No rights reserved

--- a/src/Haskoin/Network.hs
+++ b/src/Haskoin/Network.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 -- |
 -- Module      : Haskoin.Network
 -- Copyright   : No rights reserved

--- a/src/Haskoin/Transaction.hs
+++ b/src/Haskoin/Transaction.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 -- |
 -- Module      : Haskoin.Transaction
 -- Copyright   : No rights reserved


### PR DESCRIPTION
Also requires https://github.com/haskoin/secp256k1-haskell/pull/47

Note this lib has a good deal of warnings with ghc 9.8 from `head` / `tail` in the lib and test suite - among others:
```
src/Haskoin/Transaction/Builder.hs:431:32: warning: [GHC-63394] [-Wx-partial]
    In the use of ‘head’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
    |
431 |   | length txs == 1 = return $ head txs
    |                                ^^^^

src/Haskoin/Transaction/Builder.hs:432:51: warning: [GHC-63394] [-Wx-partial]
    In the use of ‘head’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
    |
432 |   | otherwise = foldM (mergeTxInput net ctx txs) (head emptyTxs) outs
    |                                                   ^^^^

src/Haskoin/Transaction/Builder.hs:434:36: warning: [GHC-63394] [-Wx-partial]
    In the use of ‘head’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
    |
434 |     zipOp = zip (matchTemplate os (head txs).inputs f) [0 ..]
    |                                    ^^^^

src/Haskoin/Transaction/Builder.hs:457:19: warning: [GHC-63394] [-Wx-partial]
    In the use of ‘head’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
    |
457 |   let rdm = snd $ head sigRes
```